### PR TITLE
Feature/ns herk block matrix (#242)

### DIFF
--- a/examples/ns/CMakeLists.txt
+++ b/examples/ns/CMakeLists.txt
@@ -102,6 +102,7 @@ SET( perigee_analysis_lib_src
   ${perigee_source}/Model/FlowRate_Unsteady.cpp
   ${perigee_source}/Model/FlowRate_Linear2Steady.cpp
   ${perigee_source}/Model/FlowRate_Cosine2Steady.cpp
+  ${perigee_source}/Model/FlowRateDot_Sine2Zero.cpp
   ${perigee_source}/Solver/PDNSolution.cpp
   ${perigee_source}/Solver/PDNTimeStep.cpp
   ${perigee_source}/Solver/TimeMethod_GenAlpha.cpp
@@ -110,8 +111,14 @@ SET( perigee_analysis_lib_src
   ${perigee_SOURCE_DIR}/src/PLocAssem_VMS_NS_GenAlpha_WeakBC.cpp
   ${perigee_SOURCE_DIR}/src/PGAssem_NS_FEM.cpp
   ${perigee_SOURCE_DIR}/src/PDNSolution_NS.cpp
+  ${perigee_SOURCE_DIR}/src/PDNSolution_V.cpp
+  ${perigee_SOURCE_DIR}/src/PDNSolution_P.cpp
   ${perigee_SOURCE_DIR}/src/PNonlinear_NS_Solver.cpp
   ${perigee_SOURCE_DIR}/src/PTime_NS_Solver.cpp
+  ${perigee_SOURCE_DIR}/src/PLocAssem_Block_VMS_NS_HERK.cpp
+  ${perigee_SOURCE_DIR}/src/PGAssem_Block_NS_FEM_HERK.cpp
+  ${perigee_SOURCE_DIR}/src/PTime_NS_HERK_Solver.cpp
+  ${perigee_SOURCE_DIR}/src/PTime_NS_HERK_Solver_AccurateA.cpp
   )
 
 SET( perigee_postprocess_lib_src
@@ -150,6 +157,8 @@ INCLUDE(../../conf/message_compiler_setup.cmake)
 # ===================================================================
 ADD_EXECUTABLE( preprocess3d preprocess.cpp)
 ADD_EXECUTABLE( ns3d driver.cpp)
+ADD_EXECUTABLE( ns3dherk ns_herk_driver.cpp)
+ADD_EXECUTABLE( ns3dherkA ns_herk_driver_accurateA.cpp)
 ADD_EXECUTABLE( prepost3d prepost.cpp)
 ADD_EXECUTABLE( vis_ns vis.cpp)
 ADD_EXECUTABLE( vis_wss_tet4 vis_wss_tet4.cpp)
@@ -157,14 +166,17 @@ ADD_EXECUTABLE( vis_wss_tet10 vis_wss_tet10.cpp)
 ADD_EXECUTABLE( vis_wss_hex8 vis_wss_hex8.cpp)
 ADD_EXECUTABLE( vis_wss_hex27 vis_wss_hex27.cpp)
 
-TARGET_LINK_LIBRARIES( preprocess3d PRIVATE perigee_preprocess )
-TARGET_LINK_LIBRARIES( ns3d PRIVATE perigee_analysis )
-TARGET_LINK_LIBRARIES( prepost3d PRIVATE perigee_preprocess )
-TARGET_LINK_LIBRARIES( vis_ns PRIVATE perigee_postprocess )
-TARGET_LINK_LIBRARIES( vis_wss_tet4 PRIVATE perigee_postprocess )
-TARGET_LINK_LIBRARIES( vis_wss_tet10 PRIVATE perigee_postprocess )
-TARGET_LINK_LIBRARIES( vis_wss_hex8 PRIVATE perigee_postprocess )
-TARGET_LINK_LIBRARIES( vis_wss_hex27 PRIVATE perigee_postprocess )
+TARGET_LINK_LIBRARIES( preprocess3d perigee_preprocess )
+TARGET_LINK_LIBRARIES( ns3d perigee_analysis )
+TARGET_LINK_LIBRARIES( ns3dherk perigee_analysis )
+TARGET_LINK_LIBRARIES( ns3dherkA perigee_analysis )
+TARGET_LINK_LIBRARIES( prepost3d perigee_preprocess )
+TARGET_LINK_LIBRARIES( vis_ns perigee_postprocess )
+TARGET_LINK_LIBRARIES( vis_wss_tet4 perigee_postprocess )
+TARGET_LINK_LIBRARIES( vis_wss_tet10 perigee_postprocess )
+TARGET_LINK_LIBRARIES( vis_wss_hex8 perigee_postprocess )
+TARGET_LINK_LIBRARIES( vis_wss_hex27 perigee_postprocess )
+
 
 if(OPENMP_CXX_FOUND)
   SET_TARGET_PROPERTIES( perigee_preprocess PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -DUSE_OPENMP" )

--- a/examples/ns/include/Matrix_Free_Tools.hpp
+++ b/examples/ns/include/Matrix_Free_Tools.hpp
@@ -1,0 +1,164 @@
+#ifndef MATRIX_FREE_TOOLS_HPP
+#define MATRIX_FREE_TOOLS_HPP
+
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+#include "PLinear_Solver_PETSc.hpp"
+
+namespace MF_T
+{
+  struct SolverContext
+  {
+    PGAssem_Block_NS_FEM_HERK *const gloAssem;
+    const std::unique_ptr<PLinear_Solver_PETSc> lsolver_A;
+    const std::unique_ptr<PLinear_Solver_PETSc> lsolver_S;
+
+    // Constructor
+    SolverContext(PGAssem_Block_NS_FEM_HERK * in_gloAssem,
+        std::unique_ptr<PLinear_Solver_PETSc> in_lsolver_A, 
+        std::unique_ptr<PLinear_Solver_PETSc> in_lsolver_S)
+    : gloAssem(in_gloAssem), 
+      lsolver_A(std::move(in_lsolver_A)), 
+      lsolver_S(std::move(in_lsolver_S))
+    {}
+  };
+
+  PetscErrorCode MF_MatMult(Mat shell, Vec x, Vec y)
+  {
+    void *ptr;
+    PGAssem_Block_NS_FEM_HERK *user;
+    MatShellGetContext(shell, &ptr);
+    user = (PGAssem_Block_NS_FEM_HERK*) ptr;
+
+    Vec x1, x2, y1, y2, tmp1, tmp2;
+
+    const PetscScalar coef = user->Get_tangent_alpha_RK();
+
+    // Split the VectNest into subVec
+    VecNestGetSubVec(x, 0, &x1);
+    VecNestGetSubVec(x, 1, &x2);
+    VecNestGetSubVec(y, 0, &y1);
+    VecNestGetSubVec(y, 1, &y2);
+
+    VecDuplicate(x1, &tmp1);
+    VecDuplicate(x2, &tmp2);
+
+    MatMult(user->subK[3], x1, y1);      // y1 = A * x1
+    MatMult(user->subK[4], x1, tmp1);    // tmp1 = A_tilde * x1
+    VecAXPY(y1, coef, tmp1);             // y1 = A * x1 + coef * A_tilde * x1
+    MatMult(user->subK[2], x2, tmp1);    // tmp1 = B * x2
+    VecAXPY(y1, coef, tmp1);             // y1 = (A + coef * A_tilde) * x1 + coef * B * x2
+
+    MatMult(user->subK[1], x1, y2);      // y2 = C * x1
+    MatMult(user->subK[0], x2, tmp2);    // tmp2 = D * x2
+    VecAXPY(y2, coef, tmp2);             // y2 = C * x1 + coef * D * x2
+ 
+    // Destruction of sub vectors
+    VecDestroy(&tmp1);
+    VecDestroy(&tmp2);
+
+    return 0;
+  }
+
+  PetscErrorCode SetupApproxSchur(PGAssem_Block_NS_FEM_HERK *const user, Mat &S_approx)
+  {
+    // Schur complement approximation: S = D - C inv(DIAGFORM(A)) B
+    Vec diag;
+    PetscInt mA_local;
+
+    MatGetLocalSize(user->subK[3], &mA_local, NULL);
+
+    // inverse of diagonal of A
+    VecCreate(PETSC_COMM_WORLD, &diag);   
+    VecSetSizes(diag, mA_local, PETSC_DETERMINE);
+    VecSetType(diag, VECMPI);
+    // MatGetRowSum(user->subK[3], diag); // Replace MatGetDiagonal() with MatGetRowSum()
+    MatGetDiagonal(user->subK[3], diag);
+    VecReciprocal(diag);
+
+    MatDiagonalScale(user->subK[2], diag, NULL); // overwrites B = subK[2]) 
+    MatMatMult(user->subK[1], user->subK[2], MAT_INITIAL_MATRIX, PETSC_DETERMINE, &S_approx);
+
+    MatScale(S_approx, -1.0);
+    MatAXPY(S_approx, 1.0, user->subK[0], DIFFERENT_NONZERO_PATTERN);  // S_approx = D - S_approx
+
+    // restore B = subK[2]
+    // MatGetRowSum(user->subK[3], diag); // Restore with row sums again
+    MatGetDiagonal(user->subK[3], diag);
+    MatDiagonalScale(user->subK[2], diag, NULL);
+
+    VecDestroy(&diag);
+
+    return 0;
+  }
+  
+  PetscErrorCode MF_PCSchurApply(PC pc, Vec x, Vec y)
+  {
+  #ifdef PETSC_USE_LOG
+    PetscLogEvent A_solve, S_solve;
+    PetscClassId classid_solve;
+    PetscClassIdRegister("PCsolve", &classid_solve);
+    PetscLogEventRegister("A_solve", classid_solve, &A_solve);
+    PetscLogEventRegister("S_solve", classid_solve, &S_solve);
+  #endif
+
+    void *ptr;
+    SolverContext *ctx;
+    PCShellGetContext(pc, &ptr);
+    ctx = (SolverContext*) ptr;    
+
+    Mat B = ctx->gloAssem->subK[2], C = ctx->gloAssem->subK[1];
+
+    Vec x1, x2, y1, y2, tmp1, tmp2;
+
+    // Split x into x1, x2
+    VecNestGetSubVec(x, 0, &x1);
+    VecNestGetSubVec(x, 1, &x2);
+    
+    // Split y into y1, y2
+    VecNestGetSubVec(y, 0, &y1);
+    VecNestGetSubVec(y, 1, &y2);
+
+    VecDuplicate(x1, &tmp1);
+    VecDuplicate(x2, &tmp2);
+
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(A_solve, 0,0,0,0);
+  #endif 
+    // Step 1: Compute y1 = A^{-1} x1
+    ctx->lsolver_A->Solve(x1, y1, false);
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(A_solve,0,0,0,0);
+  #endif
+
+    // Step 2: Compute y2 = x2 - C * y1
+    MatMult(C, y1, tmp2);
+    VecWAXPY(y2, -1.0, tmp2, x2);
+
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(S_solve, 0,0,0,0);
+  #endif 
+    // Step 3: Compute y2 = S^{-1} y2
+    ctx->lsolver_S->Solve(y2, y2, false);
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(S_solve,0,0,0,0);
+  #endif
+
+    // Step 4: Compute y1 = y1 - A^{-1} B y2 = A^{-1} x1 - A^{-1} B y2
+    MatMult(B, y2, tmp1);
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(A_solve, 0,0,0,0);
+  #endif 
+    ctx->lsolver_A->Solve(tmp1, tmp1, false); 
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(A_solve,0,0,0,0);
+  #endif
+    VecAXPY(y1, -1.0, tmp1);
+
+    VecDestroy(&tmp1);
+    VecDestroy(&tmp2);
+
+    return 0;
+  }
+}
+
+#endif

--- a/examples/ns/include/Matrix_Free_Tools_AccurateA.hpp
+++ b/examples/ns/include/Matrix_Free_Tools_AccurateA.hpp
@@ -1,0 +1,168 @@
+#ifndef MATRIX_FREE_TOOLS_ACCURATEA_HPP
+#define MATRIX_FREE_TOOLS_ACCURATEA_HPP
+
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+#include "PLinear_Solver_PETSc.hpp"
+
+namespace MF_TA
+{
+  struct SolverContext
+  {
+    const std::unique_ptr<PGAssem_Block_NS_FEM_HERK> gassem;
+    const std::unique_ptr<PLinear_Solver_PETSc> lsolver_A;
+    const std::unique_ptr<PLinear_Solver_PETSc> lsolver_S;
+
+    // Constructor
+    SolverContext(std::unique_ptr<PGAssem_Block_NS_FEM_HERK> in_gassem,
+        std::unique_ptr<PLinear_Solver_PETSc> in_lsolver_A, 
+        std::unique_ptr<PLinear_Solver_PETSc> in_lsolver_S)
+    : gassem(std::move(in_gassem)), 
+      lsolver_A(std::move(in_lsolver_A)), 
+      lsolver_S(std::move(in_lsolver_S))
+    {}
+  };
+
+  inline PetscErrorCode MF_MatMult(Mat shell, Vec x, Vec y)
+  {
+    void *ptr;
+    PGAssem_Block_NS_FEM_HERK *user;
+    MatShellGetContext(shell, &ptr);
+    user = (PGAssem_Block_NS_FEM_HERK*) ptr;
+
+    Vec x1, x2, y1, y2, tmp1, tmp2;
+
+    const PetscScalar coef = user->Get_tangent_alpha_RK();
+
+    // Split the VectNest into subVec
+    VecNestGetSubVec(x, 0, &x1);
+    VecNestGetSubVec(x, 1, &x2);
+    VecNestGetSubVec(y, 0, &y1);
+    VecNestGetSubVec(y, 1, &y2);
+
+    VecDuplicate(x1, &tmp1);
+    VecDuplicate(x2, &tmp2);
+
+    MatMult(user->subK[3], x1, y1);      // y1 = A * x1
+    MatMult(user->subK[4], x1, tmp1);    // tmp1 = A_tilde * x1
+    VecAXPY(y1, coef, tmp1);             // y1 = A * x1 + coef * A_tilde * x1
+    MatMult(user->subK[2], x2, tmp1);    // tmp1 = B * x2
+    VecAXPY(y1, coef, tmp1);             // y1 = (A + coef * A_tilde) * x1 + coef * B * x2
+
+    MatMult(user->subK[1], x1, y2);      // y2 = C * x1
+    MatMult(user->subK[0], x2, tmp2);    // tmp2 = D * x2
+    VecAXPY(y2, coef, tmp2);             // y2 = C * x1 + coef * D * x2
+    
+    // Destruction of sub vectors
+    VecDestroy(&tmp1);
+    VecDestroy(&tmp2);
+
+    return 0;
+  }
+
+  inline PetscErrorCode SetupApproxSchur(PGAssem_Block_NS_FEM_HERK *const user, Mat &S_approx)
+  {
+    // Schur complement approximation: S = D - C inv(DIAGFORM(A)) B
+    Vec diag;
+    PetscInt mA_local;
+
+    MatGetLocalSize(user->subK[5], &mA_local, NULL);
+
+    // inverse of diagonal of A
+    VecCreate(PETSC_COMM_WORLD, &diag);   
+    VecSetSizes(diag, mA_local, PETSC_DETERMINE);
+    VecSetType(diag, VECMPI);
+    // MatGetRowSum(user->subK[5], diag); // Replace MatGetDiagonal() with MatGetRowSum()
+    MatGetDiagonal(user->subK[5], diag);
+    VecReciprocal(diag);
+
+    MatDiagonalScale(user->subK[2], diag, NULL); // overwrites B = subK[2]) 
+    MatMatMult(user->subK[1], user->subK[2], MAT_INITIAL_MATRIX, PETSC_DETERMINE, &S_approx);
+
+    MatScale(S_approx, -1.0);
+    MatAXPY(S_approx, 1.0, user->subK[0], DIFFERENT_NONZERO_PATTERN);  // S_approx = D - S_approx
+
+    // MatGetRowSum(user->subK[5], diag); // Restore with row sums again
+    MatGetDiagonal(user->subK[5], diag);
+    MatDiagonalScale(user->subK[2], diag, NULL);
+
+    VecDestroy(&diag);
+
+    return 0;
+  }
+
+  inline PetscErrorCode MF_PCSchurApply(PC pc, Vec x, Vec y)
+  {
+  #ifdef PETSC_USE_LOG
+    PetscLogEvent A_solve, S_solve;
+    PetscClassId classid_solve;
+    PetscClassIdRegister("PCsolve", &classid_solve);
+    PetscLogEventRegister("A_solve", classid_solve, &A_solve);
+    PetscLogEventRegister("S_solve", classid_solve, &S_solve);
+  #endif
+
+    void *ptr;
+    SolverContext *ctx;
+    PCShellGetContext(pc, &ptr);
+    ctx = (SolverContext*) ptr;    
+
+    ctx->lsolver_A->SetOperator(ctx->gassem->subK[5]); 
+    Mat S_approx;
+    SetupApproxSchur(ctx->gassem.get(), S_approx);
+    ctx->lsolver_S->SetOperator(S_approx);
+
+    Mat B = ctx->gassem->subK[2], C = ctx->gassem->subK[1];
+
+    Vec x1, x2, y1, y2, tmp1, tmp2;
+
+    // Split x into x1, x2
+    VecNestGetSubVec(x, 0, &x1);
+    VecNestGetSubVec(x, 1, &x2);
+    
+    // Split y into y1, y2
+    VecNestGetSubVec(y, 0, &y1);
+    VecNestGetSubVec(y, 1, &y2);
+
+    VecDuplicate(x1, &tmp1);
+    VecDuplicate(x2, &tmp2);
+
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(A_solve, 0,0,0,0);
+  #endif 
+    // Step 1: Compute y1 = A^{-1} x1
+    ctx->lsolver_A->Solve(x1, y1, false);
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(A_solve,0,0,0,0);
+  #endif
+
+    // Step 2: Compute y2 = x2 - C * y1
+    MatMult(C, y1, tmp2);
+    VecWAXPY(y2, -1.0, tmp2, x2);
+
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(S_solve, 0,0,0,0);
+  #endif 
+    // Step 3: Compute y2 = S^{-1} y2
+    ctx->lsolver_S->Solve(y2, y2, false);
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(S_solve,0,0,0,0);
+  #endif
+
+    // Step 4: Compute y1 = y1 - A^{-1} B y2 = A^{-1} x1 - A^{-1} B y2
+    MatMult(B, y2, tmp1);
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(A_solve, 0,0,0,0);
+  #endif 
+    ctx->lsolver_A->Solve(tmp1, tmp1, false); 
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(A_solve,0,0,0,0);
+  #endif
+    VecAXPY(y1, -1.0, tmp1);
+
+    VecDestroy(&tmp1);
+    VecDestroy(&tmp2);
+
+    return 0;
+  }
+}
+
+#endif

--- a/examples/ns/include/PDNSolution_P.hpp
+++ b/examples/ns/include/PDNSolution_P.hpp
@@ -1,0 +1,33 @@
+#ifndef PDNSOLUTION_P_HPP
+#define PDNSOLUTION_P_HPP
+// ============================================================================
+// PDNSolution_P.hpp
+//
+// This is a solution class for the pressure field, which is attached to a
+// pressure-type mesh with 1 dof per grid point.
+//
+// Author: Yujie Sun
+// Date: Apr. 14 2025 
+// ============================================================================
+#include "PDNSolution.hpp"
+
+class PDNSolution_P final : public PDNSolution
+{
+  public:
+    PDNSolution_P( const APart_Node * const &pNode,
+        const int &type, const bool &isprint = false,
+        const std::string &in_name = "solution_pressure" );
+
+    virtual ~PDNSolution_P() = default;
+
+  private:
+    const std::string sol_name;
+    const bool is_print;
+
+    // --------------------------------------------------------------
+    // case 0: generate full zero vector
+    // --------------------------------------------------------------
+    void Init_zero( const APart_Node * const &pNode );
+};
+
+#endif

--- a/examples/ns/include/PDNSolution_V.hpp
+++ b/examples/ns/include/PDNSolution_V.hpp
@@ -1,0 +1,33 @@
+#ifndef PDNSOLUTION_V_HPP
+#define PDNSOLUTION_V_HPP
+// ============================================================================
+// PDNSolution_V.hpp
+//
+// This is a solution class for the velocity field which is attached to a velocity-type
+// mesh with 3 dofs per grid point.
+//
+// Author: Yujie Sun
+// Date: Apr. 14 2025 
+// ============================================================================
+#include "PDNSolution.hpp"
+
+class PDNSolution_V final : public PDNSolution
+{
+  public:
+    PDNSolution_V( const APart_Node * const &pNode,
+        const int &type, const bool &isprint = false,
+        const std::string &in_name = "solution_velocity" );
+
+    virtual ~PDNSolution_V() = default;
+
+  private:
+    const std::string sol_name;
+    const bool is_print;
+
+    // --------------------------------------------------------------
+    // case 0: generate full zero vector 
+    // --------------------------------------------------------------
+    void Init_zero( const APart_Node * const &pNode );
+};
+
+#endif

--- a/examples/ns/include/PGAssem_Block_NS_FEM_HERK.hpp
+++ b/examples/ns/include/PGAssem_Block_NS_FEM_HERK.hpp
@@ -1,0 +1,270 @@
+#ifndef PGASSEM_BLOCK_NS_FEM_HERK_HPP
+#define PGASSEM_BLOCK_NS_FEM_HERK_HPP
+// ==================================================================
+// PGAssem_Block_NS_FEM_HERK.hpp
+//
+// Parallel golbal assembly based on PETSc, using AIJ matrix format.
+// The assembly routine is designed for classical C0 FEM method, which
+// means we do not need extraction operators and local mesh sizes.
+//
+// The assembly is for the NS equations written in VMS and HERK formualtion
+// of NS equations. The input solution vectors contains
+//  [ velocity/dot velocity; pressure ].
+//
+// Author: Yujie Sun 
+// Date Created: Mar. 4 2025
+// ==================================================================
+#include "PETSc_Tools.hpp"
+#include "PDNSolution_NS.hpp"
+#include "PDNSolution_V.hpp"
+#include "PDNSolution_P.hpp"
+#include "PLocAssem_Block_VMS_NS_HERK.hpp"
+#include "APart_Node.hpp"
+#include "ALocal_Elem.hpp"
+#include "AGlobal_Mesh_Info.hpp"
+#include "FEANode.hpp"
+#include "PDNSolution.hpp"
+#include "ALocal_NBC.hpp"
+#include "ALocal_EBC.hpp"
+#include "ALocal_IEN.hpp"
+
+class PGAssem_Block_NS_FEM_HERK
+{
+  public:
+    Mat subK[6];
+
+    Vec G;
+    Vec subG[2];
+
+    // Constructor
+    PGAssem_Block_NS_FEM_HERK(
+        std::unique_ptr<ALocal_IEN> in_locien,
+        std::unique_ptr<ALocal_Elem> in_locelem,
+        std::unique_ptr<FEANode> in_fnode,
+        std::unique_ptr<APart_Node> in_pnode,
+        std::unique_ptr<ALocal_NBC> in_nbc,
+        std::unique_ptr<ALocal_EBC> in_ebc,
+        std::unique_ptr<PLocAssem_Block_VMS_NS_HERK> in_locassem,
+        const int &in_nz_estimate=60 );
+
+    // Destructor
+    ~PGAssem_Block_NS_FEM_HERK();
+
+    // ------------------------------------------------------------------------
+    // ! Flag : Fix nonzero structure
+    //          Add or insert in new location is ignored. Set after
+    //         the first MatAssemblyEnd().
+    // ------------------------------------------------------------------------
+    void Fix_nonzero_str()
+    {
+      MatSetOption(subK[0], MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
+      MatSetOption(subK[1], MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
+      MatSetOption(subK[2], MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
+      MatSetOption(subK[3], MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
+      MatSetOption(subK[4], MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
+    }
+
+    // ------------------------------------------------------------------------
+    // ! Flag : New allocation error
+    //          Add or insert in new locations will generate an error message.
+    //          Supports AIJ and BAIJ formats.
+    // ------------------------------------------------------------------------
+    void Fix_nonzero_err_str()
+    {
+      MatSetOption(subK[0], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+      MatSetOption(subK[1], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+      MatSetOption(subK[2], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+      MatSetOption(subK[3], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+      MatSetOption(subK[4], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+    }
+    
+    // ------------------------------------------------------------------------
+    // ! Flag : Ignore new allocation
+    //          Add or insert in a new allocation will NOT generate error.
+    // ------------------------------------------------------------------------
+    void Release_nonzero_err_str()
+    {
+      MatSetOption(subK[0], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+      MatSetOption(subK[1], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+      MatSetOption(subK[2], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+      MatSetOption(subK[3], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+      MatSetOption(subK[4], MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+    }
+
+    // ------------------------------------------------------------------------
+    // ! Flag : Keep nonzero pattern of the matrix K
+    // ------------------------------------------------------------------------
+    void Keep_nonzero_pattern()
+    {
+      MatSetOption(subK[0], MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+      MatSetOption(subK[1], MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+      MatSetOption(subK[2], MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+      MatSetOption(subK[3], MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+      MatSetOption(subK[4], MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+    }
+
+    void Clear_G() {VecSet(G, 0.0);}
+
+    void Clear_subKG()
+    {
+      MatZeroEntries(subK[0]);
+      MatZeroEntries(subK[1]);
+      MatZeroEntries(subK[2]);
+      MatZeroEntries(subK[3]);
+      MatZeroEntries(subK[4]);
+      VecSet(G, 0.0);
+    }
+
+    void Clear_subK5()
+    {
+      MatZeroEntries(subK[5]);
+    }
+    
+    // Nonzero pattern estimate for the NS equations
+    void Assem_nonzero_estimate();
+    
+    // Assembly the tangent block matrix for the HERK
+    void Assem_tangent_matrix(
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &dt );
+
+    // Assembly the residual vector for the sub-step of HERK        
+    void Assem_residual_substep(
+        const int &substep_index,
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution ** const &pre_velo_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution ** const &pre_pres_sols,
+        PDNSolution * const &pre_velo_before,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &curr_time,
+        const double &dt );
+
+    // Assembly the residual vector for the final step of HERK 
+    void Assem_residual_finalstep(
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution * const &cur_velo,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution ** const &pre_velo_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution ** const &pre_pres_sols,
+        PDNSolution * const &pre_velo_before,    
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &curr_time,
+        const double &dt );
+
+    // Assembly the residual vector for the pres stage of HERK 
+    void Assem_residual_presstage(
+        PDNSolution * const &cur_dot_velo,
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution * const &cur_velo,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution * const &cur_pres,    
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &curr_time,
+        const double &dt );
+
+    // Assembly the residual vector and tangent matrix for the sub-step of HERK
+    void Assem_tangent_residual_substep(
+        const int &substep_index,
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution ** const &pre_velo_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution ** const &pre_pres_sols,
+        PDNSolution * const &pre_velo_before,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &curr_time,
+        const double &dt );
+
+    // Assembly the residual vector and tangent matrix for the final step of HERK
+    void Assem_tangent_residual_finalstep(
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution * const &cur_velo,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution ** const &pre_velo_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution ** const &pre_pres_sols,
+        PDNSolution * const &pre_velo_before,    
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &curr_time,
+        const double &dt );
+
+    // Assembly the residual vector and tangent matrix for the pres stage of HERK 
+    void Assem_tangent_residual_presstage(
+        PDNSolution * const &cur_dot_velo,
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution * const &cur_velo,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution * const &cur_pres,    
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double &curr_time,
+        const double &dt );
+
+    void Update_tangent_alpha_RK( const double &aa )
+    {tangent_alpha_RK = aa;}
+
+    double Get_tangent_alpha_RK()
+    {return tangent_alpha_RK;}
+
+    // Assembly the tangent block matrix (A + coef * A_tilde)
+    void Update_tangent_submatrix5()
+    {
+      if (subK[5] == NULL) // If subK [5] has not yet allocated memory, proceed with memory allocation
+        MatDuplicate(subK[3], MAT_COPY_VALUES, &subK[5]);
+      else // If subK [5] already has memory, update its contents directly
+        MatCopy(subK[3], subK[5], DIFFERENT_NONZERO_PATTERN);
+
+      MatAXPY(subK[5], tangent_alpha_RK, subK[4], DIFFERENT_NONZERO_PATTERN);
+    }
+
+  private:
+    // Private data
+    const std::unique_ptr<const ALocal_IEN> locien;
+    const std::unique_ptr<const ALocal_Elem> locelem;
+    const std::unique_ptr<const FEANode> fnode;
+    const std::unique_ptr<const APart_Node> pnode;
+    const std::unique_ptr<const ALocal_NBC> nbc;
+    const std::unique_ptr<const ALocal_EBC> ebc;
+    const std::unique_ptr<PLocAssem_Block_VMS_NS_HERK> locassem;
+
+    const int nLocBas, snLocBas, dof_sol, dof_mat_v, dof_mat_p, num_ebc, nlgn;
+
+    // Runge-Kutta butcher table coefficients
+    double tangent_alpha_RK;
+
+    // Essential boundary condition
+    void EssBC_KG();
+
+    void EssBC_K();
+
+    void EssBC_G();
+
+    // Natural boundary condition for sub-step of the HERK
+    void NatBC_G_HERK_Sub( const double &curr_time, const double &dt,
+        const int &substep_index,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr );
+
+    // Natural boundary condition for final step of the HERK
+    void NatBC_G_HERK_Final( const double &curr_time, const double &dt,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr );
+
+    // Natural boundary condition for pres stage of the HERK
+    void NatBC_G_HERK_Pressure( const double &curr_time, const double &dt );
+
+    std::vector<double> GetLocal( const std::vector<double> &array,
+      const std::vector<int> &IEN, const int &in_locbas, const int &in_dof ) const
+    {
+      std::vector<double> out( in_locbas * in_dof, 0.0 );
+      for(int ii=0; ii<in_locbas; ++ii)
+        for(int jj=0; jj<in_dof; ++jj)
+          out[ii * in_dof + jj] = array[IEN[ii] * in_dof + jj];
+  
+      return out;
+    }
+};
+
+#endif

--- a/examples/ns/include/PLocAssem_Block_VMS_NS_HERK.hpp
+++ b/examples/ns/include/PLocAssem_Block_VMS_NS_HERK.hpp
@@ -1,0 +1,280 @@
+#ifndef PLOCASSEM_VMS_NS_HERK_HPP
+#define PLOCASSEM_VMS_NS_HERK_HPP
+// ==================================================================
+// PLocAssem_Block_MS_NS_HERK.hpp
+// 
+// Parallel Local Assembly routine for VMS and HERK based NS
+// solver into 5 sub blocks.
+//
+// Author: Yujie Sun
+// Date: Mar. 5 2025
+// ==================================================================
+#include "ITimeMethod_RungeKutta.hpp"
+#include "SymmTensor2_3D.hpp"
+#include "FEAElementFactory.hpp"
+#include "QuadPtsFactory.hpp"
+
+class PLocAssem_Block_VMS_NS_HERK
+{
+  public:
+    PetscScalar * Tangent0; // A00
+    PetscScalar * Tangent1; // A01
+    PetscScalar * Tangent2; // A10
+    PetscScalar * Tangent3; // A11
+    PetscScalar * Tangent4; // tilde{A}11
+        
+    PetscScalar * Residual0; // R0
+    PetscScalar * Residual1; // R1
+
+    PetscScalar * sur_Residual1; // sur_R1
+
+    PLocAssem_Block_VMS_NS_HERK(
+        const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
+        const ITimeMethod_RungeKutta * const &tm_RK, const double &in_rho, 
+        const double &in_vis_mu, const double &in_L0,
+        const double &in_ct = 4.0, const double &in_ctauc = 1.0, 
+        const double &in_cu = 2.0, const double &in_cp = 2.0);
+
+    ~PLocAssem_Block_VMS_NS_HERK();
+
+    int get_dof() const {return 4;}
+
+    int get_dof_mat() const {return 4;}
+
+    int get_dof_mat_0() const {return 1;}
+    
+    int get_dof_mat_1() const {return 3;}
+
+    int get_nLocBas() const {return nLocBas;}
+
+    int get_snLocBas() const {return snLocBas;}
+
+    void Zero_Tangent_Residual()
+    {
+      for(int ii=0; ii<vec_size_p; ++ii) Residual0[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v; ++ii) Residual1[ii] = 0.0;
+      for(int ii=0; ii<vec_size_p*vec_size_p; ++ii) Tangent0[ii] = 0.0;
+      for(int ii=0; ii<vec_size_p*vec_size_v; ++ii) Tangent1[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v*vec_size_p; ++ii) Tangent2[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v*vec_size_v; ++ii) Tangent3[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v*vec_size_v; ++ii) Tangent4[ii] = 0.0;
+    }
+
+    void Zero_Tangent()
+    {
+      for(int ii=0; ii<vec_size_p*vec_size_p; ++ii) Tangent0[ii] = 0.0;
+      for(int ii=0; ii<vec_size_p*vec_size_v; ++ii) Tangent1[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v*vec_size_p; ++ii) Tangent2[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v*vec_size_v; ++ii) Tangent3[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v*vec_size_v; ++ii) Tangent4[ii] = 0.0;
+    }
+
+    void Zero_sur_Residual()
+    {
+      for(int ii=0; ii<sur_size_v; ++ii) sur_Residual1[ii] = 0.0;
+    }
+
+    void Zero_Residual()
+    {
+      for(int ii=0; ii<vec_size_p; ++ii) Residual0[ii] = 0.0;
+      for(int ii=0; ii<vec_size_v; ++ii) Residual1[ii] = 0.0;
+    }
+
+    void Assem_Estimate()
+    {
+      for(int ii=0; ii<vec_size_p*vec_size_p; ++ii) Tangent0[ii] = 1.0;
+      for(int ii=0; ii<vec_size_p*vec_size_v; ++ii) Tangent1[ii] = 1.0;
+      for(int ii=0; ii<vec_size_v*vec_size_p; ++ii) Tangent2[ii] = 1.0;
+      for(int ii=0; ii<vec_size_v*vec_size_v; ++ii) Tangent3[ii] = 1.0;
+      for(int ii=0; ii<vec_size_v*vec_size_v; ++ii) Tangent4[ii] = 1.0;
+    }
+
+    void Assem_Residual_EBC_HERK_Sub(
+        const int &ebc_id,
+        const double &time, const double &dt,
+        const int &subindex,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Residual_EBC_HERK_Final(
+        const int &ebc_id,
+        const double &time, const double &dt,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Residual_EBC_HERK_Pressure(
+        const int &ebc_id,
+        const double &time, const double &dt,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Tangent_Matrix(
+      const double &dt,
+      const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+      const double * const &eleCtrlPts_x,
+      const double * const &eleCtrlPts_y,
+      const double * const &eleCtrlPts_z );
+
+    void Assem_Residual_Sub(
+        const double &time, const double &dt,
+        const int &subindex,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const std::vector<std::vector<double>>& cur_velo_sols,
+        const std::vector<std::vector<double>>& cur_pres_sols,
+        const std::vector<std::vector<double>>& pre_velo_sols,
+        const std::vector<std::vector<double>>& pre_pres_sols,
+        const std::vector<double>& pre_velo,
+        const std::vector<double>& pre_velo_before,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Residual_Final(
+        const double &time, const double &dt,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const std::vector<std::vector<double>>& cur_velo_sols,
+        const std::vector<double>& cur_velo,
+        const std::vector<std::vector<double>>& cur_pres_sols,
+        const std::vector<std::vector<double>>& pre_velo_sols,
+        const std::vector<double>& pre_velo,
+        const std::vector<std::vector<double>>& pre_pres_sols,
+        const std::vector<double>& pre_velo_before,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Residual_Pressure(
+        const double &time, const double &dt,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const std::vector<double>& cur_dot_velo,
+        const std::vector<std::vector<double>>& cur_velo_sols,
+        const std::vector<double>& cur_velo,
+        const std::vector<std::vector<double>>& cur_pres_sols,
+        const std::vector<double>& pre_velo,
+        const std::vector<double>& cur_pres,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Tangent_Residual_Sub(
+        const double &time, const double &dt,
+        const int &subindex,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const std::vector<std::vector<double>>& cur_velo_sols,
+        const std::vector<std::vector<double>>& cur_pres_sols,
+        const std::vector<std::vector<double>>& pre_velo_sols,
+        const std::vector<std::vector<double>>& pre_pres_sols,
+        const std::vector<double>& pre_velo,
+        const std::vector<double>& pre_velo_before,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Tangent_Residual_Final(
+        const double &time, const double &dt,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const std::vector<std::vector<double>>& cur_velo_sols,
+        const std::vector<double>& cur_velo,
+        const std::vector<std::vector<double>>& cur_pres_sols,
+        const std::vector<std::vector<double>>& pre_velo_sols,
+        const std::vector<double>& pre_velo,
+        const std::vector<std::vector<double>>& pre_pres_sols,
+        const std::vector<double>& pre_velo_before,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+    void Assem_Tangent_Residual_Pressure(
+        const double &time, const double &dt,
+        const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+        const std::vector<double>& cur_dot_velo,
+        const std::vector<std::vector<double>>& cur_velo_sols,
+        const std::vector<double>& cur_velo,
+        const std::vector<std::vector<double>>& cur_pres_sols,
+        const std::vector<double>& pre_velo,
+        const std::vector<double>& cur_pres,
+        const double * const &eleCtrlPts_x,
+        const double * const &eleCtrlPts_y,
+        const double * const &eleCtrlPts_z );
+
+  protected:
+    // Private data
+    const FEType elemType;
+    
+    const int nqpv, nqps;
+
+    const std::unique_ptr<FEAElement> elementv, elements;
+
+    const std::unique_ptr<IQuadPts> quadv, quads;
+
+    const double rho0, vis_mu;
+    
+    const double CI, CT; // Constants for stabilization parameters
+    
+    const double Ctauc; // Constant scaling factor for tau_C
+    
+    const double L0, cu, cp; // Stabilization parameters for Darcy problem
+
+    const int nLocBas, snLocBas, vec_size_v, vec_size_p, sur_size_v;
+
+    // M matrix for tau_m
+    //             mm[0], mm[1], mm[2]
+    // M = coef *  mm[3], mm[4], mm[5]
+    //             mm[6], mm[7], mm[8]
+    const double coef;
+    const std::array<double, 9> mm; 
+
+    // Private functions
+    void print_info() const;
+
+    SymmTensor2_3D get_metric( const std::array<double, 9> &dxi_dx ) const;
+
+    // Return tau_m and tau_c in RB-VMS
+    std::array<double, 2> get_tau( const double &dt, 
+        const std::array<double, 9> &dxi_dx,
+        const double &u, const double &v, const double &w ) const;
+
+    std::array<double, 2> get_tau_Darcy( const double &dt ) const;
+
+    // Return tau_m_dot and tau_c_dot in RB-VMS
+    std::array<double, 2> get_tau_dot( const double &dt, 
+        const std::array<double, 9> &dxi_dx,
+        const double &u, const double &v, const double &w ) const;
+
+    // Return tau_bar := (v' G v')^-0.5 x rho0, 
+    //        which scales like Time x Density
+    // Users can refer to Int. J. Numer. Meth. Fluids 2001; 35: 93–116 
+    // for more details
+    double get_DC( const std::array<double, 9> &dxi_dx,
+        const double &u, const double &v, const double &w ) const;
+
+    Vector_3 get_f(const Vector_3 &pt, const double &tt) const
+    {
+      return Vector_3( 0.0, 0.0, 0.0 );
+    }
+
+    Vector_3 get_H1(const Vector_3 &pt, const double &tt, 
+        const Vector_3 &n_out ) const
+    {
+      const double p0 = 0.0;  
+      return Vector_3( p0*n_out.x(), p0*n_out.y(), p0*n_out.z() );
+    }
+
+    typedef Vector_3 ( PLocAssem_Block_VMS_NS_HERK::*locassem_vms_ns_funs )( 
+        const Vector_3 &pt, const double &tt, const Vector_3 &n_out ) const;
+
+    locassem_vms_ns_funs * flist;
+
+    Vector_3 get_ebc_fun( const int &ebc_id, const Vector_3 &pt, 
+        const double &tt, const Vector_3 &n_out ) const
+    {
+      return ((*this).*(flist[ebc_id]))(pt, tt, n_out);
+    }
+};
+
+#endif

--- a/examples/ns/include/PTime_NS_HERK_Solver.hpp
+++ b/examples/ns/include/PTime_NS_HERK_Solver.hpp
@@ -1,0 +1,108 @@
+#ifndef PTIME_NS_HERK_SOLVER_HPP
+#define PTIME_NS_HERK_SOLVER_HPP
+// ==================================================================
+// PTime_NS_HERK_Solver.hpp
+//
+// Parallel time solver using HERK for NS.
+//
+// Author: Yujie Sun
+// Date: Mar 10 2025
+// ==================================================================
+#include "IFlowRate.hpp"
+#include "ITimeMethod_RungeKutta.hpp"
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+#include "PLinear_Solver_PETSc.hpp"
+#include "Matrix_PETSc.hpp"
+#include "PDNTimeStep.hpp"
+#include "PDNSolution_NS.hpp"
+#include "PDNSolution_V.hpp"
+#include "PDNSolution_P.hpp"
+#include "ALocal_InflowBC.hpp"
+
+class PTime_NS_HERK_Solver
+{
+  public:
+    PTime_NS_HERK_Solver(
+        std::unique_ptr<PGAssem_Block_NS_FEM_HERK> in_gassem,
+        std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
+        std::unique_ptr<Matrix_PETSc> in_bc_mat,
+        std::unique_ptr<ITimeMethod_RungeKutta> in_tmRK,
+        std::unique_ptr<IFlowRate> in_flrate,
+        std::unique_ptr<IFlowRate> in_dot_flrate,
+        std::unique_ptr<PDNSolution> in_sol_base,
+        std::unique_ptr<ALocal_InflowBC> in_infnbc,
+        const std::string &input_name, const int &in_nlocalnode, 
+        const int &input_record_freq, const double &input_final_time );
+
+    ~PTime_NS_HERK_Solver() = default;
+
+    void print_info() const;
+
+    void print_lsolver_info() const {lsolver->print_info();}
+
+    void TM_NS_HERK(
+        const bool &restart_init_assembly_flag,
+        std::unique_ptr<PDNSolution> init_sol,
+        std::unique_ptr<PDNSolution> init_velo,
+        std::unique_ptr<PDNSolution> init_dot_velo,
+        std::unique_ptr<PDNSolution> init_pres,
+        std::unique_ptr<PDNTimeStep> time_info ) const;
+
+  private:
+    const double final_time;
+    const int sol_record_freq; // the frequency for writing solutions
+    const std::string pb_name; // the problem base name for the solution
+    const int nlocalnode; // the mumber of nodes (without ghost nodes) in the local area
+
+    const std::unique_ptr<PGAssem_Block_NS_FEM_HERK> gassem;
+    const std::unique_ptr<PLinear_Solver_PETSc> lsolver;
+    const std::unique_ptr<Matrix_PETSc> bc_mat;
+    const std::unique_ptr<ITimeMethod_RungeKutta> tmRK;
+    const std::unique_ptr<IFlowRate> flrate;
+    const std::unique_ptr<IFlowRate> dot_flrate;
+    const std::unique_ptr<PDNSolution> sol_base;
+    const std::unique_ptr<const ALocal_InflowBC> infnbc;
+  
+    std::string Name_Generator( const int &counter ) const;
+
+    void Write_restart_file(const PDNTimeStep * const &timeinfo,
+        const std::string &solname ) const;
+
+    void HERK_Solve_NS(
+        const double &curr_time, const double &dt,
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution * const &cur_velo,
+        PDNSolution * const &cur_dot_velo,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution * const &cur_pres,
+        PDNSolution ** const &pre_velo_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution ** const &pre_pres_sols,
+        PDNSolution * const &pre_pres,
+        PDNSolution * const &pre_velo_before,
+        PDNSolution * const &cur_sol ) const;
+
+      void rescale_inflow_velo( const double &stime,
+          const IFlowRate * const &flrate, 
+          PDNSolution * const &velo ) const;
+
+      void Update_dot_step(const Vec &vp, 
+          PDNSolution * const &step) const;
+
+      void Update_pressure_velocity(     
+          PDNSolution * const &velo,
+          PDNSolution * const &pres,
+          const PDNSolution * const &step) const;
+
+      void Update_init_pressure_velocity(     
+          PDNSolution * const &velo,
+          PDNSolution * const &pres,
+          const PDNSolution * const &sol) const;  
+
+      void Update_solutions(   
+          const PDNSolution * const &velo,
+          const PDNSolution * const &pres,
+          PDNSolution * const &sol) const;
+};
+
+#endif

--- a/examples/ns/include/PTime_NS_HERK_Solver_AccurateA.hpp
+++ b/examples/ns/include/PTime_NS_HERK_Solver_AccurateA.hpp
@@ -1,0 +1,115 @@
+#ifndef PTIME_NS_HERK_SOLVER_ACCURATEA_HPP
+#define PTIME_NS_HERK_SOLVER_ACCURATEA_HPP
+// ==================================================================
+// PTime_NS_HERK_Solver.hpp
+//
+// Parallel time solver using HERK for NS.
+//
+// Author: Yujie Sun
+// Date: Mar 10 2025
+// ==================================================================
+#include "IFlowRate.hpp"
+#include "ITimeMethod_RungeKutta.hpp"
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+#include "PLinear_Solver_PETSc.hpp"
+#include "Matrix_PETSc.hpp"
+#include "PDNTimeStep.hpp"
+#include "PDNSolution_NS.hpp"
+#include "PDNSolution_V.hpp"
+#include "PDNSolution_P.hpp"
+#include "ALocal_InflowBC.hpp"
+#include "Matrix_Free_Tools_AccurateA.hpp"
+
+class PTime_NS_HERK_Solver_AccurateA
+{
+  public:
+
+    PTime_NS_HERK_Solver_AccurateA(
+        std::unique_ptr<MF_TA::SolverContext> in_solver_ctx,
+        std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
+        std::unique_ptr<Matrix_PETSc> in_bc_mat,
+        std::unique_ptr<ITimeMethod_RungeKutta> in_tmRK,
+        std::unique_ptr<IFlowRate> in_flrate,
+        std::unique_ptr<IFlowRate> in_dot_flrate,
+        std::unique_ptr<PDNSolution> in_sol_base,
+        std::unique_ptr<ALocal_InflowBC> in_infnbc,
+        const std::string &input_name, const int &in_nlocalnode, 
+        const int &input_record_freq, const double &input_final_time );
+
+    ~PTime_NS_HERK_Solver_AccurateA() = default;
+
+    void print_info() const;
+
+    void print_lsolver_info() const 
+    {
+      lsolver->print_info();
+      solver_ctx->lsolver_A->print_info();
+      solver_ctx->lsolver_S->print_info();
+    }
+
+    void TM_NS_HERK(
+        const bool &restart_init_assembly_flag,
+        std::unique_ptr<PDNSolution> init_sol,
+        std::unique_ptr<PDNSolution> init_velo,
+        std::unique_ptr<PDNSolution> init_dot_velo,
+        std::unique_ptr<PDNSolution> init_pres,
+        std::unique_ptr<PDNTimeStep> time_info ) const;
+
+  private:
+    const double final_time;
+    const int sol_record_freq; // the frequency for writing solutions
+    const std::string pb_name; // the problem base name for the solution
+    const int nlocalnode; // the mumber of nodes (without ghost nodes) in the local area
+
+    const std::unique_ptr<MF_TA::SolverContext> solver_ctx;
+    const std::unique_ptr<PLinear_Solver_PETSc> lsolver;
+    const std::unique_ptr<Matrix_PETSc> bc_mat;
+    const std::unique_ptr<ITimeMethod_RungeKutta> tmRK;
+    const std::unique_ptr<IFlowRate> flrate;
+    const std::unique_ptr<IFlowRate> dot_flrate;
+    const std::unique_ptr<PDNSolution> sol_base;
+    const std::unique_ptr<const ALocal_InflowBC> infnbc;
+  
+    std::string Name_Generator( const int &counter ) const;
+
+    void Write_restart_file(const PDNTimeStep * const &timeinfo,
+        const std::string &solname ) const;
+
+    void HERK_Solve_NS(
+        const double &curr_time, const double &dt,
+        PDNSolution ** const &cur_velo_sols,
+        PDNSolution * const &cur_velo,
+        PDNSolution * const &cur_dot_velo,
+        PDNSolution ** const &cur_pres_sols,
+        PDNSolution * const &cur_pres,
+        PDNSolution ** const &pre_velo_sols,
+        PDNSolution * const &pre_velo,
+        PDNSolution ** const &pre_pres_sols,
+        PDNSolution * const &pre_pres,
+        PDNSolution * const &pre_velo_before,
+        PDNSolution * const &cur_sol ) const;
+
+      void rescale_inflow_velo( const double &stime,
+          const IFlowRate * const &flrate, 
+          PDNSolution * const &velo ) const;
+        
+      void Update_dot_step(const Vec &vp, 
+          PDNSolution * const &step) const;
+
+      void Update_pressure_velocity(     
+          PDNSolution * const &velo,
+          PDNSolution * const &pres,
+          const PDNSolution * const &step) const;
+
+      void Update_init_pressure_velocity(     
+          PDNSolution * const &velo,
+          PDNSolution * const &pres,
+          const PDNSolution * const &sol) const;
+    
+      void Update_solutions(   
+          const PDNSolution * const &velo,
+          const PDNSolution * const &pres,
+          PDNSolution * const &sol) const;
+};
+
+#endif

--- a/examples/ns/ns_herk_driver.cpp
+++ b/examples/ns/ns_herk_driver.cpp
@@ -1,0 +1,367 @@
+// ==================================================================
+// ns code driver.cpp
+//
+// Finite element code for 3D Navier-Stokes equations using the 
+// Variational Multiscale Formulation and Half-explicit RK time 
+// stepping.
+//
+// Author: Yujie Sun
+// Date: Apr. 4 2025
+// ==================================================================
+#include "HDF5_Writer.hpp"
+#include "ANL_Tools.hpp"
+#include "FlowRateFactory.hpp"
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+#include "PTime_NS_HERK_Solver.hpp"
+#include "ExplicitRK_SSPRK3p3s.hpp"
+#include "ExplicitRK_EMRK2p2s.hpp"
+#include "ExplicitRK_HeunRK2p2s.hpp"
+#include "ExplicitRK_RalstonRK2p2s.hpp"
+#include "ExplicitRK_PseudoSymplecticRK3p5q4s.hpp"
+#include "Matrix_Free_Tools.hpp"
+
+int main(int argc, char *argv[])
+{
+  // Number of quadrature points for tets and triangles
+  // Suggested values: 5 / 4 for linear, 17 / 13 for quadratic
+  // Number of quadrature points for hexs and quadrangles
+  // Suggested values: 8 / 4 for linear, 64 / 16 for quadratic
+  int nqp_vol = 5, nqp_sur = 4;
+
+  // Estimate of the nonzero per row for the sparse matrix
+  int nz_estimate = 300;
+
+  // fluid properties
+  double fluid_density = 1.065;
+  double fluid_mu = 3.5e-2;
+  double c_tauc = 1.0; // scaling factor for tau_c, take 0.0, 0.125, or 1.0
+  double c_ct = 4.0;   // C_T parameter for defining tau_M
+  
+  // Stabilization para for Darcy problem
+  double L0 = 0.1;
+  double cu = 2.0;
+  double cp = 2.0;
+
+  // inflow file & dot_inflow_file
+  std::string inflow_file("inflow_fourier_series.txt");
+  std::string dot_inflow_file("dot_inflow_fourier_series.txt");
+
+  // LPN file
+//   std::string lpn_file("lpn_rcr_input.txt");
+
+  // part file location
+  std::string part_file("part");
+
+  // time stepping parameters
+  double initial_time = 0.0; // time of the initial condition
+  double initial_step = 0.1; // time step size
+  int initial_index = 0;     // indiex of the initial condition
+  double final_time = 1.0;   // final time
+  std::string sol_bName("SOL_"); // base name of the solution file
+  int sol_record_freq = 1;   // frequency of recording the solution
+
+  // Restart options
+  bool is_restart = false;
+  int restart_index = 0;             // restart solution time index
+  double restart_time = 0.0;         // restart time
+  double restart_step = 1.0e-3;      // restart simulation time step size
+  std::string restart_name = "SOL_"; // restart solution base name
+
+  // Yaml options
+  bool is_loadYaml = true;
+  std::string yaml_file("./runscript.yml");
+
+#if PETSC_VERSION_LT(3,19,0)
+  PetscInitialize(&argc, &argv, (char *)0, PETSC_NULL);
+#else
+  PetscInitialize(&argc, &argv, (char *)0, PETSC_NULLPTR);
+#endif
+
+  const PetscMPIInt rank = SYS_T::get_MPI_rank();
+  const PetscMPIInt size = SYS_T::get_MPI_size();
+
+  SYS_T::print_perigee_art();
+
+  // ===== Yaml Arguments =====
+  SYS_T::GetOptionBool("-is_loadYaml", is_loadYaml);
+  SYS_T::GetOptionString("-yaml_file", yaml_file);
+
+  if (is_loadYaml) SYS_T::InsertFileYAML( yaml_file,  false );
+
+  // ===== Read Command Line Arguments =====
+  SYS_T::commPrint("===> Reading arguments from Command line ... \n");
+
+  SYS_T::GetOptionInt("-nqp_vol", nqp_vol);
+  SYS_T::GetOptionInt("-nqp_sur", nqp_sur);
+  SYS_T::GetOptionInt("-nz_estimate", nz_estimate);
+  SYS_T::GetOptionReal("-fl_density", fluid_density);
+  SYS_T::GetOptionReal("-fl_mu", fluid_mu);
+  SYS_T::GetOptionReal("-c_tauc", c_tauc);
+  SYS_T::GetOptionReal("-c_ct", c_ct);
+  SYS_T::GetOptionReal("-L0", L0);
+  SYS_T::GetOptionReal("-cu", cu);
+  SYS_T::GetOptionReal("-cp", cp);
+  SYS_T::GetOptionString("-inflow_file", inflow_file);
+  SYS_T::GetOptionString("-dot_inflow_file", dot_inflow_file);
+//   SYS_T::GetOptionString("-lpn_file", lpn_file);
+  SYS_T::GetOptionString("-part_file", part_file);
+  SYS_T::GetOptionReal("-init_time", initial_time);
+  SYS_T::GetOptionReal("-fina_time", final_time);
+  SYS_T::GetOptionReal("-init_step", initial_step);
+  SYS_T::GetOptionInt("-init_index", initial_index);
+  SYS_T::GetOptionInt("-sol_rec_freq", sol_record_freq);
+  SYS_T::GetOptionString("-sol_name", sol_bName);
+  SYS_T::GetOptionBool("-is_restart", is_restart);
+  SYS_T::GetOptionInt("-restart_index", restart_index);
+  SYS_T::GetOptionReal("-restart_time", restart_time);
+  SYS_T::GetOptionReal("-restart_step", restart_step);
+  SYS_T::GetOptionString("-restart_name", restart_name);
+
+  // ===== Print Command Line Arguments =====
+  SYS_T::cmdPrint("-nqp_vol:", nqp_vol);
+  SYS_T::cmdPrint("-nqp_sur:", nqp_sur);
+  SYS_T::cmdPrint("-nz_estimate:", nz_estimate);
+  SYS_T::cmdPrint("-fl_density:", fluid_density);
+  SYS_T::cmdPrint("-fl_mu:", fluid_mu);
+  SYS_T::cmdPrint("-c_tauc:", c_tauc);
+  SYS_T::cmdPrint("-c_ct:", c_ct);
+  SYS_T::cmdPrint("-L0", L0);
+  SYS_T::cmdPrint("-cu", cu);
+  SYS_T::cmdPrint("-cp", cp);
+  SYS_T::cmdPrint("-inflow_file:", inflow_file);
+  SYS_T::cmdPrint("-dot_inflow_file:", dot_inflow_file);
+//   SYS_T::cmdPrint("-lpn_file:", lpn_file);
+  SYS_T::cmdPrint("-part_file:", part_file);;
+  SYS_T::cmdPrint("-init_time:", initial_time);
+  SYS_T::cmdPrint("-init_step:", initial_step);
+  SYS_T::cmdPrint("-init_index:", initial_index);
+  SYS_T::cmdPrint("-fina_time:", final_time);
+  SYS_T::cmdPrint("-sol_rec_freq:", sol_record_freq);
+  SYS_T::cmdPrint("-sol_name:", sol_bName);
+  if(is_restart)
+  {
+    SYS_T::commPrint("-is_restart: true \n");
+    SYS_T::cmdPrint("-restart_index:", restart_index);
+    SYS_T::cmdPrint("-restart_time:", restart_time);
+    SYS_T::cmdPrint("-restart_step:", restart_step);
+    SYS_T::cmdPrint("-restart_name:", restart_name);
+  }
+  else SYS_T::commPrint("-is_restart: false \n");
+
+  // ===== Record important solver options =====
+  if(rank == 0)
+  {
+    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5",
+        H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+
+    cmdh5w->write_doubleScalar("fl_density", fluid_density);
+    cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
+    cmdh5w->write_doubleScalar("init_step", initial_step);
+    cmdh5w->write_intScalar("sol_record_freq", sol_record_freq);
+    // cmdh5w->write_string("lpn_file", lpn_file);
+    cmdh5w->write_string("inflow_file", inflow_file);
+    cmdh5w->write_string("dot_inflow_file", dot_inflow_file);
+    delete cmdh5w; H5Fclose(cmd_file_id);
+  }
+
+  MPI_Barrier(PETSC_COMM_WORLD);
+
+  // ===== Data from Files =====
+  // Control points' xyz coordinates
+  auto fNode = SYS_T::make_unique<FEANode>(part_file, rank);
+
+  // Local sub-domain's IEN array
+  auto locIEN = SYS_T::make_unique<ALocal_IEN>(part_file, rank);
+  
+  // Local sub-domain's element indices
+  auto locElem = SYS_T::make_unique<ALocal_Elem>(part_file, rank);
+
+  // Local sub-domain's nodal bc
+  auto locnbc = SYS_T::make_unique<ALocal_NBC>(part_file, rank);
+
+  // Local sub-domain's inflow bc
+  auto locinfnbc = SYS_T::make_unique<ALocal_InflowBC>(part_file, rank);
+
+  // Local sub-domain's elemental bc
+  auto locebc = SYS_T::make_unique<ALocal_EBC>(part_file, rank);
+
+  // Local sub-domain's nodal indices
+  auto pNode = SYS_T::make_unique<APart_Node>(part_file, rank);
+
+  const int nlocalnode = pNode->get_nlocalnode();
+
+  PetscInt local_row_size, local_col_size;
+  local_row_size = 4 * nlocalnode;
+  local_col_size = local_row_size;
+
+  SYS_T::commPrint("===> Data from HDF5 files are read from disk.\n");
+
+  SYS_T::print_fatal_if( size!= ANL_T::get_cpu_size(part_file, rank),
+      "Error: Assigned CPU number does not match the partition. \n");
+
+  SYS_T::commPrint("===> %d processor(s) are assigned for FEM analysis. \n", size);
+
+  // ===== Inflow flow rate =====
+  SYS_T::commPrint("===> Setup inflow flow rate. \n");
+
+  auto inflow_rate = FlowRateFactory::createFlowRate(inflow_file);
+
+  auto dot_inflow_rate = FlowRateFactory::createFlowRate(dot_inflow_file);
+
+  inflow_rate->print_info();
+
+  dot_inflow_rate->print_info();
+
+  // ===== LPN models =====
+//   auto gbc = GenBCFactory::createGenBC(lpn_file, initial_time, initial_step, 
+//       initial_index, 1000);
+
+//   gbc -> print_info();
+
+  // Make sure the gbc number of faces matches that of ALocal_EBC
+//   SYS_T::print_fatal_if(gbc->get_num_ebc() != locebc->get_num_ebc(),
+//       "Error: GenBC number of faces does not match with that in ALocal_EBC.\n");
+
+  // ===== Generate a sparse matrix for the enforcement of essential BCs
+  auto pmat = SYS_T::make_unique<Matrix_PETSc>(pNode.get(), locnbc.get());
+
+  pmat->gen_perm_bc(pNode.get(), locnbc.get());
+
+  // ===== Half Explicit Runge Kutta scheme =====
+  SYS_T::commPrint("===> Setup the Runge Kutta time scheme.\n");
+
+  std::unique_ptr<ITimeMethod_RungeKutta> tm_RK = SYS_T::make_unique<ExplicitRK_PseudoSymplecticRK3p5q4s>();
+
+  tm_RK->print_coefficients();
+ 
+    // ===== HERK Local Assembly routine =====
+  auto locAssem = SYS_T::make_unique<PLocAssem_Block_VMS_NS_HERK>(
+        ANL_T::get_elemType(part_file, rank), nqp_vol, nqp_sur, tm_RK.get(),
+        fluid_density, fluid_mu, L0, c_ct, c_tauc, cu, cp );
+
+  // ===== Initial condition =====
+  std::unique_ptr<PDNSolution> base =
+    SYS_T::make_unique<PDNSolution_NS>( pNode.get(), fNode.get(), locinfnbc.get(), 1 );    
+
+  std::unique_ptr<PDNSolution> sol =
+    SYS_T::make_unique<PDNSolution_NS>( pNode.get(), 0 );
+
+  std::unique_ptr<PDNSolution> velo =
+    SYS_T::make_unique<PDNSolution_V>( pNode.get(), 0, true, "velo" );
+
+  std::unique_ptr<PDNSolution> pres =
+    SYS_T::make_unique<PDNSolution_P>( pNode.get(), 0, true, "pres" );
+
+  std::unique_ptr<PDNSolution> dot_velo =
+    SYS_T::make_unique<PDNSolution_V>( pNode.get(), 0, true, "dot_velo" );
+
+  if( is_restart )
+  {
+    initial_index = restart_index;
+    initial_time  = restart_time;
+    initial_step  = restart_step;
+
+    // Read sol file
+    SYS_T::file_check(restart_name);
+    sol->ReadBinary(restart_name);
+
+    SYS_T::commPrint("===> Read sol from disk as a restart run... \n");
+    SYS_T::commPrint("     restart_name: %s \n", restart_name.c_str());
+    SYS_T::commPrint("     restart_time: %e \n", restart_time);
+    SYS_T::commPrint("     restart_index: %d \n", restart_index);
+    SYS_T::commPrint("     restart_step: %e \n", restart_step);
+  }
+
+  // ===== Global assembly =====
+  SYS_T::commPrint("===> Initializing Mat K and Vec G ... \n");
+  auto gloAssem = SYS_T::make_unique<PGAssem_Block_NS_FEM_HERK>( 
+      std::move(locIEN), std::move(locElem), std::move(fNode), 
+      std::move(pNode), std::move(locnbc), std::move(locebc), 
+      std::move(locAssem), nz_estimate );
+
+  SYS_T::commPrint("===> Assembly nonzero estimate matrix ... \n");
+  gloAssem->Assem_nonzero_estimate();
+
+  SYS_T::commPrint("===> Matrix nonzero structure fixed. \n");
+  gloAssem->Fix_nonzero_err_str();
+  gloAssem->Clear_subKG();
+
+  gloAssem->Assem_tangent_matrix(tm_RK.get(), initial_step);
+  
+  // ===== Initialize the shell tangent matrix =====
+  Mat K_shell;
+  
+  MatCreateShell( PETSC_COMM_WORLD, local_row_size, local_col_size,
+    PETSC_DETERMINE, PETSC_DETERMINE, (void *)gloAssem.get(), &K_shell);
+
+  MatShellSetOperation(K_shell, MATOP_MULT, (void(*)(void))MF_T::MF_MatMult);
+
+  // ===== Linear solver context =====
+  auto lsolver = SYS_T::make_unique<PLinear_Solver_PETSc>();
+
+  // ===== Linear solver context of Martrix A =====
+  auto lsolver_A = SYS_T::make_unique<PLinear_Solver_PETSc>(
+    1.0e-8, 1.0e-15, 1.0e30, 1000, "A_", "A_");
+
+  lsolver_A->SetOperator(gloAssem->subK[3]); 
+
+  // ===== Linear solver context of Schur complement matrix =====
+  auto lsolver_S = SYS_T::make_unique<PLinear_Solver_PETSc>(
+    1.0e-8, 1.0e-15, 1.0e30, 1000, "S_", "S_");
+  
+  Mat S_approx;
+  
+  MF_T::SetupApproxSchur(gloAssem.get(), S_approx);
+
+  lsolver_S->SetOperator(S_approx);
+  
+  auto solverCtx = SYS_T::make_unique<MF_T::SolverContext>(gloAssem.get(), std::move(lsolver_A), std::move(lsolver_S));
+
+  // ===== Initialize the shell preconditioner =====
+  PC pc_shell;
+
+  PCCreate(PETSC_COMM_WORLD, &pc_shell);
+  PCSetType( pc_shell, PCSHELL );
+  PCShellSetContext(pc_shell, solverCtx.get());
+  PCShellSetApply(pc_shell, MF_T::MF_PCSchurApply);
+
+  KSPSetPC( lsolver->ksp, pc_shell ); 
+  
+  lsolver->SetOperator(K_shell); 
+
+  // ===== Time step info ===== 
+  auto timeinfo = SYS_T::make_unique<PDNTimeStep>(initial_index, initial_time, 
+      initial_step);
+ 
+  // ===== Temporal solver context =====
+  auto tsolver = SYS_T::make_unique<PTime_NS_HERK_Solver>(
+      std::move(gloAssem), std::move(lsolver), std::move(pmat), std::move(tm_RK),
+      std::move(inflow_rate), std::move(dot_inflow_rate), std::move(base),
+      std::move(locinfnbc), sol_bName, nlocalnode, sol_record_freq, final_time );
+
+  tsolver->print_info();
+
+  MPI_Barrier(PETSC_COMM_WORLD);
+
+  // ===== FEM analysis =====
+  SYS_T::commPrint("===> Start Finite Element Analysis:\n");
+  tsolver->TM_NS_HERK(is_restart, std::move(sol), std::move(velo), std::move(dot_velo), 
+      std::move(pres), std::move(timeinfo));
+
+  // ===== Print complete solver info =====
+  tsolver -> print_lsolver_info();
+  solverCtx -> lsolver_A -> print_info();
+  solverCtx -> lsolver_S -> print_info();
+
+  MatDestroy(&S_approx);
+  MatDestroy(&K_shell);
+  PCDestroy(&pc_shell);
+  tsolver.reset();
+  solverCtx.reset();
+
+  PetscFinalize();
+  return EXIT_SUCCESS;
+}
+
+// EOF

--- a/examples/ns/ns_herk_driver_accurateA.cpp
+++ b/examples/ns/ns_herk_driver_accurateA.cpp
@@ -1,0 +1,355 @@
+// ==================================================================
+// ns code driver.cpp
+//
+// Finite element code for 3D Navier-Stokes equations using the 
+// Variational Multiscale Formulation and Half-explicit RK time 
+// stepping.
+//
+// Author: Yujie Sun
+// Date: Apr. 4 2025
+// ==================================================================
+#include "HDF5_Writer.hpp"
+#include "ANL_Tools.hpp"
+#include "FlowRateFactory.hpp"
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+#include "PTime_NS_HERK_Solver_AccurateA.hpp"
+#include "ExplicitRK_SSPRK3p3s.hpp"
+#include "ExplicitRK_EMRK2p2s.hpp"
+#include "ExplicitRK_HeunRK2p2s.hpp"
+#include "ExplicitRK_RalstonRK2p2s.hpp"
+#include "ExplicitRK_PseudoSymplecticRK3p5q4s.hpp"
+#include "Matrix_Free_Tools.hpp"
+#include "Matrix_Free_Tools_AccurateA.hpp"
+
+int main(int argc, char *argv[])
+{
+  // Number of quadrature points for tets and triangles
+  // Suggested values: 5 / 4 for linear, 17 / 13 for quadratic
+  // Number of quadrature points for hexs and quadrangles
+  // Suggested values: 8 / 4 for linear, 64 / 16 for quadratic
+  int nqp_vol = 5, nqp_sur = 4;
+
+  // Estimate of the nonzero per row for the sparse matrix
+  int nz_estimate = 300;
+
+  // fluid properties
+  double fluid_density = 1.065;
+  double fluid_mu = 3.5e-2;
+  double c_tauc = 1.0; // scaling factor for tau_c, take 0.0, 0.125, or 1.0
+  double c_ct = 4.0;   // C_T parameter for defining tau_M
+  
+  // Stabilization para for Darcy problem
+  double L0 = 0.1;
+  double cu = 2.0;
+  double cp = 2.0;
+
+  // inflow file & dot_inflow_file
+  std::string inflow_file("inflow_fourier_series.txt");
+  std::string dot_inflow_file("dot_inflow_fourier_series.txt");
+
+  // LPN file
+//   std::string lpn_file("lpn_rcr_input.txt");
+
+  // part file location
+  std::string part_file("part");
+
+  // time stepping parameters
+  double initial_time = 0.0; // time of the initial condition
+  double initial_step = 0.1; // time step size
+  int initial_index = 0;     // indiex of the initial condition
+  double final_time = 1.0;   // final time
+  std::string sol_bName("SOL_"); // base name of the solution file
+  int sol_record_freq = 1;   // frequency of recording the solution
+
+  // Restart options
+  bool is_restart = false;
+  int restart_index = 0;             // restart solution time index
+  double restart_time = 0.0;         // restart time
+  double restart_step = 1.0e-3;      // restart simulation time step size
+  std::string restart_name = "SOL_"; // restart solution base name
+
+  // Yaml options
+  bool is_loadYaml = true;
+  std::string yaml_file("./runscript.yml");
+
+#if PETSC_VERSION_LT(3,19,0)
+  PetscInitialize(&argc, &argv, (char *)0, PETSC_NULL);
+#else
+  PetscInitialize(&argc, &argv, (char *)0, PETSC_NULLPTR);
+#endif
+
+  const PetscMPIInt rank = SYS_T::get_MPI_rank();
+  const PetscMPIInt size = SYS_T::get_MPI_size();
+
+  SYS_T::print_perigee_art();
+
+  // ===== Yaml Arguments =====
+  SYS_T::GetOptionBool("-is_loadYaml", is_loadYaml);
+  SYS_T::GetOptionString("-yaml_file", yaml_file);
+
+  if (is_loadYaml) SYS_T::InsertFileYAML( yaml_file,  false );
+
+  // ===== Read Command Line Arguments =====
+  SYS_T::commPrint("===> Reading arguments from Command line ... \n");
+
+  SYS_T::GetOptionInt("-nqp_vol", nqp_vol);
+  SYS_T::GetOptionInt("-nqp_sur", nqp_sur);
+  SYS_T::GetOptionInt("-nz_estimate", nz_estimate);
+  SYS_T::GetOptionReal("-fl_density", fluid_density);
+  SYS_T::GetOptionReal("-fl_mu", fluid_mu);
+  SYS_T::GetOptionReal("-c_tauc", c_tauc);
+  SYS_T::GetOptionReal("-c_ct", c_ct);
+  SYS_T::GetOptionReal("-L0", L0);
+  SYS_T::GetOptionReal("-cu", cu);
+  SYS_T::GetOptionReal("-cp", cp);
+  SYS_T::GetOptionString("-inflow_file", inflow_file);
+  SYS_T::GetOptionString("-dot_inflow_file", dot_inflow_file);
+//   SYS_T::GetOptionString("-lpn_file", lpn_file);
+  SYS_T::GetOptionString("-part_file", part_file);
+  SYS_T::GetOptionReal("-init_time", initial_time);
+  SYS_T::GetOptionReal("-fina_time", final_time);
+  SYS_T::GetOptionReal("-init_step", initial_step);
+  SYS_T::GetOptionInt("-init_index", initial_index);
+  SYS_T::GetOptionInt("-sol_rec_freq", sol_record_freq);
+  SYS_T::GetOptionString("-sol_name", sol_bName);
+  SYS_T::GetOptionBool("-is_restart", is_restart);
+  SYS_T::GetOptionInt("-restart_index", restart_index);
+  SYS_T::GetOptionReal("-restart_time", restart_time);
+  SYS_T::GetOptionReal("-restart_step", restart_step);
+  SYS_T::GetOptionString("-restart_name", restart_name);
+
+  // ===== Print Command Line Arguments =====
+  SYS_T::cmdPrint("-nqp_vol:", nqp_vol);
+  SYS_T::cmdPrint("-nqp_sur:", nqp_sur);
+  SYS_T::cmdPrint("-nz_estimate:", nz_estimate);
+  SYS_T::cmdPrint("-fl_density:", fluid_density);
+  SYS_T::cmdPrint("-fl_mu:", fluid_mu);
+  SYS_T::cmdPrint("-c_tauc:", c_tauc);
+  SYS_T::cmdPrint("-c_ct:", c_ct);
+  SYS_T::cmdPrint("-L0", L0);
+  SYS_T::cmdPrint("-cu", cu);
+  SYS_T::cmdPrint("-cp", cp);
+  SYS_T::cmdPrint("-inflow_file:", inflow_file);
+  SYS_T::cmdPrint("-dot_inflow_file:", dot_inflow_file);
+//   SYS_T::cmdPrint("-lpn_file:", lpn_file);
+  SYS_T::cmdPrint("-part_file:", part_file);;
+  SYS_T::cmdPrint("-init_time:", initial_time);
+  SYS_T::cmdPrint("-init_step:", initial_step);
+  SYS_T::cmdPrint("-init_index:", initial_index);
+  SYS_T::cmdPrint("-fina_time:", final_time);
+  SYS_T::cmdPrint("-sol_rec_freq:", sol_record_freq);
+  SYS_T::cmdPrint("-sol_name:", sol_bName);
+  if(is_restart)
+  {
+    SYS_T::commPrint("-is_restart: true \n");
+    SYS_T::cmdPrint("-restart_index:", restart_index);
+    SYS_T::cmdPrint("-restart_time:", restart_time);
+    SYS_T::cmdPrint("-restart_step:", restart_step);
+    SYS_T::cmdPrint("-restart_name:", restart_name);
+  }
+  else SYS_T::commPrint("-is_restart: false \n");
+
+  // ===== Record important solver options =====
+  if(rank == 0)
+  {
+    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5",
+        H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+
+    cmdh5w->write_doubleScalar("fl_density", fluid_density);
+    cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
+    cmdh5w->write_doubleScalar("init_step", initial_step);
+    cmdh5w->write_intScalar("sol_record_freq", sol_record_freq);
+    // cmdh5w->write_string("lpn_file", lpn_file);
+    cmdh5w->write_string("inflow_file", inflow_file);
+    cmdh5w->write_string("dot_inflow_file", dot_inflow_file);
+    delete cmdh5w; H5Fclose(cmd_file_id);
+  }
+
+  MPI_Barrier(PETSC_COMM_WORLD);
+
+  // ===== Data from Files =====
+  // Control points' xyz coordinates
+  auto fNode = SYS_T::make_unique<FEANode>(part_file, rank);
+
+  // Local sub-domain's IEN array
+  auto locIEN = SYS_T::make_unique<ALocal_IEN>(part_file, rank);
+  
+  // Local sub-domain's element indices
+  auto locElem = SYS_T::make_unique<ALocal_Elem>(part_file, rank);
+
+  // Local sub-domain's nodal bc
+  auto locnbc = SYS_T::make_unique<ALocal_NBC>(part_file, rank);
+
+  // Local sub-domain's inflow bc
+  auto locinfnbc = SYS_T::make_unique<ALocal_InflowBC>(part_file, rank);
+
+  // Local sub-domain's elemental bc
+  auto locebc = SYS_T::make_unique<ALocal_EBC>(part_file, rank);
+
+  // Local sub-domain's nodal indices
+  auto pNode = SYS_T::make_unique<APart_Node>(part_file, rank);
+
+  const int nlocalnode = pNode->get_nlocalnode();
+
+  PetscInt local_row_size, local_col_size;
+  local_row_size = 4 * nlocalnode;
+  local_col_size = local_row_size;
+
+  SYS_T::commPrint("===> Data from HDF5 files are read from disk.\n");
+
+  SYS_T::print_fatal_if( size!= ANL_T::get_cpu_size(part_file, rank),
+      "Error: Assigned CPU number does not match the partition. \n");
+
+  SYS_T::commPrint("===> %d processor(s) are assigned for FEM analysis. \n", size);
+
+  // ===== Inflow flow rate =====
+  SYS_T::commPrint("===> Setup inflow flow rate. \n");
+
+  auto inflow_rate = FlowRateFactory::createFlowRate(inflow_file);
+
+  auto dot_inflow_rate = FlowRateFactory::createFlowRate(dot_inflow_file);
+
+  inflow_rate->print_info();
+
+  dot_inflow_rate->print_info();
+
+  // ===== LPN models =====
+//   auto gbc = GenBCFactory::createGenBC(lpn_file, initial_time, initial_step, 
+//       initial_index, 1000);
+
+//   gbc -> print_info();
+
+  // Make sure the gbc number of faces matches that of ALocal_EBC
+//   SYS_T::print_fatal_if(gbc->get_num_ebc() != locebc->get_num_ebc(),
+//       "Error: GenBC number of faces does not match with that in ALocal_EBC.\n");
+
+  // ===== Generate a sparse matrix for the enforcement of essential BCs
+  auto pmat = SYS_T::make_unique<Matrix_PETSc>(pNode.get(), locnbc.get());
+
+  pmat->gen_perm_bc(pNode.get(), locnbc.get());
+
+  // ===== Half Explicit Runge Kutta scheme =====
+  SYS_T::commPrint("===> Setup the Runge Kutta time scheme.\n");
+
+  std::unique_ptr<ITimeMethod_RungeKutta> tm_RK = SYS_T::make_unique<ExplicitRK_PseudoSymplecticRK3p5q4s>();
+
+  tm_RK->print_coefficients();
+ 
+    // ===== HERK Local Assembly routine =====
+  auto locAssem = SYS_T::make_unique<PLocAssem_Block_VMS_NS_HERK>(
+        ANL_T::get_elemType(part_file, rank), nqp_vol, nqp_sur, tm_RK.get(),
+        fluid_density, fluid_mu, L0, c_ct, c_tauc, cu, cp );
+
+  // ===== Initial condition =====
+  std::unique_ptr<PDNSolution> base =
+    SYS_T::make_unique<PDNSolution_NS>( pNode.get(), fNode.get(), locinfnbc.get(), 1 );    
+
+  std::unique_ptr<PDNSolution> sol =
+    SYS_T::make_unique<PDNSolution_NS>( pNode.get(), 0 );
+
+  std::unique_ptr<PDNSolution> velo =
+    SYS_T::make_unique<PDNSolution_V>( pNode.get(), 0, true, "velo" );
+
+  std::unique_ptr<PDNSolution> pres =
+    SYS_T::make_unique<PDNSolution_P>( pNode.get(), 0, true, "pres" );
+
+  std::unique_ptr<PDNSolution> dot_velo =
+    SYS_T::make_unique<PDNSolution_V>( pNode.get(), 0, true, "dot_velo" );
+
+  if( is_restart )
+  {
+    initial_index = restart_index;
+    initial_time  = restart_time;
+    initial_step  = restart_step;
+
+    // Read sol file
+    SYS_T::file_check(restart_name);
+    sol->ReadBinary(restart_name);
+
+    SYS_T::commPrint("===> Read sol from disk as a restart run... \n");
+    SYS_T::commPrint("     restart_name: %s \n", restart_name.c_str());
+    SYS_T::commPrint("     restart_time: %e \n", restart_time);
+    SYS_T::commPrint("     restart_index: %d \n", restart_index);
+    SYS_T::commPrint("     restart_step: %e \n", restart_step);
+  }
+
+  // ===== Global assembly =====
+  SYS_T::commPrint("===> Initializing Mat K and Vec G ... \n");
+  auto gloAssem = SYS_T::make_unique<PGAssem_Block_NS_FEM_HERK>( 
+      std::move(locIEN), std::move(locElem), std::move(fNode), 
+      std::move(pNode), std::move(locnbc), std::move(locebc), 
+      std::move(locAssem), nz_estimate );
+
+  SYS_T::commPrint("===> Assembly nonzero estimate matrix ... \n");
+  gloAssem->Assem_nonzero_estimate();
+
+  SYS_T::commPrint("===> Matrix nonzero structure fixed. \n");
+  gloAssem->Fix_nonzero_err_str();
+  gloAssem->Clear_subKG();
+
+  gloAssem->Assem_tangent_matrix(tm_RK.get(), initial_step);
+  
+  // ===== Initialize the shell tangent matrix =====
+  Mat K_shell;
+  
+  MatCreateShell( PETSC_COMM_WORLD, local_row_size, local_col_size,
+    PETSC_DETERMINE, PETSC_DETERMINE, (void *)gloAssem.get(), &K_shell);
+
+  MatShellSetOperation(K_shell, MATOP_MULT, (void(*)(void))MF_TA::MF_MatMult);
+
+  // ===== Linear solver context =====
+  auto lsolver = SYS_T::make_unique<PLinear_Solver_PETSc>();
+
+  // ===== Linear solver context of Martrix A =====
+  auto lsolver_A = SYS_T::make_unique<PLinear_Solver_PETSc>(
+    1.0e-8, 1.0e-15, 1.0e30, 1000, "A_", "A_");
+
+  // ===== Linear solver context of Schur complement matrix =====
+  auto lsolver_S = SYS_T::make_unique<PLinear_Solver_PETSc>(
+    1.0e-8, 1.0e-15, 1.0e30, 1000, "S_", "S_");
+  
+  auto solverCtx = SYS_T::make_unique<MF_TA::SolverContext>(std::move(gloAssem), std::move(lsolver_A), std::move(lsolver_S));
+
+  // ===== Initialize the shell preconditioner =====
+  PC pc_shell;
+
+  PCCreate(PETSC_COMM_WORLD, &pc_shell);
+  PCSetType( pc_shell, PCSHELL );
+  PCShellSetContext(pc_shell, solverCtx.get());
+  PCShellSetApply(pc_shell, MF_TA::MF_PCSchurApply);
+
+  KSPSetPC( lsolver->ksp, pc_shell );   
+  lsolver->SetOperator(K_shell); 
+
+  // ===== Time step info ===== 
+  auto timeinfo = SYS_T::make_unique<PDNTimeStep>(initial_index, initial_time, 
+      initial_step);
+ 
+  // ===== Temporal solver context =====
+  auto tsolver = SYS_T::make_unique<PTime_NS_HERK_Solver_AccurateA>(
+      std::move(solverCtx), std::move(lsolver), std::move(pmat), std::move(tm_RK),
+      std::move(inflow_rate), std::move(dot_inflow_rate), std::move(base),
+      std::move(locinfnbc), sol_bName, nlocalnode, sol_record_freq, final_time );
+
+  tsolver->print_info();
+
+  MPI_Barrier(PETSC_COMM_WORLD);
+
+  // ===== FEM analysis =====
+  SYS_T::commPrint("===> Start Finite Element Analysis:\n");
+  tsolver->TM_NS_HERK(is_restart, std::move(sol), std::move(velo), std::move(dot_velo), 
+      std::move(pres), std::move(timeinfo));
+
+  // ===== Print complete solver info =====
+  tsolver -> print_lsolver_info();
+
+  MatDestroy(&K_shell);
+  PCDestroy(&pc_shell);
+  tsolver.reset();
+
+  PetscFinalize();
+  return EXIT_SUCCESS;
+}
+
+// EOF

--- a/examples/ns/src/PDNSolution_P.cpp
+++ b/examples/ns/src/PDNSolution_P.cpp
@@ -1,0 +1,42 @@
+#include "PDNSolution_P.hpp"
+
+PDNSolution_P::PDNSolution_P( const APart_Node * const &pNode,
+    const int &type, const bool &isprint,
+    const std::string &in_name )
+: PDNSolution( pNode, 1 ), sol_name( in_name ), is_print( isprint )
+{
+  switch(type)
+  {
+    case 0:
+      Init_zero( pNode );
+      break;
+    default:
+      SYS_T::print_fatal("Error: PDNSolution_P: No such type of initial condition. \n");
+      break;
+  }
+}
+
+void PDNSolution_P::Init_zero( const APart_Node * const &pNode )
+{
+  const double val = 0.0;
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    const int pos = pNode -> get_node_loc(ii);
+    VecSetValue(solution, pos, val, INSERT_VALUES);
+  }
+  
+  Assembly_GhostUpdate();
+
+  if( is_print )
+  {
+    std::ostringstream ss;
+    ss<<"===> Initial "<<sol_name<<" solution vector: \n";
+    SYS_T::commPrint(ss.str().c_str());
+    SYS_T::commPrint("     val_x = 0.0 \n");
+    SYS_T::commPrint("     val_y = 0.0 \n");
+    SYS_T::commPrint("     val_z = 0.0 \n");
+  }
+}
+
+// EOF

--- a/examples/ns/src/PDNSolution_V.cpp
+++ b/examples/ns/src/PDNSolution_V.cpp
@@ -1,0 +1,44 @@
+#include "PDNSolution_V.hpp"
+
+PDNSolution_V::PDNSolution_V( const APart_Node * const &pNode,
+    const int &type, const bool &isprint,
+    const std::string &in_name )
+: PDNSolution( pNode, 3 ), sol_name( in_name ), is_print( isprint )
+{
+  switch(type)
+  {
+    case 0:
+      Init_zero( pNode );
+      break;
+    default:
+      SYS_T::print_fatal("Error: PDNSolution_V: No such type of initial condition. \n");
+      break;
+  }
+}
+
+void PDNSolution_V::Init_zero( const APart_Node * const &pNode )
+{
+  double value[3] = {0.0, 0.0, 0.0};
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    const int pos = pNode -> get_node_loc(ii) * 3;
+    const int location[3] = { pos, pos + 1, pos + 2 };
+
+    VecSetValues(solution, 3, location, value, INSERT_VALUES);
+  }
+
+  Assembly_GhostUpdate();
+
+  if( is_print )
+  {
+    std::ostringstream ss;
+    ss<<"===> Initial "<<sol_name<<" solution vector: \n";
+    SYS_T::commPrint(ss.str().c_str());
+    SYS_T::commPrint("     val_x = 0.0 \n");
+    SYS_T::commPrint("     val_y = 0.0 \n");
+    SYS_T::commPrint("     val_z = 0.0 \n");
+  }
+}
+
+// EOF

--- a/examples/ns/src/PGAssem_Block_NS_FEM_HERK.cpp
+++ b/examples/ns/src/PGAssem_Block_NS_FEM_HERK.cpp
@@ -1,0 +1,1131 @@
+#include "PGAssem_Block_NS_FEM_HERK.hpp"
+
+PGAssem_Block_NS_FEM_HERK::PGAssem_Block_NS_FEM_HERK(
+    std::unique_ptr<ALocal_IEN> in_locien,
+    std::unique_ptr<ALocal_Elem> in_locelem,
+    std::unique_ptr<FEANode> in_fnode,
+    std::unique_ptr<APart_Node> in_pnode,
+    std::unique_ptr<ALocal_NBC> in_nbc,
+    std::unique_ptr<ALocal_EBC> in_ebc,
+    std::unique_ptr<PLocAssem_Block_VMS_NS_HERK> in_locassem,    
+    const int &in_nz_estimate )
+: locien( std::move(in_locien) ),
+  locelem( std::move(in_locelem) ),
+  fnode( std::move(in_fnode) ),
+  pnode( std::move(in_pnode) ),
+  nbc( std::move(in_nbc) ),
+  ebc( std::move(in_ebc) ),
+  locassem(std::move(in_locassem)),
+  nLocBas( locassem->get_nLocBas() ),
+  snLocBas( locassem->get_snLocBas() ),
+  dof_sol( pnode->get_dof() ),
+  dof_mat_v( locassem->get_dof_mat_1() ),
+  dof_mat_p( locassem->get_dof_mat_0() ),
+  num_ebc( ebc->get_num_ebc() ),
+  nlgn( pnode->get_nlocghonode() )
+{
+  tangent_alpha_RK = 0.0;
+
+  SYS_T::print_fatal_if(dof_sol != locassem->get_dof(),
+      "PGAssem_Block_NS_FEM_HERK::dof_sol != locassem->get_dof(). \n");
+
+  SYS_T::print_fatal_if(dof_mat_v + dof_mat_p != nbc->get_dof_LID(),
+      "PGAssem_Block_NS_FEM_HERK::dof_mat != nbc->get_dof_LID(). \n");
+  
+  for(int ebc_id=0; ebc_id < num_ebc; ++ebc_id){
+    SYS_T::print_fatal_if(snLocBas != ebc->get_cell_nLocBas(ebc_id),
+        "Error: in PGAssem_Block_NS_FEM_HERK, snLocBas has to be uniform. \n");
+  }
+
+  const int nlocrow_v  = dof_mat_v * pnode->get_nlocalnode(); 
+  const int nlocrow_p  = dof_mat_p * pnode->get_nlocalnode();
+
+  // Allocate the block matrix K
+  // D matrix
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_p, nlocrow_p, PETSC_DETERMINE,
+      PETSC_DETERMINE, dof_mat_p*in_nz_estimate, NULL,
+      dof_mat_p*in_nz_estimate, NULL, &subK[0]);
+
+  // C matrix
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_p, nlocrow_v, PETSC_DETERMINE,
+    PETSC_DETERMINE, dof_mat_p*in_nz_estimate, NULL, 
+    dof_mat_v*in_nz_estimate, NULL, &subK[1]);
+
+  // B matrix
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_v, nlocrow_p, PETSC_DETERMINE,
+    PETSC_DETERMINE, dof_mat_v*in_nz_estimate, NULL, 
+    dof_mat_p*in_nz_estimate, NULL, &subK[2]);
+
+  // A matrix
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_v, nlocrow_v, PETSC_DETERMINE,
+      PETSC_DETERMINE, dof_mat_v*in_nz_estimate, NULL, 
+      dof_mat_v*in_nz_estimate, NULL, &subK[3]);
+
+  // A_tilde matrix
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_v, nlocrow_v, PETSC_DETERMINE,
+    PETSC_DETERMINE, dof_mat_v*in_nz_estimate, NULL, 
+    dof_mat_v*in_nz_estimate, NULL, &subK[4]);
+
+  // Allocate the sub-vectors
+  VecCreate(PETSC_COMM_WORLD, &subG[0]);
+  VecCreate(PETSC_COMM_WORLD, &subG[1]);
+
+  VecSetSizes(subG[0], nlocrow_v, PETSC_DECIDE); // Vec = [Vec_v, Vec_p];
+  VecSetSizes(subG[1], nlocrow_p, PETSC_DECIDE);
+
+  VecSetFromOptions(subG[0]);
+  VecSetFromOptions(subG[1]);
+
+  VecSet(subG[0], 0.0);
+  VecSet(subG[1], 0.0);
+  
+  VecSetOption(subG[0], VEC_IGNORE_NEGATIVE_INDICES, PETSC_TRUE);
+  VecSetOption(subG[1], VEC_IGNORE_NEGATIVE_INDICES, PETSC_TRUE);
+
+  // Setup nest vectors
+  VecCreateNest(PETSC_COMM_WORLD, 2, NULL, subG, &G);
+
+  SYS_T::commPrint("===> MAT_NEW_NONZERO_ALLOCATION_ERR = FALSE.\n");
+  Release_nonzero_err_str();
+ 
+  Assem_nonzero_estimate();
+
+  // Reallocate matrices with precise preallocation
+  std::vector<int> Kdnz, Konz;
+
+  PETSc_T::Get_dnz_onz(subK[0], Kdnz, Konz);
+  MatDestroy(&subK[0]);
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_p, nlocrow_p, PETSC_DETERMINE,
+      PETSC_DETERMINE, 0, &Kdnz[0], 0, &Konz[0], &subK[0]);
+  
+  PETSc_T::Get_dnz_onz(subK[1], Kdnz, Konz);
+  MatDestroy(&subK[1]);
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_p, nlocrow_v, PETSC_DETERMINE,
+      PETSC_DETERMINE, 0, &Kdnz[0], 0, &Konz[0], &subK[1]);
+  
+  PETSc_T::Get_dnz_onz(subK[2], Kdnz, Konz);
+  MatDestroy(&subK[2]);
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_v, nlocrow_p, PETSC_DETERMINE,
+      PETSC_DETERMINE, 0, &Kdnz[0], 0, &Konz[0], &subK[2]);
+
+  PETSc_T::Get_dnz_onz(subK[3], Kdnz, Konz);
+  MatDestroy(&subK[3]);
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_v, nlocrow_v, PETSC_DETERMINE,
+      PETSC_DETERMINE, 0, &Kdnz[0], 0, &Konz[0], &subK[3]);
+ 
+  PETSc_T::Get_dnz_onz(subK[4], Kdnz, Konz);
+  MatDestroy(&subK[4]);
+  MatCreateAIJ(PETSC_COMM_WORLD, nlocrow_v, nlocrow_v, PETSC_DETERMINE,
+      PETSC_DETERMINE, 0, &Kdnz[0], 0, &Konz[0], &subK[4]);
+
+  subK[5] = NULL;
+}
+
+PGAssem_Block_NS_FEM_HERK::~PGAssem_Block_NS_FEM_HERK()
+{
+  VecDestroy(&subG[0]); VecDestroy(&subG[1]); 
+  MatDestroy(&subK[0]); MatDestroy(&subK[1]);
+  MatDestroy(&subK[2]); MatDestroy(&subK[3]);
+  MatDestroy(&subK[4]); MatDestroy(&subK[5]);
+  VecDestroy(&G);
+}
+
+void PGAssem_Block_NS_FEM_HERK::EssBC_KG()
+{
+  // pressure dof comes from field 0, to be inserted in subK[0] and subG[1]
+  int local_dir = nbc->get_Num_LD(0);
+
+  if( local_dir > 0 )
+  {
+    for(int i=0; i<local_dir; ++i)
+    {
+      const int row = nbc->get_LDN(0, i) * dof_mat_p;
+      
+      VecSetValue(subG[1], row, 0.0, INSERT_VALUES);
+      MatSetValue(subK[0], row, row, 1.0, ADD_VALUES);
+    }
+  }
+
+  int local_sla = nbc->get_Num_LPS(0);
+  if( local_sla > 0 )
+  {
+    for(int i=0; i<local_sla; ++i)
+    {
+      const int row = nbc->get_LPSN(0, i) * dof_mat_p;
+      const int col = nbc->get_LPMN(0, i) * dof_mat_p;
+      MatSetValue(subK[0], row, col, 1.0, ADD_VALUES);
+      MatSetValue(subK[0], row, row, -1.0, ADD_VALUES);
+      VecSetValue(subG[1], row, 0.0, INSERT_VALUES);
+    }
+  }
+
+  // velocity dofs
+  for(int field=1; field<=3; ++field)
+  {
+    local_dir = nbc->get_Num_LD(field);
+
+    if( local_dir > 0 )
+    {
+      for(int ii=0; ii<local_dir; ++ii) 
+      {
+        const int row = nbc->get_LDN(field, ii) * dof_mat_v + field - 1;
+        MatSetValue(subK[3], row, row, 1.0, ADD_VALUES);
+        VecSetValue(subG[0], row, 0.0, INSERT_VALUES);        
+      }
+    }
+
+    local_sla = nbc->get_Num_LPS(field);
+
+    if( local_sla > 0 )
+    {
+      for(int ii=0; ii<local_sla; ++ii)
+      {
+        const int row = nbc->get_LPSN(field, ii) * dof_mat_v + field - 1;
+        const int col = nbc->get_LPMN(field, ii) * dof_mat_v + field - 1;
+        MatSetValue(subK[3], row, col, 1.0, ADD_VALUES);
+        MatSetValue(subK[3], row, row, -1.0, ADD_VALUES);
+        VecSetValue(subG[0], row, 0.0, INSERT_VALUES);        
+      }
+    }
+  }
+}
+
+void PGAssem_Block_NS_FEM_HERK::EssBC_K()
+{
+  // pressure dof comes from field 0, to be inserted in subK[0]
+  int local_dir = nbc->get_Num_LD(0);
+
+  if( local_dir > 0 )
+  {
+    for(int ii=0; ii<local_dir; ++ii)
+    {
+      const int row = nbc->get_LDN(0, ii) * dof_mat_p;
+      
+      MatSetValue(subK[0], row, row, 1.0, ADD_VALUES);
+    }
+  }
+
+  int local_sla = nbc->get_Num_LPS(0);
+  if( local_sla > 0 )
+  {
+    for(int ii=0; ii<local_sla; ++ii)
+    {
+      const int row = nbc->get_LPSN(0, ii) * dof_mat_p;
+      const int col = nbc->get_LPMN(0, ii) * dof_mat_p;
+      MatSetValue(subK[0], row, col, 1.0, ADD_VALUES);
+      MatSetValue(subK[0], row, row, -1.0, ADD_VALUES);
+    }
+  }
+
+  // velocity dofs
+  for(int field=1; field<=3; ++field)
+  {
+    local_dir = nbc->get_Num_LD(field);
+
+    if( local_dir > 0 )
+    {
+      for(int ii=0; ii<local_dir; ++ii)
+      {
+        const int row = nbc->get_LDN(field, ii) * dof_mat_v + field - 1;
+        MatSetValue(subK[3], row, row, 1.0, ADD_VALUES); 
+      }
+    }
+
+    local_sla = nbc->get_Num_LPS(field);
+
+    if( local_sla > 0 )
+    {
+      for(int ii=0; ii<local_sla; ++ii)
+      {
+        const int row = nbc->get_LPSN(field, ii) * dof_mat_v + field - 1;
+        const int col = nbc->get_LPMN(field, ii) * dof_mat_v + field - 1;
+        MatSetValue(subK[3], row, col, 1.0, ADD_VALUES);
+        MatSetValue(subK[3], row, row, -1.0, ADD_VALUES); 
+      }
+    }
+  }
+}
+
+void PGAssem_Block_NS_FEM_HERK::EssBC_G()
+{
+  // pres field is 0, to be inserted to subG[1]
+  int local_dir = nbc->get_Num_LD(0);
+  if( local_dir > 0 )
+  {
+    for(int ii=0; ii<local_dir; ++ii)
+    {
+      const int row = nbc->get_LDN(0, ii) * dof_mat_p;
+      VecSetValue(subG[1], row, 0.0, INSERT_VALUES);
+    }
+  }
+
+  int local_sla = nbc->get_Num_LPS(0);
+  if( local_sla > 0 )
+  {
+    for(int ii=0; ii<local_sla; ++ii)
+    {
+      const int row = nbc->get_LPSN(0, ii) * dof_mat_p;
+      VecSetValue(subG[1], row, 0.0, INSERT_VALUES);
+    }
+  }
+
+  // velo fields from 1 to 3
+  for(int field=1; field<=3; ++field)
+  {
+    local_dir = nbc->get_Num_LD(field);
+    if( local_dir > 0 )
+    {
+      for(int ii=0; ii<local_dir; ++ii)
+      {
+        const int row = nbc->get_LDN(field, ii) * dof_mat_v + field - 1;
+        VecSetValue(subG[0], row, 0.0, INSERT_VALUES);
+      }
+    }
+
+    local_sla = nbc->get_Num_LPS(field);
+    if( local_sla > 0 )
+    {
+      for(int ii=0; ii<local_sla; ++ii)
+      {
+        const int row = nbc->get_LPSN(field, ii) * dof_mat_v + field - 1;
+        VecSetValue(subG[0], row, 0.0, INSERT_VALUES);
+      }
+    }
+  }
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_nonzero_estimate()
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+  
+  locassem->Assem_Estimate();
+
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+      
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+    MatSetValues(subK[0], loc_dof_p, row_idx_p, loc_dof_p, row_idx_p, locassem->Tangent0, ADD_VALUES); 
+    MatSetValues(subK[1], loc_dof_p, row_idx_p, loc_dof_v, row_idx_v, locassem->Tangent1, ADD_VALUES);
+    MatSetValues(subK[2], loc_dof_v, row_idx_v, loc_dof_p, row_idx_p, locassem->Tangent2, ADD_VALUES);
+    MatSetValues(subK[3], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent3, ADD_VALUES);    
+    MatSetValues(subK[4], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent4, ADD_VALUES); 
+  }
+
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  EssBC_KG();
+
+  MatAssemblyBegin(subK[0], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[0], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[1], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[1], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[2], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[2], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[3], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[3], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[4], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[4], MAT_FINAL_ASSEMBLY);
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_tangent_matrix(
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+  
+  for(int ee=0; ee<nElem; ++ee)
+  {    
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+  
+    locassem->Assem_Tangent_Matrix(dt, tm_RK_ptr, ectrl_x, ectrl_y, ectrl_z);
+  
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+  
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+  
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+  
+    MatSetValues(subK[0], loc_dof_p, row_idx_p, loc_dof_p, row_idx_p, locassem->Tangent0, ADD_VALUES);
+    MatSetValues(subK[1], loc_dof_p, row_idx_p, loc_dof_v, row_idx_v, locassem->Tangent1, ADD_VALUES);
+    MatSetValues(subK[2], loc_dof_v, row_idx_v, loc_dof_p, row_idx_p, locassem->Tangent2, ADD_VALUES);
+    MatSetValues(subK[3], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent3, ADD_VALUES);
+    MatSetValues(subK[4], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent4, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+  
+  EssBC_K();
+  
+  MatAssemblyBegin(subK[0], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[0], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[1], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[1], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[2], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[2], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[3], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[3], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[4], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[4], MAT_FINAL_ASSEMBLY);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_residual_substep(
+  const int &substep_index,
+  PDNSolution ** const &cur_velo_sols,
+  PDNSolution ** const &cur_pres_sols,
+  PDNSolution ** const &pre_velo_sols,
+  PDNSolution * const &pre_velo,
+  PDNSolution ** const &pre_pres_sols,
+  PDNSolution * const &pre_velo_before,   
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &curr_time,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  std::vector<std::vector<double>> array_cur_velo_sols(substep_index+1);
+  std::vector<std::vector<double>> array_cur_pres_sols(substep_index+1);
+  std::vector<std::vector<double>> array_pre_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_pre_pres_sols(tm_RK_ptr->get_RK_step());
+
+  for(int ii = 0; ii < substep_index+1; ++ii)
+  {
+    array_cur_velo_sols[ii] = cur_velo_sols[ii] -> GetLocalArray();
+    array_cur_pres_sols[ii] = cur_pres_sols[ii] -> GetLocalArray();
+  }
+
+  for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+  {
+    array_pre_velo_sols[ii] = pre_velo_sols[ii] -> GetLocalArray();
+    array_pre_pres_sols[ii] = pre_pres_sols[ii] -> GetLocalArray();
+  }
+
+  const std::vector<double> array_pre_velo = pre_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo_before = pre_velo_before -> GetLocalArray();
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    std::vector<std::vector<double>> local_cur_velo_sols(substep_index+1);    
+    std::vector<std::vector<double>> local_cur_pres_sols(substep_index+1); 
+    std::vector<std::vector<double>> local_pre_velo_sols(tm_RK_ptr->get_RK_step()); 
+    std::vector<std::vector<double>> local_pre_pres_sols(tm_RK_ptr->get_RK_step()); 
+
+    for(int ii = 0; ii < substep_index+1; ++ii)
+    {
+      local_cur_velo_sols[ii] = GetLocal( array_cur_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_cur_pres_sols[ii] = GetLocal( array_cur_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+    {
+      local_pre_velo_sols[ii] = GetLocal( array_pre_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_pre_pres_sols[ii] = GetLocal( array_pre_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    const std::vector<double> local_pre_velo = GetLocal( array_pre_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo_before = GetLocal( array_pre_velo_before, IEN_e, nLocBas, 3 );
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+
+    locassem->Assem_Residual_Sub(curr_time, dt, substep_index, tm_RK_ptr, local_cur_velo_sols, local_cur_pres_sols,
+        local_pre_velo_sols, local_pre_pres_sols, local_pre_velo, local_pre_velo_before, ectrl_x, ectrl_y, ectrl_z);
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+
+    VecSetValues(subG[1], loc_dof_p, row_idx_p, locassem->Residual0, ADD_VALUES);
+    VecSetValues(subG[0], loc_dof_v, row_idx_v, locassem->Residual1, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  NatBC_G_HERK_Sub( curr_time, dt, substep_index, tm_RK_ptr );
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+
+  EssBC_G();
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_residual_finalstep(
+  PDNSolution ** const &cur_velo_sols,
+  PDNSolution * const &cur_velo,
+  PDNSolution ** const &cur_pres_sols,
+  PDNSolution ** const &pre_velo_sols,
+  PDNSolution * const &pre_velo,
+  PDNSolution ** const &pre_pres_sols,
+  PDNSolution * const &pre_velo_before,    
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &curr_time,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  std::vector<std::vector<double>> array_cur_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_cur_pres_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_pre_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_pre_pres_sols(tm_RK_ptr->get_RK_step());
+
+  for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+  {
+    array_cur_velo_sols[ii] = cur_velo_sols[ii] -> GetLocalArray();
+    array_cur_pres_sols[ii] = cur_pres_sols[ii] -> GetLocalArray();
+    array_pre_velo_sols[ii] = pre_velo_sols[ii] -> GetLocalArray();
+    array_pre_pres_sols[ii] = pre_pres_sols[ii] -> GetLocalArray();
+  }
+
+  const std::vector<double> array_cur_velo = cur_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo = pre_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo_before = pre_velo_before -> GetLocalArray();
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    std::vector<std::vector<double>> local_cur_velo_sols(tm_RK_ptr->get_RK_step());    
+    std::vector<std::vector<double>> local_cur_pres_sols(tm_RK_ptr->get_RK_step()); 
+    std::vector<std::vector<double>> local_pre_velo_sols(tm_RK_ptr->get_RK_step()); 
+    std::vector<std::vector<double>> local_pre_pres_sols(tm_RK_ptr->get_RK_step()); 
+
+    for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+    {
+      local_cur_velo_sols[ii] = GetLocal( array_cur_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_cur_pres_sols[ii] = GetLocal( array_cur_pres_sols[ii], IEN_e, nLocBas, 1 );
+      local_pre_velo_sols[ii] = GetLocal( array_pre_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_pre_pres_sols[ii] = GetLocal( array_pre_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    const std::vector<double> local_cur_velo = GetLocal( array_cur_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo = GetLocal( array_pre_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo_before = GetLocal( array_pre_velo_before, IEN_e, nLocBas, 3 );
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+
+    locassem->Assem_Residual_Final(curr_time, dt, tm_RK_ptr, local_cur_velo_sols, local_cur_velo,
+        local_cur_pres_sols, local_pre_velo_sols, local_pre_velo, local_pre_pres_sols, local_pre_velo_before, 
+        ectrl_x, ectrl_y, ectrl_z);
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+    
+    VecSetValues(subG[1], loc_dof_p, row_idx_p, locassem->Residual0, ADD_VALUES);
+    VecSetValues(subG[0], loc_dof_v, row_idx_v, locassem->Residual1, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  NatBC_G_HERK_Final( curr_time, dt, tm_RK_ptr );
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+
+  EssBC_G();
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_residual_presstage(
+  PDNSolution * const &cur_dot_velo,
+  PDNSolution ** const &cur_velo_sols,
+  PDNSolution * const &cur_velo,
+  PDNSolution ** const &cur_pres_sols,
+  PDNSolution * const &pre_velo,
+  PDNSolution * const &cur_pres,    
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &curr_time,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  std::vector<std::vector<double>> array_cur_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_cur_pres_sols(tm_RK_ptr->get_RK_step());
+
+  for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+  {
+    array_cur_velo_sols[ii] = cur_velo_sols[ii] -> GetLocalArray();
+    array_cur_pres_sols[ii] = cur_pres_sols[ii] -> GetLocalArray();
+  }
+
+  const std::vector<double> array_cur_dot_velo = cur_dot_velo -> GetLocalArray();
+  const std::vector<double> array_cur_velo = cur_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo = pre_velo -> GetLocalArray();
+  const std::vector<double> array_cur_pres = cur_pres -> GetLocalArray();
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    std::vector<std::vector<double>> local_cur_velo_sols(tm_RK_ptr->get_RK_step());    
+    std::vector<std::vector<double>> local_cur_pres_sols(tm_RK_ptr->get_RK_step()); 
+
+    for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+    {
+      local_cur_velo_sols[ii] = GetLocal( array_cur_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_cur_pres_sols[ii] = GetLocal( array_cur_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    const std::vector<double> local_cur_dot_velo = GetLocal( array_cur_dot_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_cur_velo = GetLocal( array_cur_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo = GetLocal( array_pre_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_cur_pres = GetLocal( array_cur_pres, IEN_e, nLocBas, 1 );
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+
+    locassem->Assem_Residual_Pressure(curr_time, dt, tm_RK_ptr, local_cur_dot_velo, 
+        local_cur_velo_sols, local_cur_velo, local_cur_pres_sols, local_pre_velo, 
+        local_cur_pres, ectrl_x, ectrl_y, ectrl_z);
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+
+    VecSetValues(subG[1], loc_dof_p, row_idx_p, locassem->Residual0, ADD_VALUES);
+    VecSetValues(subG[0], loc_dof_v, row_idx_v, locassem->Residual1, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  NatBC_G_HERK_Pressure( curr_time, dt );
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+
+  EssBC_G();
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_tangent_residual_substep(
+  const int &substep_index,
+  PDNSolution ** const &cur_velo_sols,
+  PDNSolution ** const &cur_pres_sols,
+  PDNSolution ** const &pre_velo_sols,
+  PDNSolution * const &pre_velo,
+  PDNSolution ** const &pre_pres_sols,
+  PDNSolution * const &pre_velo_before,   
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &curr_time,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  std::vector<std::vector<double>> array_cur_velo_sols(substep_index+1);
+  std::vector<std::vector<double>> array_cur_pres_sols(substep_index+1);
+  std::vector<std::vector<double>> array_pre_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_pre_pres_sols(tm_RK_ptr->get_RK_step());
+
+  for(int ii = 0; ii < substep_index+1; ++ii)
+  {
+    array_cur_velo_sols[ii] = cur_velo_sols[ii] -> GetLocalArray();
+    array_cur_pres_sols[ii] = cur_pres_sols[ii] -> GetLocalArray();
+  }
+
+  for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+  {
+    array_pre_velo_sols[ii] = pre_velo_sols[ii] -> GetLocalArray();
+    array_pre_pres_sols[ii] = pre_pres_sols[ii] -> GetLocalArray();
+  }
+
+  const std::vector<double> array_pre_velo = pre_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo_before = pre_velo_before -> GetLocalArray();
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    std::vector<std::vector<double>> local_cur_velo_sols(substep_index+1);    
+    std::vector<std::vector<double>> local_cur_pres_sols(substep_index+1); 
+    std::vector<std::vector<double>> local_pre_velo_sols(tm_RK_ptr->get_RK_step()); 
+    std::vector<std::vector<double>> local_pre_pres_sols(tm_RK_ptr->get_RK_step()); 
+
+    for(int ii = 0; ii < substep_index+1; ++ii)
+    {
+      local_cur_velo_sols[ii] = GetLocal( array_cur_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_cur_pres_sols[ii] = GetLocal( array_cur_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+    {
+      local_pre_velo_sols[ii] = GetLocal( array_pre_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_pre_pres_sols[ii] = GetLocal( array_pre_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    const std::vector<double> local_pre_velo = GetLocal( array_pre_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo_before = GetLocal( array_pre_velo_before, IEN_e, nLocBas, 3 );
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+
+    locassem->Assem_Tangent_Residual_Sub(curr_time, dt, substep_index, tm_RK_ptr, local_cur_velo_sols, local_cur_pres_sols,
+        local_pre_velo_sols, local_pre_pres_sols, local_pre_velo, local_pre_velo_before, ectrl_x, ectrl_y, ectrl_z);
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+
+    MatSetValues(subK[0], loc_dof_p, row_idx_p, loc_dof_p, row_idx_p, locassem->Tangent0, ADD_VALUES);
+    MatSetValues(subK[1], loc_dof_p, row_idx_p, loc_dof_v, row_idx_v, locassem->Tangent1, ADD_VALUES);
+    MatSetValues(subK[2], loc_dof_v, row_idx_v, loc_dof_p, row_idx_p, locassem->Tangent2, ADD_VALUES);
+    MatSetValues(subK[3], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent3, ADD_VALUES);
+    MatSetValues(subK[4], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent4, ADD_VALUES);
+
+    VecSetValues(subG[1], loc_dof_p, row_idx_p, locassem->Residual0, ADD_VALUES);
+    VecSetValues(subG[0], loc_dof_v, row_idx_v, locassem->Residual1, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  NatBC_G_HERK_Sub( curr_time, dt, substep_index, tm_RK_ptr );
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+
+  EssBC_KG();
+
+  MatAssemblyBegin(subK[0], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[0], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[1], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[1], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[2], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[2], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[3], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[3], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[4], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[4], MAT_FINAL_ASSEMBLY);
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_tangent_residual_finalstep(
+  PDNSolution ** const &cur_velo_sols,
+  PDNSolution * const &cur_velo,
+  PDNSolution ** const &cur_pres_sols,
+  PDNSolution ** const &pre_velo_sols,
+  PDNSolution * const &pre_velo,
+  PDNSolution ** const &pre_pres_sols,
+  PDNSolution * const &pre_velo_before,    
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &curr_time,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  std::vector<std::vector<double>> array_cur_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_cur_pres_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_pre_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_pre_pres_sols(tm_RK_ptr->get_RK_step());
+
+  for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+  {
+    array_cur_velo_sols[ii] = cur_velo_sols[ii] -> GetLocalArray();
+    array_cur_pres_sols[ii] = cur_pres_sols[ii] -> GetLocalArray();
+    array_pre_velo_sols[ii] = pre_velo_sols[ii] -> GetLocalArray();
+    array_pre_pres_sols[ii] = pre_pres_sols[ii] -> GetLocalArray();
+  }
+
+  const std::vector<double> array_cur_velo = cur_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo = pre_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo_before = pre_velo_before -> GetLocalArray();
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    std::vector<std::vector<double>> local_cur_velo_sols(tm_RK_ptr->get_RK_step());    
+    std::vector<std::vector<double>> local_cur_pres_sols(tm_RK_ptr->get_RK_step()); 
+    std::vector<std::vector<double>> local_pre_velo_sols(tm_RK_ptr->get_RK_step()); 
+    std::vector<std::vector<double>> local_pre_pres_sols(tm_RK_ptr->get_RK_step()); 
+
+    for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+    {
+      local_cur_velo_sols[ii] = GetLocal( array_cur_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_cur_pres_sols[ii] = GetLocal( array_cur_pres_sols[ii], IEN_e, nLocBas, 1 );
+      local_pre_velo_sols[ii] = GetLocal( array_pre_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_pre_pres_sols[ii] = GetLocal( array_pre_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    const std::vector<double> local_cur_velo = GetLocal( array_cur_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo = GetLocal( array_pre_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo_before = GetLocal( array_pre_velo_before, IEN_e, nLocBas, 3 );
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+
+    locassem->Assem_Tangent_Residual_Final(curr_time, dt, tm_RK_ptr, local_cur_velo_sols, local_cur_velo,
+        local_cur_pres_sols, local_pre_velo_sols, local_pre_velo, local_pre_pres_sols, local_pre_velo_before, 
+        ectrl_x, ectrl_y, ectrl_z);
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+    
+    MatSetValues(subK[0], loc_dof_p, row_idx_p, loc_dof_p, row_idx_p, locassem->Tangent0, ADD_VALUES);
+    MatSetValues(subK[1], loc_dof_p, row_idx_p, loc_dof_v, row_idx_v, locassem->Tangent1, ADD_VALUES);
+    MatSetValues(subK[2], loc_dof_v, row_idx_v, loc_dof_p, row_idx_p, locassem->Tangent2, ADD_VALUES);
+    MatSetValues(subK[3], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent3, ADD_VALUES);
+    MatSetValues(subK[4], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent4, ADD_VALUES);
+
+    VecSetValues(subG[1], loc_dof_p, row_idx_p, locassem->Residual0, ADD_VALUES);
+    VecSetValues(subG[0], loc_dof_v, row_idx_v, locassem->Residual1, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  NatBC_G_HERK_Final( curr_time, dt, tm_RK_ptr );
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+
+  EssBC_KG();
+
+  MatAssemblyBegin(subK[0], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[0], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[1], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[1], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[2], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[2], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[3], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[3], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[4], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[4], MAT_FINAL_ASSEMBLY);
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::Assem_tangent_residual_presstage(
+  PDNSolution * const &cur_dot_velo,
+  PDNSolution ** const &cur_velo_sols,
+  PDNSolution * const &cur_velo,
+  PDNSolution ** const &cur_pres_sols,
+  PDNSolution * const &pre_velo,
+  PDNSolution * const &cur_pres,    
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double &curr_time,
+  const double &dt )
+{
+  const int nElem = locelem->get_nlocalele();
+  const int loc_dof_v = dof_mat_v * nLocBas;
+  const int loc_dof_p = dof_mat_p * nLocBas;
+
+  std::vector<std::vector<double>> array_cur_velo_sols(tm_RK_ptr->get_RK_step());
+  std::vector<std::vector<double>> array_cur_pres_sols(tm_RK_ptr->get_RK_step());
+
+  for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+  {
+    array_cur_velo_sols[ii] = cur_velo_sols[ii] -> GetLocalArray();
+    array_cur_pres_sols[ii] = cur_pres_sols[ii] -> GetLocalArray();
+  }
+
+  const std::vector<double> array_cur_dot_velo = cur_dot_velo -> GetLocalArray();
+  const std::vector<double> array_cur_velo = cur_velo -> GetLocalArray();
+  const std::vector<double> array_pre_velo = pre_velo -> GetLocalArray();
+  const std::vector<double> array_cur_pres = cur_pres -> GetLocalArray();
+
+  double * ectrl_x = new double [nLocBas];
+  double * ectrl_y = new double [nLocBas];
+  double * ectrl_z = new double [nLocBas];
+  PetscInt * row_idx_v = new PetscInt [nLocBas * dof_mat_v];
+  PetscInt * row_idx_p = new PetscInt [nLocBas * dof_mat_p];
+
+  for(int ee=0; ee<nElem; ++ee)
+  {
+    const std::vector<int> IEN_e = locien->get_LIEN(ee);
+
+    std::vector<std::vector<double>> local_cur_velo_sols(tm_RK_ptr->get_RK_step());    
+    std::vector<std::vector<double>> local_cur_pres_sols(tm_RK_ptr->get_RK_step()); 
+
+    for(int ii = 0; ii < tm_RK_ptr->get_RK_step(); ++ii)
+    {
+      local_cur_velo_sols[ii] = GetLocal( array_cur_velo_sols[ii], IEN_e, nLocBas, 3 );
+      local_cur_pres_sols[ii] = GetLocal( array_cur_pres_sols[ii], IEN_e, nLocBas, 1 );
+    }
+
+    const std::vector<double> local_cur_dot_velo = GetLocal( array_cur_dot_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_cur_velo = GetLocal( array_cur_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_pre_velo = GetLocal( array_pre_velo, IEN_e, nLocBas, 3 );
+    const std::vector<double> local_cur_pres = GetLocal( array_cur_pres, IEN_e, nLocBas, 1 );
+
+    fnode->get_ctrlPts_xyz(nLocBas, &IEN_e[0], ectrl_x, ectrl_y, ectrl_z);
+
+    locassem->Assem_Tangent_Residual_Pressure(curr_time, dt, tm_RK_ptr, local_cur_dot_velo, 
+        local_cur_velo_sols, local_cur_velo, local_cur_pres_sols, local_pre_velo, 
+        local_cur_pres, ectrl_x, ectrl_y, ectrl_z);
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int loc_index  = locien->get_LIEN(ee, ii);
+
+      row_idx_v[3*ii]   = 3 * nbc->get_LID( 1, loc_index );
+      row_idx_v[3*ii+1] = 3 * nbc->get_LID( 2, loc_index ) + 1;
+      row_idx_v[3*ii+2] = 3 * nbc->get_LID( 3, loc_index ) + 2;
+
+      row_idx_p[ii] = nbc->get_LID( 0, loc_index );
+    }
+
+    MatSetValues(subK[0], loc_dof_p, row_idx_p, loc_dof_p, row_idx_p, locassem->Tangent0, ADD_VALUES);
+    MatSetValues(subK[1], loc_dof_p, row_idx_p, loc_dof_v, row_idx_v, locassem->Tangent1, ADD_VALUES);
+    MatSetValues(subK[2], loc_dof_v, row_idx_v, loc_dof_p, row_idx_p, locassem->Tangent2, ADD_VALUES);
+    MatSetValues(subK[3], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent3, ADD_VALUES);
+    MatSetValues(subK[4], loc_dof_v, row_idx_v, loc_dof_v, row_idx_v, locassem->Tangent4, ADD_VALUES);
+    
+    VecSetValues(subG[1], loc_dof_p, row_idx_p, locassem->Residual0, ADD_VALUES);
+    VecSetValues(subG[0], loc_dof_v, row_idx_v, locassem->Residual1, ADD_VALUES);
+  }
+
+  delete [] ectrl_x; ectrl_x = nullptr;
+  delete [] ectrl_y; ectrl_y = nullptr;
+  delete [] ectrl_z; ectrl_z = nullptr;
+  delete [] row_idx_v; row_idx_v = nullptr;
+  delete [] row_idx_p; row_idx_p = nullptr;
+
+  NatBC_G_HERK_Pressure( curr_time, dt );
+
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+
+  EssBC_KG();
+
+  MatAssemblyBegin(subK[0], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[0], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[1], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[1], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[2], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[2], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[3], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[3], MAT_FINAL_ASSEMBLY);
+  MatAssemblyBegin(subK[4], MAT_FINAL_ASSEMBLY); MatAssemblyEnd(subK[4], MAT_FINAL_ASSEMBLY);
+  VecAssemblyBegin(subG[0]); VecAssemblyEnd(subG[0]);
+  VecAssemblyBegin(subG[1]); VecAssemblyEnd(subG[1]);
+}
+
+void PGAssem_Block_NS_FEM_HERK::NatBC_G_HERK_Sub( const double &curr_time, const double &dt,
+  const int &substep_index,
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr )
+{
+  int * LSIEN = new int [snLocBas];
+  double * sctrl_x = new double [snLocBas];
+  double * sctrl_y = new double [snLocBas];
+  double * sctrl_z = new double [snLocBas];
+  PetscInt * srow_index_v = new PetscInt [snLocBas * dof_mat_v];
+
+  for(int ebc_id = 0; ebc_id < num_ebc; ++ebc_id)
+  {
+    const int num_sele = ebc -> get_num_local_cell(ebc_id);
+
+    for(int ee=0; ee<num_sele; ++ee)
+    {
+      ebc -> get_SIEN(ebc_id, ee, LSIEN);
+
+      ebc -> get_ctrlPts_xyz(ebc_id, ee, sctrl_x, sctrl_y, sctrl_z);
+
+      locassem->Assem_Residual_EBC_HERK_Sub(ebc_id, curr_time, dt, substep_index, tm_RK_ptr,
+          sctrl_x, sctrl_y, sctrl_z);
+
+      for(int ii=0; ii<snLocBas; ++ii)
+      {
+        for(int mm=0; mm<dof_mat_v; ++mm)
+          srow_index_v[dof_mat_v * ii + mm] = dof_mat_v * nbc -> get_LID(mm+1, LSIEN[ii]) + mm;
+      }
+
+      VecSetValues(subG[0], dof_mat_v*snLocBas, srow_index_v, locassem->sur_Residual1, ADD_VALUES);
+    }
+  }
+
+  delete [] LSIEN; LSIEN = nullptr;
+  delete [] sctrl_x; sctrl_x = nullptr;
+  delete [] sctrl_y; sctrl_y = nullptr;
+  delete [] sctrl_z; sctrl_z = nullptr;
+  delete [] srow_index_v; srow_index_v = nullptr;
+}
+
+void PGAssem_Block_NS_FEM_HERK::NatBC_G_HERK_Final( const double &curr_time, const double &dt,
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr )
+{
+  int * LSIEN = new int [snLocBas];
+  double * sctrl_x = new double [snLocBas];
+  double * sctrl_y = new double [snLocBas];
+  double * sctrl_z = new double [snLocBas];
+  PetscInt * srow_index_v = new PetscInt [snLocBas * dof_mat_v];
+
+  for(int ebc_id = 0; ebc_id < num_ebc; ++ebc_id)
+  {
+    const int num_sele = ebc -> get_num_local_cell(ebc_id);
+
+    for(int ee=0; ee<num_sele; ++ee)
+    {
+      ebc -> get_SIEN(ebc_id, ee, LSIEN);
+
+      ebc -> get_ctrlPts_xyz(ebc_id, ee, sctrl_x, sctrl_y, sctrl_z);
+
+      locassem->Assem_Residual_EBC_HERK_Final(ebc_id, curr_time, dt, tm_RK_ptr,
+          sctrl_x, sctrl_y, sctrl_z);
+
+      for(int ii=0; ii<snLocBas; ++ii)
+      {
+        for(int mm=0; mm<dof_mat_v; ++mm)
+          srow_index_v[dof_mat_v * ii + mm] = dof_mat_v * nbc -> get_LID(mm+1, LSIEN[ii]) + mm;
+      }
+
+      VecSetValues(subG[0], dof_mat_v*snLocBas, srow_index_v, locassem->sur_Residual1, ADD_VALUES);
+    }
+  }
+
+  delete [] LSIEN; LSIEN = nullptr;
+  delete [] sctrl_x; sctrl_x = nullptr;
+  delete [] sctrl_y; sctrl_y = nullptr;
+  delete [] sctrl_z; sctrl_z = nullptr;
+  delete [] srow_index_v; srow_index_v = nullptr;
+}
+
+void PGAssem_Block_NS_FEM_HERK::NatBC_G_HERK_Pressure( const double &curr_time, const double &dt )
+{
+  int * LSIEN = new int [snLocBas];
+  double * sctrl_x = new double [snLocBas];
+  double * sctrl_y = new double [snLocBas];
+  double * sctrl_z = new double [snLocBas];
+  PetscInt * srow_index_v = new PetscInt [snLocBas * dof_mat_v];
+
+  for(int ebc_id = 0; ebc_id < num_ebc; ++ebc_id)
+  {
+    const int num_sele = ebc -> get_num_local_cell(ebc_id);
+
+    for(int ee=0; ee<num_sele; ++ee)
+    {
+      ebc -> get_SIEN(ebc_id, ee, LSIEN);
+
+      ebc -> get_ctrlPts_xyz(ebc_id, ee, sctrl_x, sctrl_y, sctrl_z);
+
+      locassem->Assem_Residual_EBC_HERK_Pressure(ebc_id, curr_time, dt,
+          sctrl_x, sctrl_y, sctrl_z);
+
+      for(int ii=0; ii<snLocBas; ++ii)
+      {
+        for(int mm=0; mm<dof_mat_v; ++mm)
+          srow_index_v[dof_mat_v * ii + mm] = dof_mat_v * nbc -> get_LID(mm+1, LSIEN[ii]) + mm;
+      }
+
+      VecSetValues(subG[0], dof_mat_v*snLocBas, srow_index_v, locassem->sur_Residual1, ADD_VALUES);
+    }
+  }
+
+  delete [] LSIEN; LSIEN = nullptr;
+  delete [] sctrl_x; sctrl_x = nullptr;
+  delete [] sctrl_y; sctrl_y = nullptr;
+  delete [] sctrl_z; sctrl_z = nullptr;
+  delete [] srow_index_v; srow_index_v = nullptr;
+}
+
+// EOF

--- a/examples/ns/src/PLocAssem_Block_VMS_NS_HERK.cpp
+++ b/examples/ns/src/PLocAssem_Block_VMS_NS_HERK.cpp
@@ -1,0 +1,2912 @@
+#include "PLocAssem_Block_VMS_NS_HERK.hpp"
+
+PLocAssem_Block_VMS_NS_HERK::PLocAssem_Block_VMS_NS_HERK(
+    const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
+    const ITimeMethod_RungeKutta * const &tm_RK, const double &in_rho, 
+    const double &in_vis_mu, const double &in_L0,
+    const double &in_ct, const double &in_ctauc, 
+    const double &in_cu, const double &in_cp )
+: elemType(in_type), nqpv(in_nqp_v), nqps(in_nqp_s),
+  elementv( ElementFactory::createVolElement(elemType, nqpv) ),
+  elements( ElementFactory::createSurElement(elemType, nqps) ),
+  quadv( QuadPtsFactory::createVolQuadrature(elemType, nqpv) ),
+  quads( QuadPtsFactory::createSurQuadrature(elemType, nqps) ),
+  rho0( in_rho ), vis_mu( in_vis_mu ),
+  CI( (elemType == FEType::Tet4 || elemType == FEType::Hex8) ? 36.0 : 60.0 ),
+  CT( in_ct ), Ctauc( in_ctauc ), L0( in_L0 ), cu( in_cu ), cp( in_cp ),
+  nLocBas( elementv->get_nLocBas() ), snLocBas( elements->get_nLocBas() ),
+  vec_size_v( nLocBas * 3 ), vec_size_p( nLocBas ), sur_size_v ( snLocBas * 3 ),
+  coef( (elemType == FEType::Tet4 || elemType == FEType::Tet10) ? 0.6299605249474365 : 1.0 ),
+  mm( (elemType == FEType::Tet4 || elemType == FEType::Tet10) ? std::array<double, 9>{2.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 2.0} :
+                                             std::array<double, 9>{1.0, 0.0, 0.0, 0.0, 1.0 ,0.0, 0.0, 0.0 ,1.0} )
+{
+  Tangent0 = new PetscScalar[vec_size_p * vec_size_p];
+  Tangent1 = new PetscScalar[vec_size_p * vec_size_v];
+  Tangent2 = new PetscScalar[vec_size_v * vec_size_p];
+  Tangent3 = new PetscScalar[vec_size_v * vec_size_v];
+  Tangent4 = new PetscScalar[vec_size_v * vec_size_v];
+  
+  Residual0 = new PetscScalar[vec_size_p];
+  Residual1 = new PetscScalar[vec_size_v];
+
+  sur_Residual1 = new PetscScalar[sur_size_v];
+
+  Zero_Tangent_Residual();
+
+  Zero_sur_Residual();
+
+  flist = nullptr;
+  flist = new locassem_vms_ns_funs[1];
+  flist[0] = &PLocAssem_Block_VMS_NS_HERK::get_H1;
+
+  print_info();
+}
+
+PLocAssem_Block_VMS_NS_HERK::~PLocAssem_Block_VMS_NS_HERK()
+{
+  delete [] Tangent0; Tangent0 = nullptr;
+  delete [] Tangent1; Tangent1 = nullptr;
+  delete [] Tangent2; Tangent2 = nullptr;
+  delete [] Tangent3; Tangent3 = nullptr;
+  delete [] Tangent4; Tangent4 = nullptr;
+
+  delete [] Residual0; Residual0 = nullptr;
+  delete [] Residual1; Residual1 = nullptr;
+
+  delete [] sur_Residual1; sur_Residual1 = nullptr;
+  delete [] flist;
+}
+
+void PLocAssem_Block_VMS_NS_HERK::print_info() const
+{
+  SYS_T::commPrint("----------------------------------------------------------- \n");
+  SYS_T::commPrint("  Three-dimensional Incompressible Navier-Stokes equations: \n");
+  elementv->print_info();
+  SYS_T::commPrint("  Spatial: Residual-based VMS \n");
+  SYS_T::commPrint("  Temporal: Half Explicit RK Method \n");
+  SYS_T::commPrint("  Density rho = %e \n", rho0);
+  SYS_T::commPrint("  Dynamic Viscosity mu = %e \n", vis_mu);
+  SYS_T::commPrint("  Kienmatic Viscosity nu = %e \n", vis_mu / rho0);
+  SYS_T::commPrint("  Stabilization para CI = %e \n", CI);
+  SYS_T::commPrint("  Stabilization para CT = %e \n", CT);
+  SYS_T::commPrint("  Scaling factor for tau_C = %e \n", Ctauc);
+  SYS_T::commPrint("  Characteristic length L0 = %e \n", L0);
+  SYS_T::commPrint("  Stabilization para cu for Darcy problem = %e \n", cu);
+  SYS_T::commPrint("  Stabilization para cp for Darcy problem = %e \n", cp);
+  SYS_T::commPrint("  Note: \n");
+  SYS_T::commPrint("----------------------------------------------------------- \n");
+}
+
+SymmTensor2_3D PLocAssem_Block_VMS_NS_HERK::get_metric(
+    const std::array<double, 9> &f ) const
+{
+  const double fk0 = mm[0] * f[0] + (mm[1] * f[3] + mm[2] * f[6]);
+  const double fk1 = mm[4] * f[3] + (mm[3] * f[0] + mm[5] * f[6]);
+  const double fk2 = mm[8] * f[6] + (mm[6] * f[0] + mm[7] * f[3]);
+  const double fk3 = mm[0] * f[1] + (mm[1] * f[4] + mm[2] * f[7]);
+  const double fk4 = mm[4] * f[4] + (mm[3] * f[1] + mm[5] * f[7]);
+  const double fk5 = mm[8] * f[7] + (mm[6] * f[1] + mm[7] * f[4]);
+  const double fk6 = mm[0] * f[2] + (mm[1] * f[5] + mm[2] * f[8]);
+  const double fk7 = mm[4] * f[5] + (mm[3] * f[2] + mm[5] * f[8]);
+  const double fk8 = mm[8] * f[8] + (mm[6] * f[2] + mm[7] * f[5]);
+
+  return SymmTensor2_3D( coef * ( fk0 * f[0] + fk1 * f[3] + fk2 * f[6] ),
+  coef * ( fk3 * f[1] + fk4 * f[4] + fk5 * f[7] ),
+  coef * ( fk6 * f[2] + fk7 * f[5] + fk8 * f[8] ),
+  coef * ( fk3 * f[2] + fk4 * f[5] + fk5 * f[8] ),
+  coef * ( fk0 * f[2] + fk1 * f[5] + fk2 * f[8] ),
+  coef * ( fk0 * f[1] + fk1 * f[4] + fk2 * f[7] ) );
+}
+
+std::array<double, 2> PLocAssem_Block_VMS_NS_HERK::get_tau_Darcy(
+  const double &dt) const
+{
+  const double tau_m = 1.0/(cu * rho0/dt * L0);
+
+  return {tau_m, 0.0};
+}
+
+std::array<double, 2> PLocAssem_Block_VMS_NS_HERK::get_tau(
+    const double &dt, const std::array<double, 9> &dxi_dx,
+    const double &u, const double &v, const double &w ) const
+{
+  const SymmTensor2_3D G = get_metric( dxi_dx );
+
+  const Vector_3 velo_vec( u, v, w );
+
+  const double temp_nu = vis_mu / rho0;
+
+  const double denom_m = std::sqrt( CT / (dt*dt) + G.VecMatVec( velo_vec, velo_vec) + CI * temp_nu * temp_nu * G.MatContraction( G ) );
+
+  // return tau_m followed by tau_c
+  return {{1.0 / ( rho0 * denom_m ), Ctauc * rho0 * denom_m / G.tr()}};
+}
+
+std::array<double, 2> PLocAssem_Block_VMS_NS_HERK::get_tau_dot(
+    const double &dt, const std::array<double, 9> &dxi_dx,
+    const double &u, const double &v, const double &w ) const
+{
+  const SymmTensor2_3D G = get_metric( dxi_dx );
+
+  const Vector_3 velo_vec( u, v, w );
+
+  const double temp_nu = vis_mu / rho0;
+
+  const double denom_m = std::sqrt( CT + G.VecMatVec( velo_vec, velo_vec) * (dt*dt) + (dt*dt) * CI * temp_nu * temp_nu * G.MatContraction( G ) );
+
+  // return tau_m followed by tau_c
+  return {{1.0 / ( rho0 * denom_m ), Ctauc * rho0 * denom_m / G.tr()}};
+}
+
+double PLocAssem_Block_VMS_NS_HERK::get_DC(
+    const std::array<double, 9> &dxi_dx,
+    const double &u, const double &v, const double &w ) const
+{
+  // const SymmTensor2_3D G = get_metric( dxi_dx );
+  // const Vector_3 velo_vec( u, v, w );
+  // double dc_tau = G.VecMatVec( velo_vec, velo_vec );
+
+  // if(dc_tau > 1.0e-15) dc_tau = rho0 * std::pow(dc_tau, -0.5);
+  // else dc_tau = 0.0;
+
+  const double dc_tau = 0.0;
+
+  return dc_tau;
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_EBC_HERK_Sub(
+    const int &ebc_id,
+    const double &time, const double &dt,
+    const int &subindex,
+    const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+    const double * const &eleCtrlPts_x,
+    const double * const &eleCtrlPts_y,
+    const double * const &eleCtrlPts_z )
+{
+  elements->buildBasis( quads.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  Zero_sur_Residual();
+
+  for(int qua = 0; qua < nqps; ++qua)
+  {
+    const std::vector<double> R = elements->get_R(qua);
+
+    double surface_area;
+
+    const Vector_3 n_out = elements->get_2d_normal_out(qua, surface_area);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+    for(int ii=0; ii<snLocBas; ++ii)
+    {
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    double sum_h_x = 0.0, sum_h_y = 0.0, sum_h_z = 0.0;
+
+    for(int jj=0; jj<subindex; ++jj)
+    {
+      const Vector_3 traction = get_ebc_fun( ebc_id, coor, time + tm_RK_ptr->get_RK_c(jj) * dt, n_out );
+      sum_h_x += tm_RK_ptr->get_RK_a(subindex, jj) * traction.x();
+      sum_h_y += tm_RK_ptr->get_RK_a(subindex, jj) * traction.y();
+      sum_h_z += tm_RK_ptr->get_RK_a(subindex, jj) * traction.z();
+    }
+    
+    for(int A=0; A<snLocBas; ++A)
+    {
+      sur_Residual1[3*A+0] -= surface_area * quads -> get_qw(qua) * R[A] * sum_h_x;
+      sur_Residual1[3*A+1] -= surface_area * quads -> get_qw(qua) * R[A] * sum_h_y;
+      sur_Residual1[3*A+2] -= surface_area * quads -> get_qw(qua) * R[A] * sum_h_z;
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_EBC_HERK_Final(
+    const int &ebc_id,
+    const double &time, const double &dt,
+    const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+    const double * const &eleCtrlPts_x,
+    const double * const &eleCtrlPts_y,
+    const double * const &eleCtrlPts_z )
+{
+  elements->buildBasis( quads.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  Zero_sur_Residual();
+
+  for(int qua = 0; qua < nqps; ++qua)
+  {
+    const std::vector<double> R = elements->get_R(qua);
+
+    double surface_area;
+
+    const Vector_3 n_out = elements->get_2d_normal_out(qua, surface_area);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+    for(int ii=0; ii<snLocBas; ++ii)
+    {
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    double sum_h_x = 0.0, sum_h_y = 0.0, sum_h_z = 0.0;
+
+    for(int jj=0; jj<tm_RK_ptr->get_RK_step(); ++jj)
+    {
+      const Vector_3 traction = get_ebc_fun( ebc_id, coor, time + tm_RK_ptr->get_RK_c(jj) * dt, n_out );
+
+      sum_h_x += tm_RK_ptr->get_RK_b(jj) * traction.x();
+      sum_h_y += tm_RK_ptr->get_RK_b(jj) * traction.y();
+      sum_h_z += tm_RK_ptr->get_RK_b(jj) * traction.z();
+    }
+
+    for(int A=0; A<snLocBas; ++A)
+    {
+      sur_Residual1[3*A+0] -= surface_area * quads -> get_qw(qua) * R[A] * sum_h_x;
+      sur_Residual1[3*A+1] -= surface_area * quads -> get_qw(qua) * R[A] * sum_h_y;
+      sur_Residual1[3*A+2] -= surface_area * quads -> get_qw(qua) * R[A] * sum_h_z;
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_EBC_HERK_Pressure(
+    const int &ebc_id,
+    const double &time, const double &dt,
+    const double * const &eleCtrlPts_x,
+    const double * const &eleCtrlPts_y,
+    const double * const &eleCtrlPts_z )
+{
+  elements->buildBasis( quads.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  Zero_sur_Residual();
+
+  for(int qua = 0; qua < nqps; ++qua)
+  {
+    const std::vector<double> R = elements->get_R(qua);
+
+    double surface_area;
+
+    const Vector_3 n_out = elements->get_2d_normal_out(qua, surface_area);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+    for(int ii=0; ii<snLocBas; ++ii)
+    {
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    const Vector_3 traction = get_ebc_fun( ebc_id, coor, time + dt, n_out );
+
+    for(int A=0; A<snLocBas; ++A)
+    {
+      sur_Residual1[3*A+0] -= surface_area * quads -> get_qw(qua) * R[A] * traction.x();
+      sur_Residual1[3*A+1] -= surface_area * quads -> get_qw(qua) * R[A] * traction.y();
+      sur_Residual1[3*A+2] -= surface_area * quads -> get_qw(qua) * R[A] * traction.z();
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Matrix(
+  const double &dt, 
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const double * const &eleCtrlPts_x,
+  const double * const &eleCtrlPts_y,
+  const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  Zero_Tangent();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_R_gradR( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    const std::array<double, 2> tau_n = get_tau_Darcy(dt);
+    const double tau_m = tau_n[0];
+    const double tau_c = tau_n[1];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+    
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+
+      for(int B=0; B<nLocBas; ++B)
+      {
+        const double NB = R[B], NB_x = dR_dx[B], NB_y = dR_dy[B], NB_z = dR_dz[B];
+        // Continuity equation with respect to p, u, v, w
+        Tangent0[  nLocBas*A+B          ] += gwts * (NA_x * tau_m * 1.0 * NB_x + NA_y * tau_m * 1.0 * NB_y + NA_z * tau_m * 1.0 * NB_z);
+        
+        Tangent1[3*nLocBas*A+3*B+0      ] += gwts * (NA * NB_x + NA_x * tau_m * NB * rho0/dt);
+
+        Tangent1[3*nLocBas*A+3*B+1      ] += gwts * (NA * NB_y + NA_y * tau_m * NB * rho0/dt);
+        
+        Tangent1[3*nLocBas*A+3*B+2      ] += gwts * (NA * NB_z + NA_z * tau_m * NB * rho0/dt);
+
+        // Momentum-x with respect to p, u, v, w
+        Tangent2[  nLocBas*3*A+B        ] += gwts * (-NA_x * 1.0 * NB - NA * rho0/dt * tau_m * 1.0 * NB_x);
+        
+        Tangent3[3*nLocBas*3*A+3*B+0    ] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m * NB * rho0 /dt);
+        
+        Tangent4[3*nLocBas*3*A+3*B+0    ] += gwts * (NA_x * 1.0 * tau_c * NB_x);
+        
+        Tangent4[3*nLocBas*3*A+3*B+1    ] += gwts * (NA_x * 1.0 * tau_c * NB_y);
+      
+        Tangent4[3*nLocBas*3*A+3*B+2    ] += gwts * (NA_x * 1.0 * tau_c * NB_z);
+
+        // Momentum-y with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+1)+B    ] += gwts * (-NA_y * 1.0 * NB - NA * rho0/dt * tau_m * 1.0 * NB_y);
+        
+        Tangent3[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m * NB * rho0/dt);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+0] += gwts * (NA_y * 1.0 * tau_c * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA_y * 1.0 * tau_c * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+2] += gwts * (NA_y * 1.0 * tau_c * NB_z );
+
+        // Momentum-z with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+2)+B    ] += gwts * (-NA_z * 1.0 * NB - NA * rho0/dt * tau_m * 1.0 * NB_z);
+
+        Tangent3[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m * NB * rho0/dt);        
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+0] += gwts * (NA_z * 1.0 * tau_c * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+1] += gwts * (NA_z * 1.0 * tau_c * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA_z * 1.0 * tau_c * NB_z);        
+      }
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Sub(
+  const double &time, const double &dt,
+  const int &subindex,
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const std::vector<std::vector<double>>& cur_velo_sols,
+  const std::vector<std::vector<double>>& cur_pres_sols,
+  const std::vector<std::vector<double>>& pre_velo_sols,
+  const std::vector<std::vector<double>>& pre_pres_sols,
+  const std::vector<double>& pre_velo,
+  const std::vector<double>& pre_velo_before,
+  const double * const &eleCtrlPts_x,
+  const double * const &eleCtrlPts_y,
+  const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  const int num_steps = tm_RK_ptr->get_RK_step();
+
+  Zero_Residual();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  std::vector<double> d2R_dxx(nLocBas, 0.0), d2R_dyy(nLocBas, 0.0), d2R_dzz(nLocBas, 0.0);
+  std::vector<double> d2R_dxy(nLocBas, 0.0), d2R_dxz(nLocBas, 0.0), d2R_dyz(nLocBas, 0.0);
+
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    double u_n = 0.0, u_nm1 = 0.0; 
+    double v_n = 0.0, v_nm1 = 0.0;
+    double w_n = 0.0, w_nm1 = 0.0;
+    
+    // The known sub steps under the current time step
+    std::vector<double> u(subindex+1, 0); std::vector<double> v(subindex+1, 0); 
+    std::vector<double> w(subindex+1, 0); std::vector<double> p(subindex+1, 0); 
+
+    std::vector<double> u_x(subindex+1, 0); std::vector<double> v_x(subindex+1, 0); 
+    std::vector<double> w_x(subindex+1, 0); std::vector<double> p_x(subindex+1, 0); 
+
+    std::vector<double> u_y(subindex+1, 0); std::vector<double> v_y(subindex+1, 0); 
+    std::vector<double> w_y(subindex+1, 0); std::vector<double> p_y(subindex+1, 0); 
+
+    std::vector<double> u_z(subindex+1, 0); std::vector<double> v_z(subindex+1, 0); 
+    std::vector<double> w_z(subindex+1, 0); std::vector<double> p_z(subindex+1, 0); 
+
+    std::vector<double> u_xx(subindex+1, 0), v_xx(subindex+1, 0), w_xx(subindex+1, 0); 
+    std::vector<double> u_yy(subindex+1, 0), v_yy(subindex+1, 0), w_yy(subindex+1, 0); 
+    std::vector<double> u_zz(subindex+1, 0), v_zz(subindex+1, 0), w_zz(subindex+1, 0); 
+
+    std::vector<double> u_xy(subindex+1, 0), v_xy(subindex+1, 0), w_xy(subindex+1, 0); 
+    std::vector<double> u_xz(subindex+1, 0), v_xz(subindex+1, 0), w_xz(subindex+1, 0); 
+    std::vector<double> u_yz(subindex+1, 0), v_yz(subindex+1, 0), w_yz(subindex+1, 0);
+
+    // All sub steps at the previous time step
+    std::vector<double> u_pre(num_steps, 0); std::vector<double> v_pre(num_steps, 0); 
+    std::vector<double> w_pre(num_steps, 0); std::vector<double> p_pre(num_steps, 0); 
+
+    std::vector<double> u_pre_x(num_steps, 0); std::vector<double> v_pre_x(num_steps, 0); 
+    std::vector<double> w_pre_x(num_steps, 0); std::vector<double> p_pre_x(num_steps, 0); 
+
+    std::vector<double> u_pre_y(num_steps, 0); std::vector<double> v_pre_y(num_steps, 0); 
+    std::vector<double> w_pre_y(num_steps, 0); std::vector<double> p_pre_y(num_steps, 0); 
+
+    std::vector<double> u_pre_z(num_steps, 0); std::vector<double> v_pre_z(num_steps, 0); 
+    std::vector<double> w_pre_z(num_steps, 0); std::vector<double> p_pre_z(num_steps, 0); 
+
+    std::vector<double> u_pre_xx(num_steps, 0), v_pre_xx(num_steps, 0), w_pre_xx(num_steps, 0); 
+    std::vector<double> u_pre_yy(num_steps, 0), v_pre_yy(num_steps, 0), w_pre_yy(num_steps, 0); 
+    std::vector<double> u_pre_zz(num_steps, 0), v_pre_zz(num_steps, 0), w_pre_zz(num_steps, 0); 
+
+    std::vector<double> u_pre_xy(num_steps, 0), v_pre_xy(num_steps, 0), w_pre_xy(num_steps, 0); 
+    std::vector<double> u_pre_xz(num_steps, 0), v_pre_xz(num_steps, 0), w_pre_xz(num_steps, 0); 
+    std::vector<double> u_pre_yz(num_steps, 0), v_pre_yz(num_steps, 0), w_pre_yz(num_steps, 0);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_3D_R_dR_d2R( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0], 
+                              &d2R_dxx[0], &d2R_dyy[0], &d2R_dzz[0],
+                              &d2R_dxy[0], &d2R_dxz[0], &d2R_dyz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int ii3 = 3 * ii;
+
+      u_nm1 += pre_velo_before[ii3+0] * R[ii];
+      v_nm1 += pre_velo_before[ii3+1] * R[ii];
+      w_nm1 += pre_velo_before[ii3+2] * R[ii];
+
+      u_n += pre_velo[ii3+0] * R[ii];
+      v_n += pre_velo[ii3+1] * R[ii];
+      w_n += pre_velo[ii3+2] * R[ii];
+
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    for(int jj=0; jj<=subindex; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u[jj] += cur_velo_sols[jj][ii3+0] * R[ii];
+        v[jj] += cur_velo_sols[jj][ii3+1] * R[ii];
+        w[jj] += cur_velo_sols[jj][ii3+2] * R[ii];
+        p[jj] += cur_pres_sols[jj][ii]    * R[ii];
+
+        u_x[jj] += cur_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_x[jj] += cur_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_x[jj] += cur_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_x[jj] += cur_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_y[jj] += cur_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_y[jj] += cur_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_y[jj] += cur_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_y[jj] += cur_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_z[jj] += cur_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_z[jj] += cur_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_z[jj] += cur_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_z[jj] += cur_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_xx[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_yy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_zz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_xz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_xy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_yz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_xx[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_yy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_zz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_xz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_xy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_yz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_xx[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_yy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_zz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_xz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_xy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_yz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u_pre[jj] += pre_velo_sols[jj][ii3+0] * R[ii];
+        v_pre[jj] += pre_velo_sols[jj][ii3+1] * R[ii];
+        w_pre[jj] += pre_velo_sols[jj][ii3+2] * R[ii];
+        p_pre[jj] += pre_pres_sols[jj][ii]    * R[ii];
+
+        u_pre_x[jj] += pre_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_pre_x[jj] += pre_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_pre_x[jj] += pre_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_pre_x[jj] += pre_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_pre_y[jj] += pre_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_pre_y[jj] += pre_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_pre_y[jj] += pre_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_pre_y[jj] += pre_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_pre_z[jj] += pre_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_pre_z[jj] += pre_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_pre_z[jj] += pre_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_pre_z[jj] += pre_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_pre_xx[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_pre_yy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_pre_zz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_pre_xz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_pre_xy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_pre_yz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_pre_xx[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_pre_yy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_pre_zz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_pre_xz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_pre_xy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_pre_yz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_pre_xx[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_pre_yy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_pre_zz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_pre_xz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_pre_xy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_pre_yz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    const std::array<double, 2> tau_n = get_tau_Darcy(dt);
+    const double tau_m = tau_n[0];
+    const double tau_c = tau_n[1];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+
+    std::vector<double> sum_u_advec(subindex+1, 0), sum_u_diffu(subindex+1, 0);
+    std::vector<double> sum_a_fx(subindex+1, 0), sum_p_x(subindex+1, 0);
+    std::vector<double> sum_v_advec(subindex+1, 0), sum_v_diffu(subindex+1, 0);
+    std::vector<double> sum_a_fy(subindex+1, 0), sum_p_y(subindex+1, 0);
+    std::vector<double> sum_w_advec(subindex+1, 0), sum_w_diffu(subindex+1, 0);
+    std::vector<double> sum_a_fz(subindex+1, 0), sum_p_z(subindex+1, 0);
+
+    std::vector<double> u_prime(subindex+1, 0); std::vector<double> v_prime(subindex+1, 0); 
+    std::vector<double> w_prime(subindex+1, 0); std::vector<double> p_prime(subindex, 0); 
+    
+    for(int index=1; index<=subindex; ++index)
+    {
+      for(int jj=0; jj<index; ++jj)
+      {
+        sum_u_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * u_x[jj] + 
+                                               v[jj] * u_y[jj] + w[jj] * u_z[jj] );
+        sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj]
+                                         + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+
+        sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj]
+                                             + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
+        sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj]
+                                         + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+        sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj]
+                                             + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
+        sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj]
+                                         + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+      }
+
+      for(int jj=0; jj<index-1; ++jj)
+      {
+        sum_p_x[index] += tm_RK_ptr->get_RK_a(index, jj) * p_x[jj];
+        sum_p_y[index] += tm_RK_ptr->get_RK_a(index, jj) * p_y[jj];
+        sum_p_z[index] += tm_RK_ptr->get_RK_a(index, jj) * p_z[jj];
+      }
+
+      u_prime[index] = -1.0 * tau_m * ( rho0 * (u[index] - u_n)/dt
+                       + tm_RK_ptr->get_RK_a(index, index-1) * p_x[index-1]
+                       + rho0 * sum_u_advec[index] - vis_mu * sum_u_diffu[index]
+                       + sum_p_x[index] - rho0 * sum_a_fx[index] );
+      v_prime[index] = -1.0 * tau_m * ( rho0 * (v[index] - v_n)/dt
+                       + tm_RK_ptr->get_RK_a(index, index-1) * p_y[index-1]
+                       + rho0 * sum_v_advec[index] - vis_mu * sum_v_diffu[index]
+                       + sum_p_y[index] - rho0 * sum_a_fy[index] );
+      w_prime[index] = -1.0 * tau_m * ( rho0 * (w[index] - w_n)/dt
+                       + tm_RK_ptr->get_RK_a(index, index-1) * p_z[index-1]
+                       + rho0 * sum_w_advec[index] - vis_mu * sum_w_diffu[index]
+                       + sum_p_z[index] - rho0 * sum_a_fz[index] );
+      p_prime[index-1]= -1.0 * tau_c * (u_x[index] + v_y[index] + w_z[index]);
+    }
+
+    double sum_u_pre_advec = 0.0, sum_u_pre_diffu = 0.0, sum_a_fx_pre = 0.0, sum_p_pre_x = 0;
+    double sum_v_pre_advec = 0.0, sum_v_pre_diffu = 0.0, sum_a_fy_pre = 0.0, sum_p_pre_y = 0;
+    double sum_w_pre_advec = 0.0, sum_w_pre_diffu = 0.0, sum_a_fz_pre = 0.0, sum_p_pre_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * u_pre_x[jj]
+                                                   + v_pre[jj] * u_pre_y[jj]
+                                                   + w_pre[jj] * u_pre_z[jj] );
+      sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj]
+                                                   + w_pre_xz[jj] + u_pre_xx[jj]
+                                                   + u_pre_yy[jj] + u_pre_zz[jj] );
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+
+      sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj]
+                                                   + v_pre[jj] * v_pre_y[jj]
+                                                   + w_pre[jj] * v_pre_z[jj] );
+      sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj]
+                                                   + w_pre_yz[jj] + v_pre_xx[jj]
+                                                   + v_pre_yy[jj] + v_pre_zz[jj] );
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj]
+                                                   + v_pre[jj] * w_pre_y[jj]
+                                                   + w_pre[jj] * w_pre_z[jj] );
+      sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj]
+                                                   + w_pre_zz[jj] + w_pre_xx[jj]
+                                                   + w_pre_yy[jj] + w_pre_zz[jj] );
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_p_pre_x += tm_RK_ptr->get_RK_b(jj) * p_pre_x[jj];
+      sum_p_pre_y += tm_RK_ptr->get_RK_b(jj) * p_pre_y[jj];
+      sum_p_pre_z += tm_RK_ptr->get_RK_b(jj) * p_pre_z[jj] ;
+    }
+
+    // velo_n_prime represents the fine-scale velocity solution at the n-th step and can be omitted
+    const double u_n_prime = 0.0;
+    const double v_n_prime = 0.0;
+    const double w_n_prime = 0.0;
+
+    const double div_vel= u_x[subindex] + v_y[subindex] + w_z[subindex];
+
+    double u_diffu1_1 = 0.0, u_diffu1_2 = 0.0, u_diffu1_3 = 0.0;
+    double v_diffu1_1 = 0.0, v_diffu1_2 = 0.0, v_diffu1_3 = 0.0;
+    double w_diffu1_1 = 0.0, w_diffu1_2 = 0.0, w_diffu1_3 = 0.0; 
+    double u_diffu2_1 = 0.0, v_diffu2_2 = 0.0, w_diffu2_3 = 0.0;
+
+    double u_stab1_1 = 0.0, u_stab1_2 = 0.0, u_stab1_3 = 0.0;
+    double u_stab2_1 = 0.0, u_stab2_2 = 0.0, u_stab2_3 = 0.0;
+    double v_stab1_1 = 0.0, v_stab1_2 = 0.0, v_stab1_3 = 0.0;
+    double v_stab2_1 = 0.0, v_stab2_2 = 0.0, v_stab2_3 = 0.0;
+    double w_stab1_1 = 0.0, w_stab1_2 = 0.0, w_stab1_3 = 0.0;
+    double w_stab2_1 = 0.0, w_stab2_2 = 0.0, w_stab2_3 = 0.0;
+  
+    double grad_p = 0.0, grad_p_stab = 0.0;
+
+    for(int jj=0; jj<subindex; ++jj)
+    {
+      // Diffusion item 1
+      u_diffu1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_x[jj] + u_x[jj]);
+      u_diffu1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_y[jj] + v_x[jj]);
+      u_diffu1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_z[jj] + w_x[jj]);
+
+      v_diffu1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_y[jj] + v_x[jj]);
+      v_diffu1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v_y[jj] + v_y[jj]);
+      v_diffu1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w_y[jj] + v_z[jj]);
+
+      w_diffu1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_z[jj] + w_x[jj]);
+      w_diffu1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v_z[jj] + w_y[jj]);
+      w_diffu1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w_z[jj] + w_z[jj]);
+
+      // Diffusion item 2
+      u_diffu2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj];
+      v_diffu2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj];
+      w_diffu2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj];
+
+      // Cross stress term 1 + Convective term
+      u_stab1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u[jj] + u_prime[jj]) * u_x[jj];
+      u_stab1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v[jj] + v_prime[jj]) * u_y[jj];
+      u_stab1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w[jj] + w_prime[jj]) * u_z[jj];
+
+      v_stab1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u[jj] + u_prime[jj]) * v_x[jj];
+      v_stab1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v[jj] + v_prime[jj]) * v_y[jj];
+      v_stab1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w[jj] + w_prime[jj]) * v_z[jj];
+
+      w_stab1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u[jj] + u_prime[jj]) * w_x[jj];
+      w_stab1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v[jj] + v_prime[jj]) * w_y[jj];
+      w_stab1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w[jj] + w_prime[jj]) * w_z[jj];
+
+      // Cross stress term 2 + Reynolds stress
+      u_stab2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj] * (u[jj] + u_prime[jj]);
+      u_stab2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj] * (u[jj] + u_prime[jj]);
+      u_stab2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj] * (u[jj] + u_prime[jj]);
+
+      v_stab2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj] * (v[jj] + v_prime[jj]);
+      v_stab2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj] * (v[jj] + v_prime[jj]);
+      v_stab2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj] * (v[jj] + v_prime[jj]);
+
+      w_stab2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj] * (w[jj] + w_prime[jj]);
+      w_stab2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj] * (w[jj] + w_prime[jj]);
+      w_stab2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj] * (w[jj] + w_prime[jj]);
+    }
+
+    for(int jj=0; jj<subindex-1; ++jj)
+    {
+      grad_p += tm_RK_ptr->get_RK_a(subindex, jj) * p[jj];
+      grad_p_stab += tm_RK_ptr->get_RK_a(subindex, jj) * p_prime[jj];
+    }
+
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+      const double NA_xx = d2R_dxx[A], NA_yy = d2R_dyy[A], NA_zz = d2R_dzz[A];
+      const double NA_xy = d2R_dxy[A], NA_xz = d2R_dxz[A], NA_yz = d2R_dyz[A];
+    
+      Residual0[ A     ] += gwts * ( NA * div_vel - NA_x * u_prime[subindex]
+                                   - NA_y * v_prime[subindex] - NA_z * w_prime[subindex] );
+
+      Residual1[3*A + 0] += gwts * ( NA * rho0/dt * u[subindex] - NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p[subindex-1]
+                                   + NA * rho0/dt * u_prime[subindex] - NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p_prime[subindex-1]
+                                   - NA * rho0 * sum_a_fx[subindex] - NA * rho0/dt * u_n - NA * rho0/dt * u_n_prime
+                                   + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu * u_diffu1_3
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
+                                   - NA_x * grad_p - NA_x * grad_p_stab
+                                   + NA * rho0 * u_stab1_1 + NA * rho0 * u_stab1_2 + NA * rho0 * u_stab1_3 
+                                   - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
+
+      Residual1[3*A + 1] += gwts * ( NA * rho0/dt * v[subindex] - NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p[subindex-1]
+                                   + NA * rho0/dt * v_prime[subindex] - NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p_prime[subindex-1]
+                                   - NA * rho0 * sum_a_fy[subindex] - NA * rho0/dt * v_n - NA * rho0/dt * v_n_prime
+                                   + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
+                                   - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
+                                   - NA_y * grad_p - NA_y * grad_p_stab
+                                   + NA * rho0 * v_stab1_1 + NA * rho0 * v_stab1_2 + NA * rho0 * v_stab1_3
+                                   - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
+      
+      Residual1[3*A + 2] += gwts * ( NA * rho0/dt * w[subindex] - NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p[subindex-1]
+                                   + NA * rho0/dt * w_prime[subindex] - NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p_prime[subindex-1]
+                                   - NA * rho0 * sum_a_fz[subindex] - NA * rho0/dt * w_n - NA * rho0/dt * w_n_prime
+                                   + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
+                                   - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_z * grad_p - NA_z * grad_p_stab
+                                   + NA * rho0 * w_stab1_1 + NA * rho0 * w_stab1_2 + NA * rho0 * w_stab1_3
+                                   - NA_x * rho0 * w_stab2_1 - NA_y * rho0 * w_stab2_2 - NA_z * rho0 * w_stab2_3 );      
+    }
+  } 
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Final(
+  const double &time, const double &dt,
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const std::vector<std::vector<double>>& cur_velo_sols,
+  const std::vector<double>& cur_velo,
+  const std::vector<std::vector<double>>& cur_pres_sols,
+  const std::vector<std::vector<double>>& pre_velo_sols,
+  const std::vector<double>& pre_velo,
+  const std::vector<std::vector<double>>& pre_pres_sols,
+  const std::vector<double>& pre_velo_before,
+  const double * const &eleCtrlPts_x,
+  const double * const &eleCtrlPts_y,
+  const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  const int num_steps = tm_RK_ptr->get_RK_step();
+
+  Zero_Residual();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  std::vector<double> d2R_dxx(nLocBas, 0.0), d2R_dyy(nLocBas, 0.0), d2R_dzz(nLocBas, 0.0);
+  std::vector<double> d2R_dxy(nLocBas, 0.0), d2R_dxz(nLocBas, 0.0), d2R_dyz(nLocBas, 0.0);
+
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    double u_n = 0.0, u_nm1 = 0.0, u_np1 = 0.0, u_np1_x = 0.0, u_np1_y = 0.0, u_np1_z = 0.0;
+    double v_n = 0.0, v_nm1 = 0.0, v_np1 = 0.0, v_np1_x = 0.0, v_np1_y = 0.0, v_np1_z = 0.0;
+    double w_n = 0.0, w_nm1 = 0.0, w_np1 = 0.0, w_np1_x = 0.0, w_np1_y = 0.0, w_np1_z = 0.0;
+
+    // All sub steps at the current time step
+    std::vector<double> u(num_steps, 0); std::vector<double> v(num_steps, 0); 
+    std::vector<double> w(num_steps, 0); std::vector<double> p(num_steps, 0); 
+
+    std::vector<double> u_x(num_steps, 0); std::vector<double> v_x(num_steps, 0); 
+    std::vector<double> w_x(num_steps, 0); std::vector<double> p_x(num_steps, 0); 
+
+    std::vector<double> u_y(num_steps, 0); std::vector<double> v_y(num_steps, 0); 
+    std::vector<double> w_y(num_steps, 0); std::vector<double> p_y(num_steps, 0); 
+
+    std::vector<double> u_z(num_steps, 0); std::vector<double> v_z(num_steps, 0); 
+    std::vector<double> w_z(num_steps, 0); std::vector<double> p_z(num_steps, 0); 
+
+    std::vector<double> u_xx(num_steps, 0), v_xx(num_steps, 0), w_xx(num_steps, 0); 
+    std::vector<double> u_yy(num_steps, 0), v_yy(num_steps, 0), w_yy(num_steps, 0); 
+    std::vector<double> u_zz(num_steps, 0), v_zz(num_steps, 0), w_zz(num_steps, 0); 
+
+    std::vector<double> u_xy(num_steps, 0), v_xy(num_steps, 0), w_xy(num_steps, 0); 
+    std::vector<double> u_xz(num_steps, 0), v_xz(num_steps, 0), w_xz(num_steps, 0); 
+    std::vector<double> u_yz(num_steps, 0), v_yz(num_steps, 0), w_yz(num_steps, 0);
+
+    // All sub steps at the previous time step
+    std::vector<double> u_pre(num_steps, 0); std::vector<double> v_pre(num_steps, 0); 
+    std::vector<double> w_pre(num_steps, 0); std::vector<double> p_pre(num_steps, 0); 
+
+    std::vector<double> u_pre_x(num_steps, 0); std::vector<double> v_pre_x(num_steps, 0); 
+    std::vector<double> w_pre_x(num_steps, 0); std::vector<double> p_pre_x(num_steps, 0); 
+
+    std::vector<double> u_pre_y(num_steps, 0); std::vector<double> v_pre_y(num_steps, 0); 
+    std::vector<double> w_pre_y(num_steps, 0); std::vector<double> p_pre_y(num_steps, 0); 
+
+    std::vector<double> u_pre_z(num_steps, 0); std::vector<double> v_pre_z(num_steps, 0); 
+    std::vector<double> w_pre_z(num_steps, 0); std::vector<double> p_pre_z(num_steps, 0); 
+
+    std::vector<double> u_pre_xx(num_steps, 0), v_pre_xx(num_steps, 0), w_pre_xx(num_steps, 0); 
+    std::vector<double> u_pre_yy(num_steps, 0), v_pre_yy(num_steps, 0), w_pre_yy(num_steps, 0); 
+    std::vector<double> u_pre_zz(num_steps, 0), v_pre_zz(num_steps, 0), w_pre_zz(num_steps, 0); 
+
+    std::vector<double> u_pre_xy(num_steps, 0), v_pre_xy(num_steps, 0), w_pre_xy(num_steps, 0); 
+    std::vector<double> u_pre_xz(num_steps, 0), v_pre_xz(num_steps, 0), w_pre_xz(num_steps, 0); 
+    std::vector<double> u_pre_yz(num_steps, 0), v_pre_yz(num_steps, 0), w_pre_yz(num_steps, 0);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_3D_R_dR_d2R( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0], 
+                              &d2R_dxx[0], &d2R_dyy[0], &d2R_dzz[0],
+                              &d2R_dxy[0], &d2R_dxz[0], &d2R_dyz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int ii3 = 3 * ii;
+
+      u_nm1 += pre_velo_before[ii3+0] * R[ii];
+      v_nm1 += pre_velo_before[ii3+1] * R[ii];
+      w_nm1 += pre_velo_before[ii3+2] * R[ii];
+
+      u_n += pre_velo[ii3+0] * R[ii];
+      v_n += pre_velo[ii3+1] * R[ii];
+      w_n += pre_velo[ii3+2] * R[ii];
+
+      u_np1 += cur_velo[ii3+0] * R[ii];
+      v_np1 += cur_velo[ii3+1] * R[ii];
+      w_np1 += cur_velo[ii3+2] * R[ii];
+
+      u_np1_x += cur_velo[ii3+0] * dR_dx[ii];
+      u_np1_y += cur_velo[ii3+0] * dR_dy[ii];
+      u_np1_z += cur_velo[ii3+0] * dR_dz[ii];
+
+      v_np1_x += cur_velo[ii3+1] * dR_dx[ii];
+      v_np1_y += cur_velo[ii3+1] * dR_dy[ii];
+      v_np1_z += cur_velo[ii3+1] * dR_dz[ii];
+      
+      w_np1_x += cur_velo[ii3+2] * dR_dx[ii];     
+      w_np1_y += cur_velo[ii3+2] * dR_dy[ii];
+      w_np1_z += cur_velo[ii3+2] * dR_dz[ii];
+
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u[jj] += cur_velo_sols[jj][ii3+0] * R[ii];
+        v[jj] += cur_velo_sols[jj][ii3+1] * R[ii];
+        w[jj] += cur_velo_sols[jj][ii3+2] * R[ii];
+        p[jj] += cur_pres_sols[jj][ii]    * R[ii];
+
+        u_x[jj] += cur_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_x[jj] += cur_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_x[jj] += cur_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_x[jj] += cur_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_y[jj] += cur_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_y[jj] += cur_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_y[jj] += cur_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_y[jj] += cur_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_z[jj] += cur_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_z[jj] += cur_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_z[jj] += cur_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_z[jj] += cur_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_xx[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_yy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_zz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_xz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_xy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_yz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_xx[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_yy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_zz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_xz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_xy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_yz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_xx[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_yy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_zz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_xz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_xy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_yz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+
+        u_pre[jj] += pre_velo_sols[jj][ii3+0] * R[ii];
+        v_pre[jj] += pre_velo_sols[jj][ii3+1] * R[ii];
+        w_pre[jj] += pre_velo_sols[jj][ii3+2] * R[ii];
+        p_pre[jj] += pre_pres_sols[jj][ii]    * R[ii];
+
+        u_pre_x[jj] += pre_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_pre_x[jj] += pre_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_pre_x[jj] += pre_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_pre_x[jj] += pre_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_pre_y[jj] += pre_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_pre_y[jj] += pre_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_pre_y[jj] += pre_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_pre_y[jj] += pre_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_pre_z[jj] += pre_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_pre_z[jj] += pre_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_pre_z[jj] += pre_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_pre_z[jj] += pre_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_pre_xx[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_pre_yy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_pre_zz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_pre_xz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_pre_xy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_pre_yz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_pre_xx[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_pre_yy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_pre_zz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_pre_xz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_pre_xy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_pre_yz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_pre_xx[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_pre_yy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_pre_zz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_pre_xz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_pre_xy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_pre_yz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    const std::array<double, 2> tau_n = get_tau_Darcy(dt);
+    const double tau_m = tau_n[0];
+    const double tau_c = tau_n[1];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+
+    std::vector<double> sum_u_advec(num_steps, 0), sum_u_diffu(num_steps, 0); 
+    std::vector<double> sum_a_fx(num_steps, 0), sum_p_x(num_steps, 0);
+    std::vector<double> sum_v_advec(num_steps, 0), sum_v_diffu(num_steps, 0);
+    std::vector<double> sum_a_fy(num_steps, 0), sum_p_y(num_steps, 0);
+    std::vector<double> sum_w_advec(num_steps, 0), sum_w_diffu(num_steps, 0);
+    std::vector<double> sum_a_fz(num_steps, 0), sum_p_z(num_steps, 0);
+
+    std::vector<double> u_prime(num_steps, 0); std::vector<double> v_prime(num_steps, 0);
+    std::vector<double> w_prime(num_steps, 0); std::vector<double> p_prime(num_steps, 0);
+
+    for(int index=1; index<num_steps; ++index)
+    {
+      for(int jj=0; jj<index; ++jj)
+      {
+        sum_u_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * u_x[jj]
+                                             + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
+        sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj]
+                                         + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+
+        sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj]
+                                             + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
+        sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj]
+                                         + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+        sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj]
+                                             + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
+        sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj]
+                                         + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+      }
+
+      for(int jj=0; jj<index-1; ++jj)
+      {
+        sum_p_x[index] += tm_RK_ptr->get_RK_a(index, jj) * p_x[jj];
+        sum_p_y[index] += tm_RK_ptr->get_RK_a(index, jj) * p_y[jj];
+        sum_p_z[index] += tm_RK_ptr->get_RK_a(index, jj) * p_z[jj];
+      }
+
+      u_prime[index] = -1.0 * tau_m * ( rho0 * (u[index] - u_n)/dt
+                      + tm_RK_ptr->get_RK_a(index, index-1) * p_x[index-1]
+                      + rho0 * sum_u_advec[index] - vis_mu * sum_u_diffu[index]
+                      + sum_p_x[index] - rho0 * sum_a_fx[index] );
+      v_prime[index] = -1.0 * tau_m * ( rho0 * (v[index] - v_n)/dt
+                      + tm_RK_ptr->get_RK_a(index, index-1) * p_y[index-1]
+                      + rho0 * sum_v_advec[index] - vis_mu * sum_v_diffu[index]
+                      + sum_p_y[index] - rho0 * sum_a_fy[index] );
+      w_prime[index] = -1.0 * tau_m * ( rho0 * (w[index] - w_n)/dt
+                      + tm_RK_ptr->get_RK_a(index, index-1) * p_z[index-1]
+                      + rho0 * sum_w_advec[index] - vis_mu * sum_w_diffu[index]
+                      + sum_p_z[index] - rho0 * sum_a_fz[index] );
+      p_prime[index-1] = -1.0 * tau_c * (u_x[index] + v_y[index] + w_z[index]);
+    }
+    
+    p_prime[num_steps-1] = -1.0 * tau_c * (u_np1_x + v_np1_y + w_np1_z);
+
+    double sum_u_pre_advec = 0.0, sum_u_pre_diffu = 0.0, sum_a_fx_pre = 0.0, sum_p_pre_x = 0;
+    double sum_v_pre_advec = 0.0, sum_v_pre_diffu = 0.0, sum_a_fy_pre = 0.0, sum_p_pre_y = 0;
+    double sum_w_pre_advec = 0.0, sum_w_pre_diffu = 0.0, sum_a_fz_pre = 0.0, sum_p_pre_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * u_pre_x[jj]
+                                                   + v_pre[jj] * u_pre_y[jj]
+                                                   + w_pre[jj] * u_pre_z[jj] );
+      sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj]
+                                                   + w_pre_xz[jj] + u_pre_xx[jj]
+                                                   + u_pre_yy[jj] + u_pre_zz[jj] );
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+
+      sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj]
+                                                   + v_pre[jj] * v_pre_y[jj]
+                                                   + w_pre[jj] * v_pre_z[jj] );
+      sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj]
+                                                   + w_pre_yz[jj] + v_pre_xx[jj]
+                                                   + v_pre_yy[jj] + v_pre_zz[jj] );
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj]
+                                                   + v_pre[jj] * w_pre_y[jj]
+                                                   + w_pre[jj] * w_pre_z[jj] );
+      sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj]
+                                                   + w_pre_zz[jj] + w_pre_xx[jj]
+                                                   + w_pre_yy[jj] + w_pre_zz[jj] );
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_p_pre_x += tm_RK_ptr->get_RK_b(jj) * p_pre_x[jj];
+      sum_p_pre_y += tm_RK_ptr->get_RK_b(jj) * p_pre_y[jj];
+      sum_p_pre_z += tm_RK_ptr->get_RK_b(jj) * p_pre_z[jj] ;
+    }
+
+    // velo_n_prime represents the fine-scale velocity solution at the n-th step and can be omitted
+    const double u_n_prime = 0.0;
+    const double v_n_prime = 0.0;
+    const double w_n_prime = 0.0;
+
+    double sum_u_cur_advec = 0.0, sum_u_cur_diffu = 0.0, sum_a_fx_cur = 0.0, sum_last_p_x = 0;
+    double sum_v_cur_advec = 0.0, sum_v_cur_diffu = 0.0, sum_a_fy_cur = 0.0, sum_last_p_y = 0;
+    double sum_w_cur_advec = 0.0, sum_w_cur_diffu = 0.0, sum_a_fz_cur = 0.0, sum_last_p_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj]
+                                                   + w[jj] * u_z[jj] );
+      sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj]
+                                                   + u_yy[jj] + u_zz[jj] );
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+
+      sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj]
+                                                   + w[jj] * v_z[jj] );
+      sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj]
+                                                   + v_yy[jj] + v_zz[jj] );
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj]
+                                                   + w[jj] * w_z[jj] );
+      sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj]
+                                                   + w_yy[jj] + w_zz[jj] );
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_last_p_x += tm_RK_ptr->get_RK_b(jj) * p_x[jj];
+      sum_last_p_y += tm_RK_ptr->get_RK_b(jj) * p_y[jj];
+      sum_last_p_z += tm_RK_ptr->get_RK_b(jj) * p_z[jj];
+    }
+
+    const double u_np1_prime = -1.0 * tau_m * ( rho0 * (u_np1 - u_n)/dt
+                              + tm_RK_ptr->get_RK_b(num_steps-1) * p_x[num_steps-1]
+                              + rho0 * sum_u_cur_advec - vis_mu * sum_u_cur_diffu
+                              + sum_last_p_x - rho0 * sum_a_fx_cur ); 
+    const double v_np1_prime = -1.0 * tau_m * ( rho0 * (v_np1 - v_n)/dt
+                              + tm_RK_ptr->get_RK_b(num_steps-1) * p_y[num_steps-1]
+                              + rho0 * sum_v_cur_advec - vis_mu * sum_v_cur_diffu
+                              + sum_last_p_y - rho0 * sum_a_fy_cur );
+    const double w_np1_prime = -1.0 * tau_m * ( rho0 * (w_np1 - w_n)/dt
+                              + tm_RK_ptr->get_RK_b(num_steps-1) * p_z[num_steps-1]
+                              + rho0 * sum_w_cur_advec - vis_mu * sum_w_cur_diffu
+                              + sum_last_p_z - rho0 * sum_a_fz_cur );
+
+    const double div_vel_np1 = u_np1_x + v_np1_y + w_np1_z;
+    
+    double u_diffu1_1 = 0.0, u_diffu1_2 = 0.0, u_diffu1_3 = 0.0;
+    double v_diffu1_1 = 0.0, v_diffu1_2 = 0.0, v_diffu1_3 = 0.0;
+    double w_diffu1_1 = 0.0, w_diffu1_2 = 0.0, w_diffu1_3 = 0.0; 
+    double u_diffu2_1 = 0.0, v_diffu2_2 = 0.0, w_diffu2_3 = 0.0;
+
+    double u_stab1_1 = 0.0, u_stab1_2 = 0.0, u_stab1_3 = 0.0;
+    double u_stab2_1 = 0.0, u_stab2_2 = 0.0, u_stab2_3 = 0.0;
+    double v_stab1_1 = 0.0, v_stab1_2 = 0.0, v_stab1_3 = 0.0;
+    double v_stab2_1 = 0.0, v_stab2_2 = 0.0, v_stab2_3 = 0.0;
+    double w_stab1_1 = 0.0, w_stab1_2 = 0.0, w_stab1_3 = 0.0;
+    double w_stab2_1 = 0.0, w_stab2_2 = 0.0, w_stab2_3 = 0.0;
+  
+    double grad_p = 0.0, grad_p_stab = 0.0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      // Diffusion item 1
+      u_diffu1_1 += tm_RK_ptr->get_RK_b(jj) * (u_x[jj] + u_x[jj]);
+      u_diffu1_2 += tm_RK_ptr->get_RK_b(jj) * (u_y[jj] + v_x[jj]);
+      u_diffu1_3 += tm_RK_ptr->get_RK_b(jj) * (u_z[jj] + w_x[jj]);
+
+      v_diffu1_1 += tm_RK_ptr->get_RK_b(jj) * (u_y[jj] + v_x[jj]);
+      v_diffu1_2 += tm_RK_ptr->get_RK_b(jj) * (v_y[jj] + v_y[jj]);
+      v_diffu1_3 += tm_RK_ptr->get_RK_b(jj) * (w_y[jj] + v_z[jj]);
+
+      w_diffu1_1 += tm_RK_ptr->get_RK_b(jj) * (u_z[jj] + w_x[jj]);
+      w_diffu1_2 += tm_RK_ptr->get_RK_b(jj) * (v_z[jj] + w_y[jj]);
+      w_diffu1_3 += tm_RK_ptr->get_RK_b(jj) * (w_z[jj] + w_z[jj]);
+
+      // Diffusion item 2
+      u_diffu2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj];
+      v_diffu2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj];
+      w_diffu2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj];
+
+      // Cross stress term 1 + Convective term
+      u_stab1_1 += tm_RK_ptr->get_RK_b(jj) * (u[jj] + u_prime[jj]) * u_x[jj];
+      u_stab1_2 += tm_RK_ptr->get_RK_b(jj) * (v[jj] + v_prime[jj]) * u_y[jj];
+      u_stab1_3 += tm_RK_ptr->get_RK_b(jj) * (w[jj] + w_prime[jj]) * u_z[jj];
+
+      v_stab1_1 += tm_RK_ptr->get_RK_b(jj) * (u[jj] + u_prime[jj]) * v_x[jj];
+      v_stab1_2 += tm_RK_ptr->get_RK_b(jj) * (v[jj] + v_prime[jj]) * v_y[jj];
+      v_stab1_3 += tm_RK_ptr->get_RK_b(jj) * (w[jj] + w_prime[jj]) * v_z[jj];
+
+      w_stab1_1 += tm_RK_ptr->get_RK_b(jj) * (u[jj] + u_prime[jj]) * w_x[jj];
+      w_stab1_2 += tm_RK_ptr->get_RK_b(jj) * (v[jj] + v_prime[jj]) * w_y[jj];
+      w_stab1_3 += tm_RK_ptr->get_RK_b(jj) * (w[jj] + w_prime[jj]) * w_z[jj];
+
+      // Cross stress term 2 + Reynolds stress
+      u_stab2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj] * (u[jj] + u_prime[jj]);
+      u_stab2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj] * (u[jj] + u_prime[jj]);
+      u_stab2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj] * (u[jj] + u_prime[jj]);
+
+      v_stab2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj] * (v[jj] + v_prime[jj]);
+      v_stab2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj] * (v[jj] + v_prime[jj]);
+      v_stab2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj] * (v[jj] + v_prime[jj]);
+
+      w_stab2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj] * (w[jj] + w_prime[jj]);
+      w_stab2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj] * (w[jj] + w_prime[jj]);
+      w_stab2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj] * (w[jj] + w_prime[jj]);
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      grad_p += tm_RK_ptr->get_RK_b(jj) * p[jj];
+      grad_p_stab += tm_RK_ptr->get_RK_b(jj) * p_prime[jj];
+    }
+
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+      const double NA_xx = d2R_dxx[A], NA_yy = d2R_dyy[A], NA_zz = d2R_dzz[A];
+      const double NA_xy = d2R_dxy[A], NA_xz = d2R_dxz[A], NA_yz = d2R_dyz[A];
+
+      Residual0[  A    ] += gwts * ( NA * div_vel_np1 - NA_x * u_np1_prime
+                                   - NA_y * v_np1_prime - NA_z * w_np1_prime );
+
+      Residual1[3*A + 0] += gwts * ( NA * rho0/dt * u_np1 - NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * p[num_steps-1]
+                                   + NA * rho0/dt * u_np1_prime - NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * p_prime[num_steps-1] 
+                                   - NA * rho0 * sum_a_fx_cur - NA * rho0/dt * u_n - NA * rho0/dt * u_n_prime
+                                   + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu * u_diffu1_3
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
+                                   - NA_x * grad_p - NA_x * grad_p_stab
+                                   + NA * rho0 * u_stab1_1 + NA * rho0 * u_stab1_2 + NA * rho0 * u_stab1_3 
+                                   - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
+
+      Residual1[3*A + 1] += gwts * ( NA * rho0/dt * v_np1 - NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * p[num_steps-1]
+                                   + NA * rho0/dt * v_np1_prime - NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * p_prime[num_steps-1]
+                                   - NA * rho0 * sum_a_fy_cur - NA * rho0/dt * v_n - NA * rho0/dt * v_n_prime
+                                   + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
+                                   - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
+                                   - NA_y * grad_p - NA_y * grad_p_stab
+                                   + NA * rho0 * v_stab1_1 + NA * rho0 * v_stab1_2 + NA * rho0 * v_stab1_3
+                                   - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
+
+      Residual1[3*A + 2] += gwts * ( NA * rho0/dt * w_np1 - NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * p[num_steps-1]
+                                   + NA * rho0/dt * w_np1_prime - NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * p_prime[num_steps-1]
+                                   - NA * rho0 * sum_a_fz_cur - NA * rho0/dt * w_n - NA * rho0/dt * w_n_prime
+                                   + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
+                                   - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_z * grad_p - NA_z * grad_p_stab
+                                   + NA * rho0 * w_stab1_1 + NA * rho0 * w_stab1_2 + NA * rho0 * w_stab1_3
+                                   - NA_x * rho0 * w_stab2_1 - NA_y * rho0 * w_stab2_2 - NA_z * rho0 * w_stab2_3 );  
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Pressure(
+  const double &time, const double &dt,
+  const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+  const std::vector<double>& cur_dot_velo,
+  const std::vector<std::vector<double>>& cur_velo_sols,
+  const std::vector<double>& cur_velo,
+  const std::vector<std::vector<double>>& cur_pres_sols,
+  const std::vector<double>& pre_velo,
+  const std::vector<double>& cur_pres,
+  const double * const &eleCtrlPts_x,
+  const double * const &eleCtrlPts_y,
+  const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  const int num_steps = tm_RK_ptr->get_RK_step();
+
+  Zero_Residual();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  std::vector<double> d2R_dxx(nLocBas, 0.0), d2R_dyy(nLocBas, 0.0), d2R_dzz(nLocBas, 0.0);
+  std::vector<double> d2R_dxy(nLocBas, 0.0), d2R_dxz(nLocBas, 0.0), d2R_dyz(nLocBas, 0.0);
+
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    double u_n = 0.0, u_np1 = 0.0, u_np1_x = 0.0, u_np1_y = 0.0, u_np1_z = 0.0;
+    double v_n = 0.0, v_np1 = 0.0, v_np1_x = 0.0, v_np1_y = 0.0, v_np1_z = 0.0;
+    double w_n = 0.0, w_np1 = 0.0, w_np1_x = 0.0, w_np1_y = 0.0, w_np1_z = 0.0;
+
+    double u_np1_xx = 0.0, u_np1_yy = 0.0, u_np1_zz = 0.0;
+    double u_np1_xy = 0.0, u_np1_xz = 0.0, u_np1_yz = 0.0;
+
+    double v_np1_xx = 0.0, v_np1_yy = 0.0, v_np1_zz = 0.0;
+    double v_np1_xy = 0.0, v_np1_xz = 0.0, v_np1_yz = 0.0;
+
+    double w_np1_xx = 0.0, w_np1_yy = 0.0, w_np1_zz = 0.0;
+    double w_np1_xy = 0.0, w_np1_xz = 0.0, w_np1_yz = 0.0;
+
+    double dot_u_np1 = 0.0, dot_u_np1_x = 0.0, dot_u_np1_y = 0.0, dot_u_np1_z = 0.0;
+    double dot_v_np1 = 0.0, dot_v_np1_x = 0.0, dot_v_np1_y = 0.0, dot_v_np1_z = 0.0;
+    double dot_w_np1 = 0.0, dot_w_np1_x = 0.0, dot_w_np1_y = 0.0, dot_w_np1_z = 0.0;
+
+    double p_np1 = 0.0, p_np1_x = 0.0, p_np1_y = 0.0, p_np1_z = 0.0;
+
+    // All sub steps at the current time step
+    std::vector<double> u(num_steps, 0); std::vector<double> v(num_steps, 0); 
+    std::vector<double> w(num_steps, 0); std::vector<double> p(num_steps, 0); 
+
+    std::vector<double> u_x(num_steps, 0); std::vector<double> v_x(num_steps, 0); 
+    std::vector<double> w_x(num_steps, 0); std::vector<double> p_x(num_steps, 0); 
+
+    std::vector<double> u_y(num_steps, 0); std::vector<double> v_y(num_steps, 0); 
+    std::vector<double> w_y(num_steps, 0); std::vector<double> p_y(num_steps, 0); 
+
+    std::vector<double> u_z(num_steps, 0); std::vector<double> v_z(num_steps, 0); 
+    std::vector<double> w_z(num_steps, 0); std::vector<double> p_z(num_steps, 0); 
+
+    std::vector<double> u_xx(num_steps, 0), v_xx(num_steps, 0), w_xx(num_steps, 0); 
+    std::vector<double> u_yy(num_steps, 0), v_yy(num_steps, 0), w_yy(num_steps, 0); 
+    std::vector<double> u_zz(num_steps, 0), v_zz(num_steps, 0), w_zz(num_steps, 0); 
+
+    std::vector<double> u_xy(num_steps, 0), v_xy(num_steps, 0), w_xy(num_steps, 0); 
+    std::vector<double> u_xz(num_steps, 0), v_xz(num_steps, 0), w_xz(num_steps, 0); 
+    std::vector<double> u_yz(num_steps, 0), v_yz(num_steps, 0), w_yz(num_steps, 0);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_3D_R_dR_d2R( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0], 
+                              &d2R_dxx[0], &d2R_dyy[0], &d2R_dzz[0],
+                              &d2R_dxy[0], &d2R_dxz[0], &d2R_dyz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int ii3 = 3 * ii;
+
+      u_n += pre_velo[ii3+0] * R[ii];
+      v_n += pre_velo[ii3+1] * R[ii];
+      w_n += pre_velo[ii3+2] * R[ii];
+
+      u_np1 += cur_velo[ii3+0] * R[ii];
+      v_np1 += cur_velo[ii3+1] * R[ii];
+      w_np1 += cur_velo[ii3+2] * R[ii];
+
+      p_np1_x += cur_pres[ii] * dR_dx[ii];
+      p_np1_y += cur_pres[ii] * dR_dy[ii];
+      p_np1_z += cur_pres[ii] * dR_dz[ii];     
+      p_np1   += cur_pres[ii] * R[ii];
+
+      u_np1_x += cur_velo[ii3+0] * dR_dx[ii];
+      u_np1_y += cur_velo[ii3+0] * dR_dy[ii];
+      u_np1_z += cur_velo[ii3+0] * dR_dz[ii];
+
+      v_np1_x += cur_velo[ii3+1] * dR_dx[ii];
+      v_np1_y += cur_velo[ii3+1] * dR_dy[ii];
+      v_np1_z += cur_velo[ii3+1] * dR_dz[ii];
+      
+      w_np1_x += cur_velo[ii3+2] * dR_dx[ii];     
+      w_np1_y += cur_velo[ii3+2] * dR_dy[ii];
+      w_np1_z += cur_velo[ii3+2] * dR_dz[ii];
+
+      u_np1_xx += cur_velo[ii3+0] * d2R_dxx[ii];
+      u_np1_yy += cur_velo[ii3+0] * d2R_dyy[ii];
+      u_np1_zz += cur_velo[ii3+0] * d2R_dzz[ii];
+      u_np1_xz += cur_velo[ii3+0] * d2R_dxz[ii];
+      u_np1_xy += cur_velo[ii3+0] * d2R_dxy[ii];
+      u_np1_yz += cur_velo[ii3+0] * d2R_dyz[ii];
+
+      v_np1_xx += cur_velo[ii3+1] * d2R_dxx[ii];
+      v_np1_yy += cur_velo[ii3+1] * d2R_dyy[ii];
+      v_np1_zz += cur_velo[ii3+1] * d2R_dzz[ii];
+      v_np1_xz += cur_velo[ii3+1] * d2R_dxz[ii];
+      v_np1_xy += cur_velo[ii3+1] * d2R_dxy[ii];
+      v_np1_yz += cur_velo[ii3+1] * d2R_dyz[ii];
+
+      w_np1_xx += cur_velo[ii3+2] * d2R_dxx[ii];
+      w_np1_yy += cur_velo[ii3+2] * d2R_dyy[ii];
+      w_np1_zz += cur_velo[ii3+2] * d2R_dzz[ii];
+      w_np1_xz += cur_velo[ii3+2] * d2R_dxz[ii];
+      w_np1_xy += cur_velo[ii3+2] * d2R_dxy[ii];
+      w_np1_yz += cur_velo[ii3+2] * d2R_dyz[ii];      
+
+      dot_u_np1 += cur_dot_velo[ii3+0] * R[ii];
+      dot_v_np1 += cur_dot_velo[ii3+1] * R[ii];
+      dot_w_np1 += cur_dot_velo[ii3+2] * R[ii];
+
+      dot_u_np1_x += cur_dot_velo[ii3+0] * dR_dx[ii];
+      dot_u_np1_y += cur_dot_velo[ii3+0] * dR_dy[ii];
+      dot_u_np1_z += cur_dot_velo[ii3+0] * dR_dz[ii];
+
+      dot_v_np1_x += cur_dot_velo[ii3+1] * dR_dx[ii];
+      dot_v_np1_y += cur_dot_velo[ii3+1] * dR_dy[ii];
+      dot_v_np1_z += cur_dot_velo[ii3+1] * dR_dz[ii];
+      
+      dot_w_np1_x += cur_dot_velo[ii3+2] * dR_dx[ii];     
+      dot_w_np1_y += cur_dot_velo[ii3+2] * dR_dy[ii];
+      dot_w_np1_z += cur_dot_velo[ii3+2] * dR_dz[ii];
+
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u[jj] += cur_velo_sols[jj][ii3+0] * R[ii];
+        v[jj] += cur_velo_sols[jj][ii3+1] * R[ii];
+        w[jj] += cur_velo_sols[jj][ii3+2] * R[ii];
+        p[jj] += cur_pres_sols[jj][ii]    * R[ii];
+
+        u_x[jj] += cur_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_x[jj] += cur_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_x[jj] += cur_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_x[jj] += cur_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_y[jj] += cur_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_y[jj] += cur_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_y[jj] += cur_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_y[jj] += cur_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_z[jj] += cur_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_z[jj] += cur_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_z[jj] += cur_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_z[jj] += cur_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_xx[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_yy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_zz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_xz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_xy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_yz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_xx[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_yy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_zz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_xz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_xy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_yz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_xx[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_yy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_zz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_xz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_xy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_yz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    const std::array<double, 2> tau_np1_dot = get_tau_Darcy(dt);
+    const double tau_m = tau_np1_dot[0];
+    const double tau_c = tau_np1_dot[1];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+
+    double sum_u_cur_advec = 0.0, sum_u_cur_diffu = 0.0, sum_a_fx_cur = 0.0, sum_last_p_x = 0;
+    double sum_v_cur_advec = 0.0, sum_v_cur_diffu = 0.0, sum_a_fy_cur = 0.0, sum_last_p_y = 0;
+    double sum_w_cur_advec = 0.0, sum_w_cur_diffu = 0.0, sum_a_fz_cur = 0.0, sum_last_p_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj]
+                                                   + w[jj] * u_z[jj] );
+      sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj]
+                                                   + u_yy[jj] + u_zz[jj] );
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+
+      sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj]
+                                                   + w[jj] * v_z[jj] );
+      sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj]
+                                                   + v_yy[jj] + v_zz[jj] );
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj]
+                                                   + w[jj] * w_z[jj] );
+      sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj]
+                                                   + w_yy[jj] + w_zz[jj] );
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_last_p_x += tm_RK_ptr->get_RK_b(jj) * p_x[jj];
+      sum_last_p_y += tm_RK_ptr->get_RK_b(jj) * p_y[jj];
+      sum_last_p_z += tm_RK_ptr->get_RK_b(jj) * p_z[jj];
+    }
+
+    const double u_np1_prime = -1.0 * tau_m * ( rho0 * (u_np1 - u_n)/dt 
+                              + tm_RK_ptr->get_RK_b(num_steps-1) * p_x[num_steps-1]
+                              + rho0 * sum_u_cur_advec - vis_mu * sum_u_cur_diffu
+                              + sum_last_p_x - rho0 * sum_a_fx_cur ); 
+    const double v_np1_prime = -1.0 * tau_m * ( rho0 * (v_np1 - v_n)/dt
+                              + tm_RK_ptr->get_RK_b(num_steps-1) * p_y[num_steps-1]
+                              + rho0 * sum_v_cur_advec - vis_mu * sum_v_cur_diffu
+                              + sum_last_p_y - rho0 * sum_a_fy_cur );
+    const double w_np1_prime = -1.0 * tau_m * ( rho0 * (w_np1 - w_n)/dt
+                              + tm_RK_ptr->get_RK_b(num_steps-1) * p_z[num_steps-1]
+                              + rho0 * sum_w_cur_advec - vis_mu * sum_w_cur_diffu
+                              + sum_last_p_z - rho0 * sum_a_fz_cur );
+
+    const double u_np1_adevc = u_np1 * u_np1_x + v_np1 * u_np1_y + w_np1 * u_np1_z;
+    const double u_np1_diffu = u_np1_xx + v_np1_xy + w_np1_xz + u_np1_xx + u_np1_yy + u_np1_zz;
+
+    const double v_np1_adevc = u_np1 * v_np1_x + v_np1 * v_np1_y + w_np1 * v_np1_z;
+    const double v_np1_diffu = u_np1_xy + v_np1_yy + w_np1_yz + v_np1_xx + v_np1_yy + v_np1_zz;
+
+    const double w_np1_adevc = u_np1 * w_np1_x + v_np1 * w_np1_y + w_np1 * w_np1_z;
+    const double w_np1_diffu = u_np1_xz + v_np1_yz + w_np1_zz + w_np1_xx + w_np1_yy + w_np1_zz;
+
+    const double dot_u_np1_prime = -1.0 * tau_m * ( rho0 * dot_u_np1 +  p_np1_x + rho0 * u_np1_adevc
+                                        - vis_mu * u_np1_diffu - rho0 * get_f( coor, time + dt ).x() );
+    const double dot_v_np1_prime = -1.0 * tau_m * ( rho0 * dot_v_np1 +  p_np1_y + rho0 * v_np1_adevc
+                                        - vis_mu * v_np1_diffu - rho0 * get_f( coor, time + dt ).y() );
+    const double dot_w_np1_prime = -1.0 * tau_m * ( rho0 * dot_w_np1 +  p_np1_z + rho0 * w_np1_adevc
+                                        - vis_mu * w_np1_diffu - rho0 * get_f( coor, time + dt ).z() );    
+
+    const double div_dot_vel_np1 = dot_u_np1_x + dot_v_np1_y + dot_w_np1_z;
+    const double p_np1_prime = -1.0 * tau_c * div_dot_vel_np1;
+
+    // Diffusion item 1
+    const double u_diffu1_1 = u_np1_x + u_np1_x;
+    const double u_diffu1_2 = u_np1_y + v_np1_x;
+    const double u_diffu1_3 = u_np1_z + w_np1_x;
+
+    const double v_diffu1_1 = u_np1_y + v_np1_x;
+    const double v_diffu1_2 = v_np1_y + v_np1_y;
+    const double v_diffu1_3 = w_np1_y + v_np1_z;
+
+    const double w_diffu1_1 = u_np1_z + w_np1_x;
+    const double w_diffu1_2 = v_np1_z + w_np1_y;
+    const double w_diffu1_3 = w_np1_z + w_np1_z;
+
+    // Diffusion item 2
+    const double u_diffu2_1 = u_np1_prime;
+    const double v_diffu2_2 = v_np1_prime;
+    const double w_diffu2_3 = w_np1_prime;
+
+    // Cross stress term 1 + Convective term
+    const double u_stab1_1 = (u_np1 + u_np1_prime) * u_np1_x;
+    const double u_stab1_2 = (v_np1 + v_np1_prime) * u_np1_y;
+    const double u_stab1_3 = (w_np1 + w_np1_prime) * u_np1_z;
+
+    const double v_stab1_1 = (u_np1 + u_np1_prime) * v_np1_x;
+    const double v_stab1_2 = (v_np1 + v_np1_prime) * v_np1_y;
+    const double v_stab1_3 = (w_np1 + w_np1_prime) * v_np1_z;
+
+    const double w_stab1_1 = (u_np1 + u_np1_prime) * w_np1_x;
+    const double w_stab1_2 = (v_np1 + v_np1_prime) * w_np1_y;
+    const double w_stab1_3 = (w_np1 + w_np1_prime) * w_np1_z;
+
+    // Cross stress term 2 + Reynolds stress
+    const double u_stab2_1 = u_np1_prime * (u_np1 + u_np1_prime);
+    const double u_stab2_2 = v_np1_prime * (u_np1 + u_np1_prime);
+    const double u_stab2_3 = w_np1_prime * (u_np1 + u_np1_prime);
+
+    const double v_stab2_1 = u_np1_prime * (v_np1 + v_np1_prime);
+    const double v_stab2_2 = v_np1_prime * (v_np1 + v_np1_prime);
+    const double v_stab2_3 = w_np1_prime * (v_np1 + v_np1_prime);
+
+    const double w_stab2_1 = u_np1_prime * (w_np1 + w_np1_prime);
+    const double w_stab2_2 = v_np1_prime * (w_np1 + w_np1_prime);
+    const double w_stab2_3 = w_np1_prime * (w_np1 + w_np1_prime);
+
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+      const double NA_xx = d2R_dxx[A], NA_yy = d2R_dyy[A], NA_zz = d2R_dzz[A];
+      const double NA_xy = d2R_dxy[A], NA_xz = d2R_dxz[A], NA_yz = d2R_dyz[A];
+
+      Residual0[ A     ] += gwts * ( NA * div_dot_vel_np1 - NA_x * dot_u_np1_prime
+                                   - NA_y * dot_v_np1_prime - NA_z * dot_w_np1_prime );
+
+      Residual1[3*A + 0] += gwts * ( NA * rho0 * dot_u_np1 - NA_x * p_np1 + NA * rho0 * dot_u_np1_prime 
+                                   - NA_x * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).x() 
+                                   + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu *  u_diffu1_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
+                                   + NA * rho0 * u_stab1_1 + NA * rho0 * u_stab1_2 + NA * rho0 * u_stab1_3 
+                                   - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
+
+      Residual1[3*A + 1] += gwts * ( NA * rho0 * dot_v_np1 - NA_y * p_np1 + NA * rho0 * dot_v_np1_prime
+                                   - NA_y * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).y() 
+                                   + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
+                                   - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
+                                   + NA * rho0 * v_stab1_1 + NA * rho0 * v_stab1_2 + NA * rho0 * v_stab1_3
+                                   - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
+
+      Residual1[3*A + 2] += gwts * ( NA * rho0 * dot_w_np1 - NA_z * p_np1+ NA * rho0 * dot_w_np1_prime 
+                                   - NA_z * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).z()
+                                   + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
+                                   - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
+                                   + NA * rho0 * w_stab1_1 + NA * rho0 * w_stab1_2 + NA * rho0 * w_stab1_3
+                                   - NA_x * rho0 * w_stab2_1 - NA_y * rho0 * w_stab2_2 - NA_z * rho0 * w_stab2_3 );
+
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Sub(
+    const double &time, const double &dt,
+    const int &subindex,
+    const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+    const std::vector<std::vector<double>>& cur_velo_sols,
+    const std::vector<std::vector<double>>& cur_pres_sols,
+    const std::vector<std::vector<double>>& pre_velo_sols,
+    const std::vector<std::vector<double>>& pre_pres_sols,
+    const std::vector<double>& pre_velo,
+    const std::vector<double>& pre_velo_before,
+    const double * const &eleCtrlPts_x,
+    const double * const &eleCtrlPts_y,
+    const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  const int num_steps = tm_RK_ptr->get_RK_step();
+
+  Zero_Tangent_Residual();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  std::vector<double> d2R_dxx(nLocBas, 0.0), d2R_dyy(nLocBas, 0.0), d2R_dzz(nLocBas, 0.0);
+  std::vector<double> d2R_dxy(nLocBas, 0.0), d2R_dxz(nLocBas, 0.0), d2R_dyz(nLocBas, 0.0);
+
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    double u_n = 0.0, u_nm1 = 0.0; 
+    double v_n = 0.0, v_nm1 = 0.0;
+    double w_n = 0.0, w_nm1 = 0.0;
+    
+    // The known sub steps under the current time step
+    std::vector<double> u(subindex+1, 0); std::vector<double> v(subindex+1, 0); 
+    std::vector<double> w(subindex+1, 0); std::vector<double> p(subindex+1, 0); 
+
+    std::vector<double> u_x(subindex+1, 0); std::vector<double> v_x(subindex+1, 0); 
+    std::vector<double> w_x(subindex+1, 0); std::vector<double> p_x(subindex+1, 0); 
+
+    std::vector<double> u_y(subindex+1, 0); std::vector<double> v_y(subindex+1, 0); 
+    std::vector<double> w_y(subindex+1, 0); std::vector<double> p_y(subindex+1, 0); 
+
+    std::vector<double> u_z(subindex+1, 0); std::vector<double> v_z(subindex+1, 0); 
+    std::vector<double> w_z(subindex+1, 0); std::vector<double> p_z(subindex+1, 0); 
+
+    std::vector<double> u_xx(subindex+1, 0), v_xx(subindex+1, 0), w_xx(subindex+1, 0); 
+    std::vector<double> u_yy(subindex+1, 0), v_yy(subindex+1, 0), w_yy(subindex+1, 0); 
+    std::vector<double> u_zz(subindex+1, 0), v_zz(subindex+1, 0), w_zz(subindex+1, 0); 
+
+    std::vector<double> u_xy(subindex+1, 0), v_xy(subindex+1, 0), w_xy(subindex+1, 0); 
+    std::vector<double> u_xz(subindex+1, 0), v_xz(subindex+1, 0), w_xz(subindex+1, 0); 
+    std::vector<double> u_yz(subindex+1, 0), v_yz(subindex+1, 0), w_yz(subindex+1, 0);
+
+    // All sub steps at the previous time step
+    std::vector<double> u_pre(num_steps, 0); std::vector<double> v_pre(num_steps, 0); 
+    std::vector<double> w_pre(num_steps, 0); std::vector<double> p_pre(num_steps, 0); 
+
+    std::vector<double> u_pre_x(num_steps, 0); std::vector<double> v_pre_x(num_steps, 0); 
+    std::vector<double> w_pre_x(num_steps, 0); std::vector<double> p_pre_x(num_steps, 0); 
+
+    std::vector<double> u_pre_y(num_steps, 0); std::vector<double> v_pre_y(num_steps, 0); 
+    std::vector<double> w_pre_y(num_steps, 0); std::vector<double> p_pre_y(num_steps, 0); 
+
+    std::vector<double> u_pre_z(num_steps, 0); std::vector<double> v_pre_z(num_steps, 0); 
+    std::vector<double> w_pre_z(num_steps, 0); std::vector<double> p_pre_z(num_steps, 0); 
+
+    std::vector<double> u_pre_xx(num_steps, 0), v_pre_xx(num_steps, 0), w_pre_xx(num_steps, 0); 
+    std::vector<double> u_pre_yy(num_steps, 0), v_pre_yy(num_steps, 0), w_pre_yy(num_steps, 0); 
+    std::vector<double> u_pre_zz(num_steps, 0), v_pre_zz(num_steps, 0), w_pre_zz(num_steps, 0); 
+
+    std::vector<double> u_pre_xy(num_steps, 0), v_pre_xy(num_steps, 0), w_pre_xy(num_steps, 0); 
+    std::vector<double> u_pre_xz(num_steps, 0), v_pre_xz(num_steps, 0), w_pre_xz(num_steps, 0); 
+    std::vector<double> u_pre_yz(num_steps, 0), v_pre_yz(num_steps, 0), w_pre_yz(num_steps, 0);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_3D_R_dR_d2R( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0], 
+                               &d2R_dxx[0], &d2R_dyy[0], &d2R_dzz[0],
+                               &d2R_dxy[0], &d2R_dxz[0], &d2R_dyz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int ii3 = 3 * ii;
+
+      u_nm1 += pre_velo_before[ii3+0] * R[ii];
+      v_nm1 += pre_velo_before[ii3+1] * R[ii];
+      w_nm1 += pre_velo_before[ii3+2] * R[ii];
+
+      u_n += pre_velo[ii3+0] * R[ii];
+      v_n += pre_velo[ii3+1] * R[ii];
+      w_n += pre_velo[ii3+2] * R[ii];
+
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    for(int jj=0; jj<=subindex; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u[jj] += cur_velo_sols[jj][ii3+0] * R[ii];
+        v[jj] += cur_velo_sols[jj][ii3+1] * R[ii];
+        w[jj] += cur_velo_sols[jj][ii3+2] * R[ii];
+        p[jj] += cur_pres_sols[jj][ii]    * R[ii];
+
+        u_x[jj] += cur_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_x[jj] += cur_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_x[jj] += cur_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_x[jj] += cur_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_y[jj] += cur_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_y[jj] += cur_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_y[jj] += cur_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_y[jj] += cur_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_z[jj] += cur_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_z[jj] += cur_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_z[jj] += cur_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_z[jj] += cur_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_xx[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_yy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_zz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_xz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_xy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_yz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_xx[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_yy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_zz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_xz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_xy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_yz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_xx[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_yy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_zz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_xz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_xy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_yz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u_pre[jj] += pre_velo_sols[jj][ii3+0] * R[ii];
+        v_pre[jj] += pre_velo_sols[jj][ii3+1] * R[ii];
+        w_pre[jj] += pre_velo_sols[jj][ii3+2] * R[ii];
+        p_pre[jj] += pre_pres_sols[jj][ii]    * R[ii];
+
+        u_pre_x[jj] += pre_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_pre_x[jj] += pre_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_pre_x[jj] += pre_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_pre_x[jj] += pre_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_pre_y[jj] += pre_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_pre_y[jj] += pre_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_pre_y[jj] += pre_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_pre_y[jj] += pre_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_pre_z[jj] += pre_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_pre_z[jj] += pre_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_pre_z[jj] += pre_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_pre_z[jj] += pre_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_pre_xx[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_pre_yy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_pre_zz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_pre_xz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_pre_xy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_pre_yz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_pre_xx[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_pre_yy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_pre_zz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_pre_xz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_pre_xy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_pre_yz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_pre_xx[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_pre_yy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_pre_zz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_pre_xz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_pre_xy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_pre_yz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    const auto dxi_dx = elementv->get_invJacobian(qua);
+
+    std::vector<double> tau_m(subindex+1, 0); std::vector<double> tau_c(subindex+1, 0);
+
+    for(int index=1; index<=subindex; ++index)
+    {
+      const std::array<double, 2> tau_sub = get_tau( dt, dxi_dx, u[index-1], v[index-1], w[index-1] );
+      tau_m[index] = tau_sub[0];
+      tau_c[index] = tau_sub[1];
+    }
+
+    const std::array<double, 2> tau_n = get_tau( dt, dxi_dx, u_n, v_n, w_n );
+    const double tau_m_n = tau_n[0];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+
+    std::vector<double> sum_u_advec(subindex+1, 0), sum_u_diffu(subindex+1, 0); 
+    std::vector<double> sum_a_fx(subindex+1, 0), sum_p_x(subindex+1, 0);
+    std::vector<double> sum_v_advec(subindex+1, 0), sum_v_diffu(subindex+1, 0);
+    std::vector<double> sum_a_fy(subindex+1, 0), sum_p_y(subindex+1, 0);
+    std::vector<double> sum_w_advec(subindex+1, 0), sum_w_diffu(subindex+1, 0);
+    std::vector<double> sum_a_fz(subindex+1, 0), sum_p_z(subindex+1, 0);
+
+    std::vector<double> u_prime(subindex+1, 0); std::vector<double> v_prime(subindex+1, 0); 
+    std::vector<double> w_prime(subindex+1, 0); std::vector<double> p_prime(subindex, 0); 
+    
+    for(int index=1; index<=subindex; ++index)
+    {
+      for(int jj=0; jj<index; ++jj)
+      {
+        sum_u_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
+        sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+
+        sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
+        sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+        sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
+        sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+      }
+
+      for(int jj=0; jj<index-1; ++jj)
+      {
+        sum_p_x[index] += tm_RK_ptr->get_RK_a(index, jj) * p_x[jj];
+        sum_p_y[index] += tm_RK_ptr->get_RK_a(index, jj) * p_y[jj];
+        sum_p_z[index] += tm_RK_ptr->get_RK_a(index, jj) * p_z[jj];
+      }
+
+      u_prime[index] = -1.0 * tau_m[index] * ( rho0 * (u[index] - u_n)/dt + tm_RK_ptr->get_RK_a(index, index-1) * p_x[index-1]
+                      + rho0 * sum_u_advec[index] - vis_mu * sum_u_diffu[index] + sum_p_x[index] - rho0 * sum_a_fx[index] );
+      v_prime[index] = -1.0 * tau_m[index] * ( rho0 * (v[index] - v_n)/dt + tm_RK_ptr->get_RK_a(index, index-1) * p_y[index-1]
+                      + rho0 * sum_v_advec[index] - vis_mu * sum_v_diffu[index] + sum_p_y[index] - rho0 * sum_a_fy[index] );
+      w_prime[index] = -1.0 * tau_m[index] * ( rho0 * (w[index] - w_n)/dt + tm_RK_ptr->get_RK_a(index, index-1) * p_z[index-1]
+                      + rho0 * sum_w_advec[index] - vis_mu * sum_w_diffu[index] + sum_p_z[index] - rho0 * sum_a_fz[index] );
+      p_prime[index-1]= -1.0 * tau_c[index] * (u_x[index] + v_y[index] + w_z[index]);
+    }
+
+    double sum_u_pre_advec = 0.0, sum_u_pre_diffu = 0.0, sum_a_fx_pre = 0.0, sum_p_pre_x = 0;
+    double sum_v_pre_advec = 0.0, sum_v_pre_diffu = 0.0, sum_a_fy_pre = 0.0, sum_p_pre_y = 0;
+    double sum_w_pre_advec = 0.0, sum_w_pre_diffu = 0.0, sum_a_fz_pre = 0.0, sum_p_pre_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * u_pre_x[jj] + v_pre[jj] * u_pre_y[jj] + w_pre[jj] * u_pre_z[jj] );
+      sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj] + w_pre_xz[jj] + u_pre_xx[jj] + u_pre_yy[jj] + u_pre_zz[jj] );
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+  
+      sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj] + v_pre[jj] * v_pre_y[jj] + w_pre[jj] * v_pre_z[jj] );
+      sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj] + w_pre_yz[jj] + v_pre_xx[jj] + v_pre_yy[jj] + v_pre_zz[jj] );
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj] + v_pre[jj] * w_pre_y[jj] + w_pre[jj] * w_pre_z[jj] );
+      sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj] + w_pre_zz[jj] + w_pre_xx[jj] + w_pre_yy[jj] + w_pre_zz[jj] );
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_p_pre_x += tm_RK_ptr->get_RK_b(jj) * p_pre_x[jj];
+      sum_p_pre_y += tm_RK_ptr->get_RK_b(jj) * p_pre_y[jj];
+      sum_p_pre_z += tm_RK_ptr->get_RK_b(jj) * p_pre_z[jj] ;
+    }
+
+    const double u_n_prime = -1.0 * tau_m_n * ( rho0 * (u_n - u_nm1)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_pre_x[num_steps-1]
+                                        + rho0 * sum_u_pre_advec - vis_mu * sum_u_pre_diffu + sum_p_pre_x - rho0 * sum_a_fx_pre ); 
+    const double v_n_prime = -1.0 * tau_m_n * ( rho0 * (v_n - v_nm1)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_pre_y[num_steps-1]
+                                        + rho0 * sum_v_pre_advec - vis_mu * sum_v_pre_diffu + sum_p_pre_y - rho0 * sum_a_fy_pre );
+    const double w_n_prime = -1.0 * tau_m_n * ( rho0 * (w_n - w_nm1)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_pre_z[num_steps-1]
+                                        + rho0 * sum_w_pre_advec - vis_mu * sum_w_pre_diffu + sum_p_pre_z - rho0 * sum_a_fz_pre );
+
+    u_prime[0] = u_n_prime;
+    v_prime[0] = v_n_prime;
+    w_prime[0] = w_n_prime;
+
+    const double div_vel= u_x[subindex] + v_y[subindex] + w_z[subindex];
+
+    double u_diffu1_1 = 0.0, u_diffu1_2 = 0.0, u_diffu1_3 = 0.0;
+    double v_diffu1_1 = 0.0, v_diffu1_2 = 0.0, v_diffu1_3 = 0.0;
+    double w_diffu1_1 = 0.0, w_diffu1_2 = 0.0, w_diffu1_3 = 0.0; 
+    double u_diffu2_1 = 0.0, v_diffu2_2 = 0.0, w_diffu2_3 = 0.0;
+
+    double u_stab1_1 = 0.0, u_stab1_2 = 0.0, u_stab1_3 = 0.0;
+    double u_stab2_1 = 0.0, u_stab2_2 = 0.0, u_stab2_3 = 0.0;
+    double v_stab1_1 = 0.0, v_stab1_2 = 0.0, v_stab1_3 = 0.0;
+    double v_stab2_1 = 0.0, v_stab2_2 = 0.0, v_stab2_3 = 0.0;
+    double w_stab1_1 = 0.0, w_stab1_2 = 0.0, w_stab1_3 = 0.0;
+    double w_stab2_1 = 0.0, w_stab2_2 = 0.0, w_stab2_3 = 0.0;
+   
+    double grad_p = 0.0, grad_p_stab = 0.0;
+
+    for(int jj=0; jj<subindex; ++jj)
+    {
+       // Diffusion item 1
+       u_diffu1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_x[jj] + u_x[jj]);
+       u_diffu1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_y[jj] + v_x[jj]);
+       u_diffu1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_z[jj] + w_x[jj]);
+
+       v_diffu1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_y[jj] + v_x[jj]);
+       v_diffu1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v_y[jj] + v_y[jj]);
+       v_diffu1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w_y[jj] + v_z[jj]);
+
+       w_diffu1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u_z[jj] + w_x[jj]);
+       w_diffu1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v_z[jj] + w_y[jj]);
+       w_diffu1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w_z[jj] + w_z[jj]);
+
+       // Diffusion item 2
+       u_diffu2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj];
+       v_diffu2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj];
+       w_diffu2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj];
+
+       // Cross stress term 1 + Convective term
+       u_stab1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u[jj] + u_prime[jj]) * u_x[jj];
+       u_stab1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v[jj] + v_prime[jj]) * u_y[jj];
+       u_stab1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w[jj] + w_prime[jj]) * u_z[jj];
+
+       v_stab1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u[jj] + u_prime[jj]) * v_x[jj];
+       v_stab1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v[jj] + v_prime[jj]) * v_y[jj];
+       v_stab1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w[jj] + w_prime[jj]) * v_z[jj];
+
+       w_stab1_1 += tm_RK_ptr->get_RK_a(subindex, jj) * (u[jj] + u_prime[jj]) * w_x[jj];
+       w_stab1_2 += tm_RK_ptr->get_RK_a(subindex, jj) * (v[jj] + v_prime[jj]) * w_y[jj];
+       w_stab1_3 += tm_RK_ptr->get_RK_a(subindex, jj) * (w[jj] + w_prime[jj]) * w_z[jj];
+
+       // Cross stress term 2 + Reynolds stress
+       u_stab2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj] * (u[jj] + u_prime[jj]);
+       u_stab2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj] * (u[jj] + u_prime[jj]);
+       u_stab2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj] * (u[jj] + u_prime[jj]);
+
+       v_stab2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj] * (v[jj] + v_prime[jj]);
+       v_stab2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj] * (v[jj] + v_prime[jj]);
+       v_stab2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj] * (v[jj] + v_prime[jj]);
+
+       w_stab2_1 += tm_RK_ptr->get_RK_a(subindex, jj) * u_prime[jj] * (w[jj] + w_prime[jj]);
+       w_stab2_2 += tm_RK_ptr->get_RK_a(subindex, jj) * v_prime[jj] * (w[jj] + w_prime[jj]);
+       w_stab2_3 += tm_RK_ptr->get_RK_a(subindex, jj) * w_prime[jj] * (w[jj] + w_prime[jj]);
+    }
+
+    for(int jj=0; jj<subindex-1; ++jj)
+    {
+      grad_p += tm_RK_ptr->get_RK_a(subindex, jj) * p[jj];
+      grad_p_stab += tm_RK_ptr->get_RK_a(subindex, jj) * p_prime[jj];
+    }
+
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+      const double NA_xx = d2R_dxx[A], NA_yy = d2R_dyy[A], NA_zz = d2R_dzz[A];
+      const double NA_xy = d2R_dxy[A], NA_xz = d2R_dxz[A], NA_yz = d2R_dyz[A];
+    
+      Residual0[ A     ] += gwts * ( NA * div_vel - NA_x * u_prime[subindex] - NA_y * v_prime[subindex] - NA_z * w_prime[subindex] );
+
+      Residual1[3*A + 0] += gwts * ( NA * rho0/dt * u[subindex] - NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p[subindex-1]
+                                   + NA * rho0/dt * u_prime[subindex] - NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p_prime[subindex-1]
+                                   - NA * rho0 * sum_a_fx[subindex] - NA * rho0/dt * u_n - NA * rho0/dt * u_n_prime
+                                   + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu * u_diffu1_3
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
+                                   - NA_x * grad_p - NA_x * grad_p_stab
+                                   + NA * rho0 * u_stab1_1 + NA * rho0 * u_stab1_2 + NA * rho0 * u_stab1_3 
+                                   - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
+      
+      Residual1[3*A + 1] += gwts * ( NA * rho0/dt * v[subindex] - NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p[subindex-1]
+                                   + NA * rho0/dt * v_prime[subindex] - NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p_prime[subindex-1]
+                                   - NA * rho0 * sum_a_fy[subindex] - NA * rho0/dt * v_n - NA * rho0/dt * v_n_prime
+                                   + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
+                                   - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
+                                   - NA_y * grad_p - NA_y * grad_p_stab
+                                   + NA * rho0 * v_stab1_1 + NA * rho0 * v_stab1_2 + NA * rho0 * v_stab1_3
+                                   - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
+      
+      Residual1[3*A + 2] += gwts * ( NA * rho0/dt * w[subindex] - NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p[subindex-1]
+                                   + NA * rho0/dt * w_prime[subindex] - NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * p_prime[subindex-1]
+                                   - NA * rho0 * sum_a_fz[subindex] - NA * rho0/dt * w_n - NA * rho0/dt * w_n_prime
+                                   + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
+                                   - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_z * grad_p - NA_z * grad_p_stab
+                                   + NA * rho0 * w_stab1_1 + NA * rho0 * w_stab1_2 + NA * rho0 * w_stab1_3
+                                   - NA_x * rho0 * w_stab2_1 - NA_y * rho0 * w_stab2_2 - NA_z * rho0 * w_stab2_3 );
+
+      for(int B=0; B<nLocBas; ++B)
+      {
+        const double NB = R[B], NB_x = dR_dx[B], NB_y = dR_dy[B], NB_z = dR_dz[B];
+        // Continuity equation with respect to p, u, v, w
+        Tangent0[  nLocBas*A+B          ] += gwts * (NA_x * tau_m[subindex] * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB_x
+                                                   + NA_y * tau_m[subindex] * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB_y
+                                                   + NA_z * tau_m[subindex] * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB_z);
+        
+        Tangent1[3*nLocBas*A+3*B+0      ] += gwts * (NA * NB_x + NA_x * tau_m[subindex] * NB * rho0/dt);
+
+        Tangent1[3*nLocBas*A+3*B+1      ] += gwts * (NA * NB_y + NA_y * tau_m[subindex] * NB * rho0/dt);
+        
+        Tangent1[3*nLocBas*A+3*B+2      ] += gwts * (NA * NB_z + NA_z * tau_m[subindex] * NB * rho0/dt);
+
+        // Momentum-x with respect to p, u, v, w
+        Tangent2[  nLocBas*3*A+B        ] += gwts * (-NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB 
+                                                    - NA * rho0/dt * tau_m[subindex] * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB_x);
+        
+        Tangent3[3*nLocBas*3*A+3*B+0    ] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m[subindex] * NB * rho0 /dt);
+
+        Tangent4[3*nLocBas*3*A+3*B+0    ] += gwts * (NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_x);
+        
+        Tangent4[3*nLocBas*3*A+3*B+1    ] += gwts * (NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_y);
+      
+        Tangent4[3*nLocBas*3*A+3*B+2    ] += gwts * (NA_x * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_z);
+
+        // Momentum-y with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+1)+B    ] += gwts * (-NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB
+                                                    - NA * rho0/dt * tau_m[subindex] * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB_y);
+
+        Tangent3[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m[subindex] * NB * rho0/dt);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+0] += gwts * (NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+2] += gwts * (NA_y * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_z );
+
+        // Momentum-z with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+2)+B    ] += gwts * (-NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB
+                                                    - NA * rho0/dt * tau_m[subindex] * tm_RK_ptr->get_RK_a(subindex, subindex-1) * NB_z);
+
+        Tangent3[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m[subindex] * NB * rho0/dt);        
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+0] += gwts * (NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+1] += gwts * (NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA_z * tm_RK_ptr->get_RK_a(subindex, subindex-1) * tau_c[subindex] * NB_z);        
+      }
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Final(
+    const double &time, const double &dt,
+    const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+    const std::vector<std::vector<double>>& cur_velo_sols,
+    const std::vector<double>& cur_velo,
+    const std::vector<std::vector<double>>& cur_pres_sols,
+    const std::vector<std::vector<double>>& pre_velo_sols,
+    const std::vector<double>& pre_velo,
+    const std::vector<std::vector<double>>& pre_pres_sols,
+    const std::vector<double>& pre_velo_before,
+    const double * const &eleCtrlPts_x,
+    const double * const &eleCtrlPts_y,
+    const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  const int num_steps = tm_RK_ptr->get_RK_step();
+
+  Zero_Tangent_Residual();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  std::vector<double> d2R_dxx(nLocBas, 0.0), d2R_dyy(nLocBas, 0.0), d2R_dzz(nLocBas, 0.0);
+  std::vector<double> d2R_dxy(nLocBas, 0.0), d2R_dxz(nLocBas, 0.0), d2R_dyz(nLocBas, 0.0);
+
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    double u_n = 0.0, u_nm1 = 0.0, u_np1 = 0.0, u_np1_x = 0.0, u_np1_y = 0.0, u_np1_z = 0.0;
+    double v_n = 0.0, v_nm1 = 0.0, v_np1 = 0.0, v_np1_x = 0.0, v_np1_y = 0.0, v_np1_z = 0.0;
+    double w_n = 0.0, w_nm1 = 0.0, w_np1 = 0.0, w_np1_x = 0.0, w_np1_y = 0.0, w_np1_z = 0.0;
+
+    // All sub steps at the current time step
+    std::vector<double> u(num_steps, 0); std::vector<double> v(num_steps, 0); 
+    std::vector<double> w(num_steps, 0); std::vector<double> p(num_steps, 0); 
+
+    std::vector<double> u_x(num_steps, 0); std::vector<double> v_x(num_steps, 0); 
+    std::vector<double> w_x(num_steps, 0); std::vector<double> p_x(num_steps, 0); 
+
+    std::vector<double> u_y(num_steps, 0); std::vector<double> v_y(num_steps, 0); 
+    std::vector<double> w_y(num_steps, 0); std::vector<double> p_y(num_steps, 0); 
+
+    std::vector<double> u_z(num_steps, 0); std::vector<double> v_z(num_steps, 0); 
+    std::vector<double> w_z(num_steps, 0); std::vector<double> p_z(num_steps, 0); 
+
+    std::vector<double> u_xx(num_steps, 0), v_xx(num_steps, 0), w_xx(num_steps, 0); 
+    std::vector<double> u_yy(num_steps, 0), v_yy(num_steps, 0), w_yy(num_steps, 0); 
+    std::vector<double> u_zz(num_steps, 0), v_zz(num_steps, 0), w_zz(num_steps, 0); 
+
+    std::vector<double> u_xy(num_steps, 0), v_xy(num_steps, 0), w_xy(num_steps, 0); 
+    std::vector<double> u_xz(num_steps, 0), v_xz(num_steps, 0), w_xz(num_steps, 0); 
+    std::vector<double> u_yz(num_steps, 0), v_yz(num_steps, 0), w_yz(num_steps, 0);
+
+    // All sub steps at the previous time step
+    std::vector<double> u_pre(num_steps, 0); std::vector<double> v_pre(num_steps, 0); 
+    std::vector<double> w_pre(num_steps, 0); std::vector<double> p_pre(num_steps, 0); 
+
+    std::vector<double> u_pre_x(num_steps, 0); std::vector<double> v_pre_x(num_steps, 0); 
+    std::vector<double> w_pre_x(num_steps, 0); std::vector<double> p_pre_x(num_steps, 0); 
+
+    std::vector<double> u_pre_y(num_steps, 0); std::vector<double> v_pre_y(num_steps, 0); 
+    std::vector<double> w_pre_y(num_steps, 0); std::vector<double> p_pre_y(num_steps, 0); 
+
+    std::vector<double> u_pre_z(num_steps, 0); std::vector<double> v_pre_z(num_steps, 0); 
+    std::vector<double> w_pre_z(num_steps, 0); std::vector<double> p_pre_z(num_steps, 0); 
+
+    std::vector<double> u_pre_xx(num_steps, 0), v_pre_xx(num_steps, 0), w_pre_xx(num_steps, 0); 
+    std::vector<double> u_pre_yy(num_steps, 0), v_pre_yy(num_steps, 0), w_pre_yy(num_steps, 0); 
+    std::vector<double> u_pre_zz(num_steps, 0), v_pre_zz(num_steps, 0), w_pre_zz(num_steps, 0); 
+
+    std::vector<double> u_pre_xy(num_steps, 0), v_pre_xy(num_steps, 0), w_pre_xy(num_steps, 0); 
+    std::vector<double> u_pre_xz(num_steps, 0), v_pre_xz(num_steps, 0), w_pre_xz(num_steps, 0); 
+    std::vector<double> u_pre_yz(num_steps, 0), v_pre_yz(num_steps, 0), w_pre_yz(num_steps, 0);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_3D_R_dR_d2R( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0], 
+                               &d2R_dxx[0], &d2R_dyy[0], &d2R_dzz[0],
+                               &d2R_dxy[0], &d2R_dxz[0], &d2R_dyz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int ii3 = 3 * ii;
+
+      u_nm1 += pre_velo_before[ii3+0] * R[ii];
+      v_nm1 += pre_velo_before[ii3+1] * R[ii];
+      w_nm1 += pre_velo_before[ii3+2] * R[ii];
+
+      u_n += pre_velo[ii3+0] * R[ii];
+      v_n += pre_velo[ii3+1] * R[ii];
+      w_n += pre_velo[ii3+2] * R[ii];
+
+      u_np1 += cur_velo[ii3+0] * R[ii];
+      v_np1 += cur_velo[ii3+1] * R[ii];
+      w_np1 += cur_velo[ii3+2] * R[ii];
+
+      u_np1_x += cur_velo[ii3+0] * dR_dx[ii];
+      u_np1_y += cur_velo[ii3+0] * dR_dy[ii];
+      u_np1_z += cur_velo[ii3+0] * dR_dz[ii];
+
+      v_np1_x += cur_velo[ii3+1] * dR_dx[ii];
+      v_np1_y += cur_velo[ii3+1] * dR_dy[ii];
+      v_np1_z += cur_velo[ii3+1] * dR_dz[ii];
+      
+      w_np1_x += cur_velo[ii3+2] * dR_dx[ii];     
+      w_np1_y += cur_velo[ii3+2] * dR_dy[ii];
+      w_np1_z += cur_velo[ii3+2] * dR_dz[ii];
+
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u[jj] += cur_velo_sols[jj][ii3+0] * R[ii];
+        v[jj] += cur_velo_sols[jj][ii3+1] * R[ii];
+        w[jj] += cur_velo_sols[jj][ii3+2] * R[ii];
+        p[jj] += cur_pres_sols[jj][ii]    * R[ii];
+
+        u_x[jj] += cur_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_x[jj] += cur_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_x[jj] += cur_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_x[jj] += cur_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_y[jj] += cur_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_y[jj] += cur_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_y[jj] += cur_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_y[jj] += cur_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_z[jj] += cur_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_z[jj] += cur_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_z[jj] += cur_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_z[jj] += cur_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_xx[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_yy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_zz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_xz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_xy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_yz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_xx[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_yy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_zz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_xz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_xy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_yz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_xx[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_yy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_zz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_xz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_xy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_yz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+
+        u_pre[jj] += pre_velo_sols[jj][ii3+0] * R[ii];
+        v_pre[jj] += pre_velo_sols[jj][ii3+1] * R[ii];
+        w_pre[jj] += pre_velo_sols[jj][ii3+2] * R[ii];
+        p_pre[jj] += pre_pres_sols[jj][ii]    * R[ii];
+
+        u_pre_x[jj] += pre_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_pre_x[jj] += pre_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_pre_x[jj] += pre_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_pre_x[jj] += pre_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_pre_y[jj] += pre_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_pre_y[jj] += pre_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_pre_y[jj] += pre_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_pre_y[jj] += pre_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_pre_z[jj] += pre_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_pre_z[jj] += pre_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_pre_z[jj] += pre_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_pre_z[jj] += pre_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_pre_xx[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_pre_yy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_pre_zz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_pre_xz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_pre_xy[jj] += pre_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_pre_yz[jj] += pre_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_pre_xx[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_pre_yy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_pre_zz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_pre_xz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_pre_xy[jj] += pre_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_pre_yz[jj] += pre_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_pre_xx[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_pre_yy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_pre_zz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_pre_xz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_pre_xy[jj] += pre_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_pre_yz[jj] += pre_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    const auto dxi_dx = elementv->get_invJacobian(qua);
+
+    std::vector<double> tau_m(num_steps, 0); std::vector<double> tau_c(num_steps, 0);
+
+    for(int index=1; index<num_steps; ++index)
+    {
+      const std::array<double, 2> tau_sub = get_tau( dt, dxi_dx, u[index], v[index], w[index] );
+      tau_m[index] = tau_sub[0];
+      tau_c[index] = tau_sub[1];
+    }
+
+    const std::array<double, 2> tau_n = get_tau( dt, dxi_dx, u_n, v_n, w_n );
+    const double tau_m_n = tau_n[0];
+    const double tau_c_n = tau_n[1];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+
+    std::vector<double> sum_u_advec(num_steps, 0), sum_u_diffu(num_steps, 0); 
+    std::vector<double> sum_a_fx(num_steps, 0), sum_p_x(num_steps, 0);
+    std::vector<double> sum_v_advec(num_steps, 0), sum_v_diffu(num_steps, 0); 
+    std::vector<double> sum_a_fy(num_steps, 0), sum_p_y(num_steps, 0);
+    std::vector<double> sum_w_advec(num_steps, 0), sum_w_diffu(num_steps, 0); 
+    std::vector<double> sum_a_fz(num_steps, 0), sum_p_z(num_steps, 0);
+
+    std::vector<double> u_prime(num_steps, 0); std::vector<double> v_prime(num_steps, 0); 
+    std::vector<double> w_prime(num_steps, 0); std::vector<double> p_prime(num_steps, 0); 
+
+    for(int index=1; index<num_steps; ++index)
+    {
+      for(int jj=0; jj<index; ++jj)
+      {
+        sum_u_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
+        sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+
+        sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
+        sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+        sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
+        sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+      }
+
+      for(int jj=0; jj<index-1; ++jj)
+      {
+        sum_p_x[index] += tm_RK_ptr->get_RK_a(index, jj) * p_x[jj];
+        sum_p_y[index] += tm_RK_ptr->get_RK_a(index, jj) * p_y[jj];
+        sum_p_z[index] += tm_RK_ptr->get_RK_a(index, jj) * p_z[jj];
+      }
+
+      u_prime[index] = -1.0 * tau_m[index] * ( rho0 * (u[index] - u_n)/dt + tm_RK_ptr->get_RK_a(index, index-1) * p_x[index-1]
+                     + rho0 * sum_u_advec[index] - vis_mu * sum_u_diffu[index] + sum_p_x[index] - rho0 * sum_a_fx[index] );
+      v_prime[index] = -1.0 * tau_m[index] * ( rho0 * (v[index] - v_n)/dt + tm_RK_ptr->get_RK_a(index, index-1) * p_y[index-1]
+                     + rho0 * sum_v_advec[index] - vis_mu * sum_v_diffu[index] + sum_p_y[index] - rho0 * sum_a_fy[index] );
+      w_prime[index] = -1.0 * tau_m[index] * ( rho0 * (w[index] - w_n)/dt + tm_RK_ptr->get_RK_a(index, index-1) * p_z[index-1]
+                     + rho0 * sum_w_advec[index] - vis_mu * sum_w_diffu[index] + sum_p_z[index] - rho0 * sum_a_fz[index] );
+      p_prime[index-1] = -1.0 * tau_c[index] * (u_x[index] + v_y[index] + w_z[index]);
+    }
+    
+    p_prime[num_steps-1] = -1.0 * tau_c_n * (u_np1_x + v_np1_y + w_np1_z);
+
+    double sum_u_pre_advec = 0.0, sum_u_pre_diffu = 0.0, sum_a_fx_pre = 0.0, sum_p_pre_x = 0;
+    double sum_v_pre_advec = 0.0, sum_v_pre_diffu = 0.0, sum_a_fy_pre = 0.0, sum_p_pre_y = 0;
+    double sum_w_pre_advec = 0.0, sum_w_pre_diffu = 0.0, sum_a_fz_pre = 0.0, sum_p_pre_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * u_pre_x[jj] + v_pre[jj] * u_pre_y[jj] + w_pre[jj] * u_pre_z[jj] );
+      sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj] + w_pre_xz[jj] + u_pre_xx[jj] + u_pre_yy[jj] + u_pre_zz[jj] );
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+  
+      sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj] + v_pre[jj] * v_pre_y[jj] + w_pre[jj] * v_pre_z[jj] );
+      sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj] + w_pre_yz[jj] + v_pre_xx[jj] + v_pre_yy[jj] + v_pre_zz[jj] );
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj] + v_pre[jj] * w_pre_y[jj] + w_pre[jj] * w_pre_z[jj] );
+      sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj] + w_pre_zz[jj] + w_pre_xx[jj] + w_pre_yy[jj] + w_pre_zz[jj] );
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_p_pre_x += tm_RK_ptr->get_RK_b(jj) * p_pre_x[jj];
+      sum_p_pre_y += tm_RK_ptr->get_RK_b(jj) * p_pre_y[jj];
+      sum_p_pre_z += tm_RK_ptr->get_RK_b(jj) * p_pre_z[jj] ;
+    }
+
+    const double u_n_prime = -1.0 * tau_m_n * ( rho0 * (u_n - u_nm1)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_pre_x[num_steps-1]
+                             + rho0 * sum_u_pre_advec - vis_mu * sum_u_pre_diffu + sum_p_pre_x - rho0 * sum_a_fx_pre ); 
+    const double v_n_prime = -1.0 * tau_m_n * ( rho0 * (v_n - v_nm1)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_pre_y[num_steps-1]
+                             + rho0 * sum_v_pre_advec - vis_mu * sum_v_pre_diffu + sum_p_pre_y - rho0 * sum_a_fy_pre );
+    const double w_n_prime = -1.0 * tau_m_n * ( rho0 * (w_n - w_nm1)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_pre_z[num_steps-1]
+                             + rho0 * sum_w_pre_advec - vis_mu * sum_w_pre_diffu + sum_p_pre_z - rho0 * sum_a_fz_pre );
+    
+    u_prime[0] = u_n_prime;
+    v_prime[0] = v_n_prime;
+    w_prime[0] = w_n_prime;
+
+    double sum_u_cur_advec = 0.0, sum_u_cur_diffu = 0.0, sum_a_fx_cur = 0.0, sum_last_p_x = 0;
+    double sum_v_cur_advec = 0.0, sum_v_cur_diffu = 0.0, sum_a_fy_cur = 0.0, sum_last_p_y = 0;
+    double sum_w_cur_advec = 0.0, sum_w_cur_diffu = 0.0, sum_a_fz_cur = 0.0, sum_last_p_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
+      sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+  
+      sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
+      sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
+      sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_last_p_x += tm_RK_ptr->get_RK_b(jj) * p_x[jj];
+      sum_last_p_y += tm_RK_ptr->get_RK_b(jj) * p_y[jj];
+      sum_last_p_z += tm_RK_ptr->get_RK_b(jj) * p_z[jj];
+    }
+
+    const double u_np1_prime = -1.0 * tau_m_n * ( rho0 * (u_np1 - u_n)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_x[num_steps-1]
+                              + rho0 * sum_u_cur_advec - vis_mu * sum_u_cur_diffu + sum_last_p_x - rho0 * sum_a_fx_cur ); 
+    const double v_np1_prime = -1.0 * tau_m_n * ( rho0 * (v_np1 - v_n)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_y[num_steps-1]
+                              + rho0 * sum_v_cur_advec - vis_mu * sum_v_cur_diffu + sum_last_p_y - rho0 * sum_a_fy_cur );
+    const double w_np1_prime = -1.0 * tau_m_n * ( rho0 * (w_np1 - w_n)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_z[num_steps-1]
+                              + rho0 * sum_w_cur_advec - vis_mu * sum_w_cur_diffu + sum_last_p_z - rho0 * sum_a_fz_cur );
+  
+    const double div_vel_np1 = u_np1_x + v_np1_y + w_np1_z;
+    
+    double u_diffu1_1 = 0.0, u_diffu1_2 = 0.0, u_diffu1_3 = 0.0;
+    double v_diffu1_1 = 0.0, v_diffu1_2 = 0.0, v_diffu1_3 = 0.0;
+    double w_diffu1_1 = 0.0, w_diffu1_2 = 0.0, w_diffu1_3 = 0.0; 
+    double u_diffu2_1 = 0.0, v_diffu2_2 = 0.0, w_diffu2_3 = 0.0;
+
+    double u_stab1_1 = 0.0, u_stab1_2 = 0.0, u_stab1_3 = 0.0;
+    double u_stab2_1 = 0.0, u_stab2_2 = 0.0, u_stab2_3 = 0.0;
+    double v_stab1_1 = 0.0, v_stab1_2 = 0.0, v_stab1_3 = 0.0;
+    double v_stab2_1 = 0.0, v_stab2_2 = 0.0, v_stab2_3 = 0.0;
+    double w_stab1_1 = 0.0, w_stab1_2 = 0.0, w_stab1_3 = 0.0;
+    double w_stab2_1 = 0.0, w_stab2_2 = 0.0, w_stab2_3 = 0.0;
+   
+    double grad_p = 0.0, grad_p_stab = 0.0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+       // Diffusion item 1
+       u_diffu1_1 += tm_RK_ptr->get_RK_b(jj) * (u_x[jj] + u_x[jj]);
+       u_diffu1_2 += tm_RK_ptr->get_RK_b(jj) * (u_y[jj] + v_x[jj]);
+       u_diffu1_3 += tm_RK_ptr->get_RK_b(jj) * (u_z[jj] + w_x[jj]);
+
+       v_diffu1_1 += tm_RK_ptr->get_RK_b(jj) * (u_y[jj] + v_x[jj]);
+       v_diffu1_2 += tm_RK_ptr->get_RK_b(jj) * (v_y[jj] + v_y[jj]);
+       v_diffu1_3 += tm_RK_ptr->get_RK_b(jj) * (w_y[jj] + v_z[jj]);
+
+       w_diffu1_1 += tm_RK_ptr->get_RK_b(jj) * (u_z[jj] + w_x[jj]);
+       w_diffu1_2 += tm_RK_ptr->get_RK_b(jj) * (v_z[jj] + w_y[jj]);
+       w_diffu1_3 += tm_RK_ptr->get_RK_b(jj) * (w_z[jj] + w_z[jj]);
+
+       // Diffusion item 2
+       u_diffu2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj];
+       v_diffu2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj];
+       w_diffu2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj];
+
+       // Cross stress term 1 + Convective term
+       u_stab1_1 += tm_RK_ptr->get_RK_b(jj) * (u[jj] + u_prime[jj]) * u_x[jj];
+       u_stab1_2 += tm_RK_ptr->get_RK_b(jj) * (v[jj] + v_prime[jj]) * u_y[jj];
+       u_stab1_3 += tm_RK_ptr->get_RK_b(jj) * (w[jj] + w_prime[jj]) * u_z[jj];
+
+       v_stab1_1 += tm_RK_ptr->get_RK_b(jj) * (u[jj] + u_prime[jj]) * v_x[jj];
+       v_stab1_2 += tm_RK_ptr->get_RK_b(jj) * (v[jj] + v_prime[jj]) * v_y[jj];
+       v_stab1_3 += tm_RK_ptr->get_RK_b(jj) * (w[jj] + w_prime[jj]) * v_z[jj];
+
+       w_stab1_1 += tm_RK_ptr->get_RK_b(jj) * (u[jj] + u_prime[jj]) * w_x[jj];
+       w_stab1_2 += tm_RK_ptr->get_RK_b(jj) * (v[jj] + v_prime[jj]) * w_y[jj];
+       w_stab1_3 += tm_RK_ptr->get_RK_b(jj) * (w[jj] + w_prime[jj]) * w_z[jj];
+
+       // Cross stress term 2 + Reynolds stress
+       u_stab2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj] * (u[jj] + u_prime[jj]);
+       u_stab2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj] * (u[jj] + u_prime[jj]);
+       u_stab2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj] * (u[jj] + u_prime[jj]);
+
+       v_stab2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj] * (v[jj] + v_prime[jj]);
+       v_stab2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj] * (v[jj] + v_prime[jj]);
+       v_stab2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj] * (v[jj] + v_prime[jj]);
+
+       w_stab2_1 += tm_RK_ptr->get_RK_b(jj) * u_prime[jj] * (w[jj] + w_prime[jj]);
+       w_stab2_2 += tm_RK_ptr->get_RK_b(jj) * v_prime[jj] * (w[jj] + w_prime[jj]);
+       w_stab2_3 += tm_RK_ptr->get_RK_b(jj) * w_prime[jj] * (w[jj] + w_prime[jj]);
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      grad_p += tm_RK_ptr->get_RK_b(jj) * p[jj];
+      grad_p_stab += tm_RK_ptr->get_RK_b(jj) * p_prime[jj];
+    }
+
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+      const double NA_xx = d2R_dxx[A], NA_yy = d2R_dyy[A], NA_zz = d2R_dzz[A];
+      const double NA_xy = d2R_dxy[A], NA_xz = d2R_dxz[A], NA_yz = d2R_dyz[A];
+
+      Residual0[  A    ] += gwts * ( NA * div_vel_np1 - NA_x * u_np1_prime - NA_y * v_np1_prime - NA_z * w_np1_prime );
+
+      Residual1[3*A + 0] += gwts * ( NA * rho0/dt * u_np1 - NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * p[num_steps-1]
+                                   + NA * rho0/dt * u_np1_prime - NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * p_prime[num_steps-1] 
+                                   - NA * rho0 * sum_a_fx_cur - NA * rho0/dt * u_n - NA * rho0/dt * u_n_prime
+                                   + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu * u_diffu1_3
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
+                                   - NA_x * grad_p - NA_x * grad_p_stab
+                                   + NA * rho0 * u_stab1_1 + NA * rho0 * u_stab1_2 + NA * rho0 * u_stab1_3 
+                                   - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
+
+      Residual1[3*A + 1] += gwts * ( NA * rho0/dt * v_np1 - NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * p[num_steps-1]
+                                   + NA * rho0/dt * v_np1_prime - NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * p_prime[num_steps-1]
+                                   - NA * rho0 * sum_a_fy_cur - NA * rho0/dt * v_n - NA * rho0/dt * v_n_prime
+                                   + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
+                                   - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
+                                   - NA_y * grad_p - NA_y * grad_p_stab
+                                   + NA * rho0 * v_stab1_1 + NA * rho0 * v_stab1_2 + NA * rho0 * v_stab1_3
+                                   - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
+
+      Residual1[3*A + 2] += gwts * ( NA * rho0/dt * w_np1 - NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * p[num_steps-1]
+                                   + NA * rho0/dt * w_np1_prime - NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * p_prime[num_steps-1]
+                                   - NA * rho0 * sum_a_fz_cur - NA * rho0/dt * w_n - NA * rho0/dt * w_n_prime
+                                   + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
+                                   - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_z * grad_p - NA_z * grad_p_stab
+                                   + NA * rho0 * w_stab1_1 + NA * rho0 * w_stab1_2 + NA * rho0 * w_stab1_3
+                                   - NA_x * rho0 * w_stab2_1 - NA_y * rho0 * w_stab2_2 - NA_z * rho0 * w_stab2_3 );
+
+      for(int B=0; B<nLocBas; ++B)
+      {
+        const double NB = R[B], NB_x = dR_dx[B], NB_y = dR_dy[B], NB_z = dR_dz[B];
+        // Continuity equation with respect to p, u, v, w
+        Tangent0[  nLocBas*A+B          ] += gwts * (NA_x * tau_m_n * tm_RK_ptr->get_RK_b(num_steps-1) * NB_x 
+                                                   + NA_y * tau_m_n * tm_RK_ptr->get_RK_b(num_steps-1) * NB_y
+                                                   + NA_z * tau_m_n * tm_RK_ptr->get_RK_b(num_steps-1) * NB_z);
+
+        Tangent1[3*nLocBas*A+3*B+0      ] += gwts * (NA * NB_x + NA_x * tau_m_n * NB * rho0/dt);
+
+        Tangent1[3*nLocBas*A+3*B+1      ] += gwts * (NA * NB_y + NA_y * tau_m_n * NB * rho0/dt);
+        
+        Tangent1[3*nLocBas*A+3*B+2      ] += gwts * (NA * NB_z + NA_z * tau_m_n * NB * rho0/dt);
+
+        // Momentum-x with respect to p, u, v, w
+        Tangent2[  nLocBas*3*A+B        ] += gwts * (-NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * NB
+                                                    - NA * rho0/dt * tau_m_n * tm_RK_ptr->get_RK_b(num_steps-1) * NB_x);
+        
+        Tangent3[3*nLocBas*3*A+3*B+0    ] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m_n * NB * rho0 /dt);
+        
+        Tangent4[3*nLocBas*3*A+3*B+0    ] += gwts * (NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_x);
+        
+        Tangent4[3*nLocBas*3*A+3*B+1    ] += gwts * (NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_y);
+      
+        Tangent4[3*nLocBas*3*A+3*B+2    ] += gwts * (NA_x * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_z);
+
+        // Momentum-y with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+1)+B    ] += gwts * (-NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * NB
+                                                    - NA * rho0/dt * tau_m_n * tm_RK_ptr->get_RK_b(num_steps-1) * NB_y);
+
+        Tangent3[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m_n * NB * rho0/dt);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+0] += gwts * (NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+2] += gwts * (NA_y * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_z );
+
+        // Momentum-z with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+2)+B    ] += gwts * (-NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * NB
+                                                    - NA * rho0/dt * tau_m_n * tm_RK_ptr->get_RK_b(num_steps-1) * NB_z);
+
+        Tangent3[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA * rho0/dt * NB - NA * rho0/dt * tau_m_n * NB * rho0/dt);   
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+0] += gwts * (NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+1] += gwts * (NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA_z * tm_RK_ptr->get_RK_b(num_steps-1) * tau_c_n * NB_z);   
+      }    
+    }
+  }
+}
+
+void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Pressure(
+    const double &time, const double &dt,
+    const ITimeMethod_RungeKutta * const &tm_RK_ptr,
+    const std::vector<double>& cur_dot_velo,
+    const std::vector<std::vector<double>>& cur_velo_sols,
+    const std::vector<double>& cur_velo,
+    const std::vector<std::vector<double>>& cur_pres_sols,
+    const std::vector<double>& pre_velo,
+    const std::vector<double>& cur_pres,
+    const double * const &eleCtrlPts_x,
+    const double * const &eleCtrlPts_y,
+    const double * const &eleCtrlPts_z )
+{
+  elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
+
+  const int num_steps = tm_RK_ptr->get_RK_step();
+
+  Zero_Tangent_Residual();
+
+  std::vector<double> R(nLocBas, 0.0), dR_dx(nLocBas, 0.0), dR_dy(nLocBas, 0.0), dR_dz(nLocBas, 0.0);
+  std::vector<double> d2R_dxx(nLocBas, 0.0), d2R_dyy(nLocBas, 0.0), d2R_dzz(nLocBas, 0.0);
+  std::vector<double> d2R_dxy(nLocBas, 0.0), d2R_dxz(nLocBas, 0.0), d2R_dyz(nLocBas, 0.0);
+
+  for(int qua=0; qua<nqpv; ++qua)
+  {
+    double u_n = 0.0, u_np1 = 0.0, u_np1_x = 0.0, u_np1_y = 0.0, u_np1_z = 0.0;
+    double v_n = 0.0, v_np1 = 0.0, v_np1_x = 0.0, v_np1_y = 0.0, v_np1_z = 0.0;
+    double w_n = 0.0, w_np1 = 0.0, w_np1_x = 0.0, w_np1_y = 0.0, w_np1_z = 0.0;
+
+    double u_np1_xx = 0.0, u_np1_yy = 0.0, u_np1_zz = 0.0;
+    double u_np1_xy = 0.0, u_np1_xz = 0.0, u_np1_yz = 0.0;
+
+    double v_np1_xx = 0.0, v_np1_yy = 0.0, v_np1_zz = 0.0;
+    double v_np1_xy = 0.0, v_np1_xz = 0.0, v_np1_yz = 0.0;
+
+    double w_np1_xx = 0.0, w_np1_yy = 0.0, w_np1_zz = 0.0;
+    double w_np1_xy = 0.0, w_np1_xz = 0.0, w_np1_yz = 0.0;
+
+    double dot_u_np1 = 0.0, dot_u_np1_x = 0.0, dot_u_np1_y = 0.0, dot_u_np1_z = 0.0;
+    double dot_v_np1 = 0.0, dot_v_np1_x = 0.0, dot_v_np1_y = 0.0, dot_v_np1_z = 0.0;
+    double dot_w_np1 = 0.0, dot_w_np1_x = 0.0, dot_w_np1_y = 0.0, dot_w_np1_z = 0.0;
+
+    double p_np1 = 0.0, p_np1_x = 0.0, p_np1_y = 0.0, p_np1_z = 0.0;
+
+    // All sub steps at the current time step
+    std::vector<double> u(num_steps, 0); std::vector<double> v(num_steps, 0); 
+    std::vector<double> w(num_steps, 0); std::vector<double> p(num_steps, 0); 
+
+    std::vector<double> u_x(num_steps, 0); std::vector<double> v_x(num_steps, 0); 
+    std::vector<double> w_x(num_steps, 0); std::vector<double> p_x(num_steps, 0); 
+
+    std::vector<double> u_y(num_steps, 0); std::vector<double> v_y(num_steps, 0); 
+    std::vector<double> w_y(num_steps, 0); std::vector<double> p_y(num_steps, 0); 
+
+    std::vector<double> u_z(num_steps, 0); std::vector<double> v_z(num_steps, 0); 
+    std::vector<double> w_z(num_steps, 0); std::vector<double> p_z(num_steps, 0); 
+
+    std::vector<double> u_xx(num_steps, 0), v_xx(num_steps, 0), w_xx(num_steps, 0); 
+    std::vector<double> u_yy(num_steps, 0), v_yy(num_steps, 0), w_yy(num_steps, 0); 
+    std::vector<double> u_zz(num_steps, 0), v_zz(num_steps, 0), w_zz(num_steps, 0); 
+
+    std::vector<double> u_xy(num_steps, 0), v_xy(num_steps, 0), w_xy(num_steps, 0); 
+    std::vector<double> u_xz(num_steps, 0), v_xz(num_steps, 0), w_xz(num_steps, 0); 
+    std::vector<double> u_yz(num_steps, 0), v_yz(num_steps, 0), w_yz(num_steps, 0);
+
+    Vector_3 coor(0.0, 0.0, 0.0);
+
+    elementv->get_3D_R_dR_d2R( qua, &R[0], &dR_dx[0], &dR_dy[0], &dR_dz[0], 
+                              &d2R_dxx[0], &d2R_dyy[0], &d2R_dzz[0],
+                              &d2R_dxy[0], &d2R_dxz[0], &d2R_dyz[0] );
+
+    for(int ii=0; ii<nLocBas; ++ii)
+    {
+      const int ii3 = 3 * ii;
+
+      u_n += pre_velo[ii3+0] * R[ii];
+      v_n += pre_velo[ii3+1] * R[ii];
+      w_n += pre_velo[ii3+2] * R[ii];
+
+      u_np1 += cur_velo[ii3+0] * R[ii];
+      v_np1 += cur_velo[ii3+1] * R[ii];
+      w_np1 += cur_velo[ii3+2] * R[ii];
+
+      p_np1_x += cur_pres[ii] * dR_dx[ii];
+      p_np1_y += cur_pres[ii] * dR_dy[ii];
+      p_np1_z += cur_pres[ii] * dR_dz[ii];     
+      p_np1   += cur_pres[ii] * R[ii];
+
+      u_np1_x += cur_velo[ii3+0] * dR_dx[ii];
+      u_np1_y += cur_velo[ii3+0] * dR_dy[ii];
+      u_np1_z += cur_velo[ii3+0] * dR_dz[ii];
+
+      v_np1_x += cur_velo[ii3+1] * dR_dx[ii];
+      v_np1_y += cur_velo[ii3+1] * dR_dy[ii];
+      v_np1_z += cur_velo[ii3+1] * dR_dz[ii];
+      
+      w_np1_x += cur_velo[ii3+2] * dR_dx[ii];     
+      w_np1_y += cur_velo[ii3+2] * dR_dy[ii];
+      w_np1_z += cur_velo[ii3+2] * dR_dz[ii];
+
+      u_np1_xx += cur_velo[ii3+0] * d2R_dxx[ii];
+      u_np1_yy += cur_velo[ii3+0] * d2R_dyy[ii];
+      u_np1_zz += cur_velo[ii3+0] * d2R_dzz[ii];
+      u_np1_xz += cur_velo[ii3+0] * d2R_dxz[ii];
+      u_np1_xy += cur_velo[ii3+0] * d2R_dxy[ii];
+      u_np1_yz += cur_velo[ii3+0] * d2R_dyz[ii];
+
+      v_np1_xx += cur_velo[ii3+1] * d2R_dxx[ii];
+      v_np1_yy += cur_velo[ii3+1] * d2R_dyy[ii];
+      v_np1_zz += cur_velo[ii3+1] * d2R_dzz[ii];
+      v_np1_xz += cur_velo[ii3+1] * d2R_dxz[ii];
+      v_np1_xy += cur_velo[ii3+1] * d2R_dxy[ii];
+      v_np1_yz += cur_velo[ii3+1] * d2R_dyz[ii];
+
+      w_np1_xx += cur_velo[ii3+2] * d2R_dxx[ii];
+      w_np1_yy += cur_velo[ii3+2] * d2R_dyy[ii];
+      w_np1_zz += cur_velo[ii3+2] * d2R_dzz[ii];
+      w_np1_xz += cur_velo[ii3+2] * d2R_dxz[ii];
+      w_np1_xy += cur_velo[ii3+2] * d2R_dxy[ii];
+      w_np1_yz += cur_velo[ii3+2] * d2R_dyz[ii];      
+
+      dot_u_np1 += cur_dot_velo[ii3+0] * R[ii];
+      dot_v_np1 += cur_dot_velo[ii3+1] * R[ii];
+      dot_w_np1 += cur_dot_velo[ii3+2] * R[ii];
+
+      dot_u_np1_x += cur_dot_velo[ii3+0] * dR_dx[ii];
+      dot_u_np1_y += cur_dot_velo[ii3+0] * dR_dy[ii];
+      dot_u_np1_z += cur_dot_velo[ii3+0] * dR_dz[ii];
+
+      dot_v_np1_x += cur_dot_velo[ii3+1] * dR_dx[ii];
+      dot_v_np1_y += cur_dot_velo[ii3+1] * dR_dy[ii];
+      dot_v_np1_z += cur_dot_velo[ii3+1] * dR_dz[ii];
+      
+      dot_w_np1_x += cur_dot_velo[ii3+2] * dR_dx[ii];     
+      dot_w_np1_y += cur_dot_velo[ii3+2] * dR_dy[ii];
+      dot_w_np1_z += cur_dot_velo[ii3+2] * dR_dz[ii];
+
+      coor.x() += eleCtrlPts_x[ii] * R[ii];
+      coor.y() += eleCtrlPts_y[ii] * R[ii];
+      coor.z() += eleCtrlPts_z[ii] * R[ii];
+    }
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      for(int ii=0; ii<nLocBas; ++ii)
+      {
+        const int ii3 = 3 * ii;
+
+        u[jj] += cur_velo_sols[jj][ii3+0] * R[ii];
+        v[jj] += cur_velo_sols[jj][ii3+1] * R[ii];
+        w[jj] += cur_velo_sols[jj][ii3+2] * R[ii];
+        p[jj] += cur_pres_sols[jj][ii]    * R[ii];
+
+        u_x[jj] += cur_velo_sols[jj][ii3+0] * dR_dx[ii];
+        v_x[jj] += cur_velo_sols[jj][ii3+1] * dR_dx[ii];
+        w_x[jj] += cur_velo_sols[jj][ii3+2] * dR_dx[ii];
+        p_x[jj] += cur_pres_sols[jj][ii]    * dR_dx[ii];
+
+        u_y[jj] += cur_velo_sols[jj][ii3+0] * dR_dy[ii];
+        v_y[jj] += cur_velo_sols[jj][ii3+1] * dR_dy[ii];
+        w_y[jj] += cur_velo_sols[jj][ii3+2] * dR_dy[ii];
+        p_y[jj] += cur_pres_sols[jj][ii]    * dR_dy[ii];
+
+        u_z[jj] += cur_velo_sols[jj][ii3+0] * dR_dz[ii];
+        v_z[jj] += cur_velo_sols[jj][ii3+1] * dR_dz[ii];
+        w_z[jj] += cur_velo_sols[jj][ii3+2] * dR_dz[ii];
+        p_z[jj] += cur_pres_sols[jj][ii]    * dR_dz[ii];
+
+        u_xx[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxx[ii];
+        u_yy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyy[ii];
+        u_zz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dzz[ii];
+        u_xz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxz[ii];
+        u_xy[jj] += cur_velo_sols[jj][ii3+0] * d2R_dxy[ii];
+        u_yz[jj] += cur_velo_sols[jj][ii3+0] * d2R_dyz[ii];
+
+        v_xx[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxx[ii];
+        v_yy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyy[ii];
+        v_zz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dzz[ii];
+        v_xz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxz[ii];
+        v_xy[jj] += cur_velo_sols[jj][ii3+1] * d2R_dxy[ii];
+        v_yz[jj] += cur_velo_sols[jj][ii3+1] * d2R_dyz[ii];
+
+        w_xx[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxx[ii];
+        w_yy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyy[ii];
+        w_zz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dzz[ii];
+        w_xz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxz[ii];
+        w_xy[jj] += cur_velo_sols[jj][ii3+2] * d2R_dxy[ii];
+        w_yz[jj] += cur_velo_sols[jj][ii3+2] * d2R_dyz[ii];
+      }
+    }
+
+    const auto dxi_dx = elementv->get_invJacobian(qua);
+
+    const std::array<double, 2> tau_np1_dot = get_tau_dot( dt, dxi_dx, u_np1, v_np1, w_np1 );
+    const double tau_m = tau_np1_dot[0];
+    const double tau_c = tau_np1_dot[1];
+
+    const std::array<double, 2> tau_n = get_tau( dt, dxi_dx, u_n, v_n, w_n );
+    const double tau_m_n = tau_n[0];
+
+    const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
+
+    double sum_u_cur_advec = 0.0, sum_u_cur_diffu = 0.0, sum_a_fx_cur = 0.0, sum_last_p_x = 0;
+    double sum_v_cur_advec = 0.0, sum_v_cur_diffu = 0.0, sum_a_fy_cur = 0.0, sum_last_p_y = 0;
+    double sum_w_cur_advec = 0.0, sum_w_cur_diffu = 0.0, sum_a_fz_cur = 0.0, sum_last_p_z = 0;
+
+    for(int jj=0; jj<num_steps; ++jj)
+    {
+      sum_u_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
+      sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+  
+      sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
+      sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+
+      sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
+      sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+    }
+
+    for(int jj=0; jj<num_steps-1; ++jj)
+    {
+      sum_last_p_x += tm_RK_ptr->get_RK_b(jj) * p_x[jj];
+      sum_last_p_y += tm_RK_ptr->get_RK_b(jj) * p_y[jj];
+      sum_last_p_z += tm_RK_ptr->get_RK_b(jj) * p_z[jj];
+    }
+
+    const double u_np1_prime = -1.0 * tau_m_n * ( rho0 * (u_np1 - u_n)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_x[num_steps-1] 
+                             + rho0 * sum_u_cur_advec - vis_mu * sum_u_cur_diffu + sum_last_p_x - rho0 * sum_a_fx_cur ); 
+    const double v_np1_prime = -1.0 * tau_m_n * ( rho0 * (v_np1 - v_n)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_y[num_steps-1]
+                             + rho0 * sum_v_cur_advec - vis_mu * sum_v_cur_diffu + sum_last_p_y - rho0 * sum_a_fy_cur );
+    const double w_np1_prime = -1.0 * tau_m_n * ( rho0 * (w_np1 - w_n)/dt + tm_RK_ptr->get_RK_b(num_steps-1) * p_z[num_steps-1]
+                             + rho0 * sum_w_cur_advec - vis_mu * sum_w_cur_diffu + sum_last_p_z - rho0 * sum_a_fz_cur );
+
+    const double u_np1_adevc = u_np1 * u_np1_x + v_np1 * u_np1_y + w_np1 * u_np1_z;
+    const double u_np1_diffu = u_np1_xx + v_np1_xy + w_np1_xz + u_np1_xx + u_np1_yy + u_np1_zz;
+
+    const double v_np1_adevc = u_np1 * v_np1_x + v_np1 * v_np1_y + w_np1 * v_np1_z;
+    const double v_np1_diffu = u_np1_xy + v_np1_yy + w_np1_yz + v_np1_xx + v_np1_yy + v_np1_zz;
+
+    const double w_np1_adevc = u_np1 * w_np1_x + v_np1 * w_np1_y + w_np1 * w_np1_z;
+    const double w_np1_diffu = u_np1_xz + v_np1_yz + w_np1_zz + w_np1_xx + w_np1_yy + w_np1_zz;
+
+    const double dot_u_np1_prime = -1.0 * tau_m * ( rho0 * dot_u_np1 +  p_np1_x + rho0 * u_np1_adevc 
+                                        - vis_mu * u_np1_diffu - rho0 * get_f( coor, time + dt ).x() );
+    const double dot_v_np1_prime = -1.0 * tau_m * ( rho0 * dot_v_np1 +  p_np1_y + rho0 * v_np1_adevc
+                                        - vis_mu * v_np1_diffu - rho0 * get_f( coor, time + dt ).y() );
+    const double dot_w_np1_prime = -1.0 * tau_m * ( rho0 * dot_w_np1 +  p_np1_z + rho0 * w_np1_adevc
+                                        - vis_mu * w_np1_diffu - rho0 * get_f( coor, time + dt ).z() );    
+
+    const double div_dot_vel_np1 = dot_u_np1_x + dot_v_np1_y + dot_w_np1_z;
+    const double p_np1_prime = -1.0 * tau_c * div_dot_vel_np1;
+
+    // Diffusion item 1
+    const double u_diffu1_1 = u_np1_x + u_np1_x;
+    const double u_diffu1_2 = u_np1_y + v_np1_x;
+    const double u_diffu1_3 = u_np1_z + w_np1_x;
+
+    const double v_diffu1_1 = u_np1_y + v_np1_x;
+    const double v_diffu1_2 = v_np1_y + v_np1_y;
+    const double v_diffu1_3 = w_np1_y + v_np1_z;
+
+    const double w_diffu1_1 = u_np1_z + w_np1_x;
+    const double w_diffu1_2 = v_np1_z + w_np1_y;
+    const double w_diffu1_3 = w_np1_z + w_np1_z;
+
+    // Diffusion item 2
+    const double u_diffu2_1 = u_np1_prime;
+    const double v_diffu2_2 = v_np1_prime;
+    const double w_diffu2_3 = w_np1_prime;
+
+    // Cross stress term 1 + Convective term
+    const double u_stab1_1 = (u_np1 + u_np1_prime) * u_np1_x;
+    const double u_stab1_2 = (v_np1 + v_np1_prime) * u_np1_y;
+    const double u_stab1_3 = (w_np1 + w_np1_prime) * u_np1_z;
+
+    const double v_stab1_1 = (u_np1 + u_np1_prime) * v_np1_x;
+    const double v_stab1_2 = (v_np1 + v_np1_prime) * v_np1_y;
+    const double v_stab1_3 = (w_np1 + w_np1_prime) * v_np1_z;
+
+    const double w_stab1_1 = (u_np1 + u_np1_prime) * w_np1_x;
+    const double w_stab1_2 = (v_np1 + v_np1_prime) * w_np1_y;
+    const double w_stab1_3 = (w_np1 + w_np1_prime) * w_np1_z;
+
+    // Cross stress term 2 + Reynolds stress
+    const double u_stab2_1 = u_np1_prime * (u_np1 + u_np1_prime);
+    const double u_stab2_2 = v_np1_prime * (u_np1 + u_np1_prime);
+    const double u_stab2_3 = w_np1_prime * (u_np1 + u_np1_prime);
+
+    const double v_stab2_1 = u_np1_prime * (v_np1 + v_np1_prime);
+    const double v_stab2_2 = v_np1_prime * (v_np1 + v_np1_prime);
+    const double v_stab2_3 = w_np1_prime * (v_np1 + v_np1_prime);
+
+    const double w_stab2_1 = u_np1_prime * (w_np1 + w_np1_prime);
+    const double w_stab2_2 = v_np1_prime * (w_np1 + w_np1_prime);
+    const double w_stab2_3 = w_np1_prime * (w_np1 + w_np1_prime);
+
+    for(int A=0; A<nLocBas; ++A)
+    {
+      const double NA = R[A], NA_x = dR_dx[A], NA_y = dR_dy[A], NA_z = dR_dz[A];
+      const double NA_xx = d2R_dxx[A], NA_yy = d2R_dyy[A], NA_zz = d2R_dzz[A];
+      const double NA_xy = d2R_dxy[A], NA_xz = d2R_dxz[A], NA_yz = d2R_dyz[A];
+
+      Residual0[ A     ] += gwts * ( NA * div_dot_vel_np1 - NA_x * dot_u_np1_prime - NA_y * dot_v_np1_prime - NA_z * dot_w_np1_prime );
+
+      Residual1[3*A + 0] += gwts * ( NA * rho0 * dot_u_np1 - NA_x * p_np1 + NA * rho0 * dot_u_np1_prime 
+                                   - NA_x * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).x() 
+                                   + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu *  u_diffu1_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
+                                   - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
+                                   + NA * rho0 * u_stab1_1 + NA * rho0 * u_stab1_2 + NA * rho0 * u_stab1_3 
+                                   - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
+
+      Residual1[3*A + 1] += gwts * ( NA * rho0 * dot_v_np1 - NA_y * p_np1 + NA * rho0 * dot_v_np1_prime 
+                                   - NA_y * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).y() 
+                                   + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
+                                   - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
+                                   + NA * rho0 * v_stab1_1 + NA * rho0 * v_stab1_2 + NA * rho0 * v_stab1_3
+                                   - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
+
+      Residual1[3*A + 2] += gwts * ( NA * rho0 * dot_w_np1 - NA_z * p_np1+ NA * rho0 * dot_w_np1_prime
+                                   - NA_z * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).z()
+                                   + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
+                                   - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
+                                   - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
+                                   + NA * rho0 * w_stab1_1 + NA * rho0 * w_stab1_2 + NA * rho0 * w_stab1_3
+                                   - NA_x * rho0 * w_stab2_1 - NA_y * rho0 * w_stab2_2 - NA_z * rho0 * w_stab2_3 );
+
+      for(int B=0; B<nLocBas; ++B)
+      {
+        const double NB = R[B], NB_x = dR_dx[B], NB_y = dR_dy[B], NB_z = dR_dz[B];
+        // Continuity equation with respect to p, u, v, w
+        Tangent0[  nLocBas*A+B         ] += gwts * (NA_x * tau_m * NB_x + NA_y * tau_m * NB_y + NA_z * tau_m * NB_z);
+    
+        Tangent1[3*nLocBas*A+3*B+0     ] += gwts * (NA * NB_x + NA_x * tau_m * NB * rho0);
+
+        Tangent1[3*nLocBas*A+3*B+1     ] += gwts * (NA * NB_y + NA_y * tau_m * NB * rho0);
+        
+        Tangent1[3*nLocBas*A+3*B+2     ] += gwts * (NA * NB_z + NA_z * tau_m * NB * rho0);
+
+        // Momentum-x with respect to p, u, v, w
+        Tangent2[  nLocBas*3*A+B       ] += gwts * (-NA_x * NB - NA * rho0 * tau_m * NB_x);
+        
+        Tangent3[3*nLocBas*3*A+3*B+0   ] += gwts * (NA * rho0 * NB - NA * rho0 * tau_m * NB * rho0);
+        
+        Tangent4[3*nLocBas*3*A+3*B+0   ] += gwts * (NA_x * tau_c * NB_x);
+        
+        Tangent4[3*nLocBas*3*A+3*B+1   ] += gwts * (NA_x * tau_c * NB_y);
+      
+        Tangent4[3*nLocBas*3*A+3*B+2   ] += gwts * (NA_x * tau_c * NB_z);
+
+        // Momentum-y with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+1)+B    ] += gwts * (-NA_y *  NB - NA * rho0 * tau_m * NB_y);
+
+        Tangent3[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA * rho0 * NB - NA * rho0 * tau_m * NB * rho0);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+0] += gwts * (NA_y * tau_c * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+1] += gwts * (NA_y * tau_c * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+1)+3*B+2] += gwts * (NA_y * tau_c * NB_z);
+
+        // Momentum-z with repspect to p, u, v, w
+        Tangent2[  nLocBas*(3*A+2)+B    ] += gwts * (-NA_z * NB - NA * rho0 * tau_m * NB_z);
+
+        Tangent3[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA * rho0 * NB - NA * rho0 * tau_m * NB * rho0);   
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+0] += gwts * (NA_z * tau_c * NB_x);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+1] += gwts * (NA_z * tau_c * NB_y);
+
+        Tangent4[3*nLocBas*(3*A+2)+3*B+2] += gwts * (NA_z * tau_c * NB_z); 
+      }
+    }
+  }
+}
+
+// EOF

--- a/examples/ns/src/PTime_NS_HERK_Solver.cpp
+++ b/examples/ns/src/PTime_NS_HERK_Solver.cpp
@@ -1,0 +1,455 @@
+#include "PTime_NS_HERK_Solver.hpp"
+
+PTime_NS_HERK_Solver::PTime_NS_HERK_Solver(
+    std::unique_ptr<PGAssem_Block_NS_FEM_HERK> in_gassem,
+    std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
+    std::unique_ptr<Matrix_PETSc> in_bc_mat,
+    std::unique_ptr<ITimeMethod_RungeKutta> in_tmRK,
+    std::unique_ptr<IFlowRate> in_flrate,
+    std::unique_ptr<IFlowRate> in_dot_flrate,
+    std::unique_ptr<PDNSolution> in_sol_base,
+    std::unique_ptr<ALocal_InflowBC> in_infnbc, 
+    const std::string &input_name, const int &in_nlocalnode,
+    const int &input_record_freq, const double &input_final_time )
+: final_time(input_final_time), sol_record_freq(input_record_freq),
+  pb_name(input_name), nlocalnode(in_nlocalnode), gassem(std::move(in_gassem)), 
+  lsolver(std::move(in_lsolver)), bc_mat(std::move(in_bc_mat)), 
+  tmRK(std::move(in_tmRK)), flrate(std::move(in_flrate)), 
+  dot_flrate(std::move(in_dot_flrate)), sol_base(std::move(in_sol_base)),
+  infnbc(std::move(in_infnbc))
+{}
+
+std::string PTime_NS_HERK_Solver::Name_Generator(const int &counter) const
+{
+  return pb_name + std::to_string(900000000 + counter);
+}
+
+void PTime_NS_HERK_Solver::print_info() const
+{
+  SYS_T::commPrint("----------------------------------------------------------- \n");
+  SYS_T::commPrint("Time stepping solver setted up:\n");
+  SYS_T::commPrint("  final time: %e \n", final_time);
+  SYS_T::commPrint("  solution record frequency : %d \n", sol_record_freq);
+  SYS_T::commPrint("  solution base name: %s \n", pb_name.c_str());
+  SYS_T::commPrint("----------------------------------------------------------- \n");
+}
+
+void PTime_NS_HERK_Solver::Write_restart_file(const PDNTimeStep * const &timeinfo,
+    const std::string &solname ) const
+{
+  std::ofstream restart_file("restart_file.txt", std::ofstream::out | std::ofstream::trunc);
+  if( restart_file.is_open() )
+  {
+    restart_file<<timeinfo->get_index()<<std::endl;
+    restart_file<<timeinfo->get_time()<<std::endl;
+    restart_file<<timeinfo->get_step()<<std::endl;
+    restart_file<<solname.c_str()<<std::endl;
+    restart_file.close();
+  }
+  else
+    SYS_T::print_fatal("Error: PTimeSolver cannot open restart_file.txt");
+}
+
+void PTime_NS_HERK_Solver::TM_NS_HERK(
+    const bool &restart_init_assembly_flag, 
+    std::unique_ptr<PDNSolution> init_sol,
+    std::unique_ptr<PDNSolution> init_velo,
+    std::unique_ptr<PDNSolution> init_dot_velo,
+    std::unique_ptr<PDNSolution> init_pres,
+    std::unique_ptr<PDNTimeStep> time_info ) const
+{
+  // Make initial velo and pres compatible with initial sol
+  Update_init_pressure_velocity(init_velo.get(), init_pres.get(), init_sol.get());
+
+  const int ss = tmRK->get_RK_step();
+
+  // The velo solutions in each sub-step at the (n+1)-th time step
+  PDNSolution** cur_velo_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    cur_velo_sols[ii] = new PDNSolution(*init_velo);
+
+  // The velo solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_velo = new PDNSolution(*init_velo);
+  
+  // The dot_velo solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_dot_velo = new PDNSolution(*init_dot_velo);
+
+  // The pres solutions in each sub-step at the (n+1)-th time step
+  PDNSolution** cur_pres_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    cur_pres_sols[ii] = new PDNSolution(*init_pres);
+
+  // The pres solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_pres = new PDNSolution(*init_pres);
+
+  // The solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_sol = new PDNSolution(*init_sol);
+
+  // The velo solutions in each sub-step at the n-th time step
+  PDNSolution** pre_velo_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    pre_velo_sols[ii] = new PDNSolution(*init_velo);
+
+  // The pres solutions in each sub-step at the n-th time step
+  PDNSolution** pre_pres_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    pre_pres_sols[ii] = new PDNSolution(*init_pres);    
+
+  // The velo solution in the final step at the n-th time step
+  PDNSolution * pre_velo = new PDNSolution(*init_velo);
+
+  // The pres solution in the final step at the n-th time step
+  PDNSolution * pre_pres = new PDNSolution(*init_pres);
+
+  // The velo solution in the final step at the (n-1)-th time step
+  PDNSolution * pre_velo_before = new PDNSolution(*init_velo);
+
+  // If this is a restart run, do not re-write the solution binaries
+  if(restart_init_assembly_flag == false)
+  {
+    const auto sol_name = Name_Generator(time_info->get_index());
+    cur_sol->WriteBinary(sol_name);
+  }
+
+  SYS_T::commPrint("Time = %e, dt = %e, index = %d, %s \n",
+      time_info->get_time(), time_info->get_step(), time_info->get_index(),
+      SYS_T::get_time().c_str());
+
+  while (time_info->get_time() < final_time)
+  {   
+    HERK_Solve_NS(
+        time_info->get_time(), time_info->get_step(),
+        cur_velo_sols, cur_velo, cur_dot_velo,
+        cur_pres_sols, cur_pres, pre_velo_sols, pre_velo,
+        pre_pres_sols, pre_pres, pre_velo_before, cur_sol );
+
+    // Update the time step information
+    time_info->TimeIncrement();
+
+    SYS_T::commPrint("Time = %e, dt = %e, index = %d, %s \n",
+        time_info->get_time(), time_info->get_step(), time_info->get_index(),
+        SYS_T::get_time().c_str());
+
+    // Record solution if meets criteria
+    if( time_info->get_index()%sol_record_freq == 0 )
+    {
+      const auto sol_name = Name_Generator( time_info->get_index() );
+      cur_sol->WriteBinary(sol_name);
+    }
+
+    // Prepare for next time step
+    pre_velo_before->Copy(pre_velo);
+    pre_velo->Copy(cur_velo);
+    pre_pres->Copy(cur_pres);
+
+    for(int ii = 0; ii < ss; ++ii)
+    {
+      pre_velo_sols[ii]->Copy(cur_velo_sols[ii]);
+      pre_pres_sols[ii]->Copy(cur_pres_sols[ii]);
+    }  
+  }
+
+  for (int ii = 0; ii < ss; ++ii) 
+  {
+    delete cur_velo_sols[ii]; delete pre_velo_sols[ii]; 
+    delete cur_pres_sols[ii]; delete pre_pres_sols[ii];
+  }
+  delete[] cur_velo_sols; delete[] pre_velo_sols; delete[] cur_pres_sols; delete[] pre_pres_sols;
+  delete cur_velo; delete cur_dot_velo; delete cur_pres; delete cur_sol; 
+  delete pre_velo; delete pre_pres; delete pre_velo_before;
+}
+
+void PTime_NS_HERK_Solver::HERK_Solve_NS(
+    const double &curr_time, const double &dt,
+    PDNSolution ** const &cur_velo_sols,
+    PDNSolution * const &cur_velo,
+    PDNSolution * const &cur_dot_velo,
+    PDNSolution ** const &cur_pres_sols,
+    PDNSolution * const &cur_pres,
+    PDNSolution ** const &pre_velo_sols,
+    PDNSolution * const &pre_velo,
+    PDNSolution ** const &pre_pres_sols,
+    PDNSolution * const &pre_pres,
+    PDNSolution * const &pre_velo_before,
+    PDNSolution * const &cur_sol ) const
+{
+  #ifdef PETSC_USE_LOG
+    PetscLogEvent K_solve, update_dotstep;
+    PetscClassId classid_solve;
+    PetscClassIdRegister("matsolve", &classid_solve);
+    PetscLogEventRegister("K_solve", classid_solve, &K_solve);
+    PetscLogEventRegister("update_dotstep", classid_solve, &update_dotstep);
+  #endif
+
+  auto dot_step = SYS_T::make_unique<PDNSolution>( cur_sol );
+
+  // HERK's number of steps
+  const int ss = tmRK->get_RK_step();
+  
+  // The first sub-step, u_1 = u_n
+  cur_velo_sols[0] -> Copy(*pre_velo);
+    
+  SYS_T::commPrint(" ==> Start solving the SubStep -- substep = 1 is solved. \n");
+  
+  // Sub-step (starting from the second sub-step)
+  for(int ii = 1; ii < ss; ++ii)
+  {
+    // Make the velo in each sub step meet the Dirchlet boundary
+    rescale_inflow_velo(curr_time + tmRK->get_RK_c(ii) * dt, flrate.get(), cur_velo_sols[ii]);
+  
+    gassem->Clear_G();  // K uses Matrix-free
+     
+    gassem->Assem_residual_substep( ii, cur_velo_sols, cur_pres_sols,
+      pre_velo_sols, pre_velo, pre_pres_sols, pre_velo_before, tmRK.get(), 
+      curr_time, dt );     
+    
+    gassem->Update_tangent_alpha_RK( tmRK->get_RK_a(ii, ii-1) );
+   
+    Vec sol_vp;
+    VecDuplicate( gassem->G, &sol_vp );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(K_solve, 0,0,0,0);
+  #endif    
+    lsolver->Solve( gassem->G, sol_vp ); 
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(K_solve,0,0,0,0);
+  #endif
+
+  #ifdef PETSC_USE_LOG
+  PetscLogEventBegin(update_dotstep, 0,0,0,0);
+  #endif 
+    Update_dot_step( sol_vp, dot_step.get() );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(update_dotstep, 0,0,0,0);
+  #endif
+
+    bc_mat->MatMultSol( dot_step.get() );
+  
+    SYS_T::commPrint(" --- substep = %d is solved. \n", ii+1);
+  
+    Update_pressure_velocity(cur_velo_sols[ii], cur_pres_sols[ii-1], dot_step.get());
+
+    VecDestroy( &sol_vp );
+  }
+    // Final step
+    SYS_T::commPrint(" ==> Start solving the FinalStep: \n");
+  
+    // Make the velo in the last step meet the Dirchlet boundary
+    rescale_inflow_velo(curr_time + dt, flrate.get(), cur_velo);
+  
+    gassem->Clear_G();
+  
+    gassem->Assem_residual_finalstep( cur_velo_sols, cur_velo, 
+      cur_pres_sols, pre_velo_sols, pre_velo, pre_pres_sols, pre_velo_before,
+      tmRK.get(), curr_time, dt );
+
+    gassem->Update_tangent_alpha_RK( tmRK->get_RK_b(ss-1) );
+
+    Vec sol_vp;
+    VecDuplicate( gassem->G, &sol_vp );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(K_solve, 0,0,0,0);
+  #endif 
+    lsolver->Solve( gassem->G, sol_vp ); 
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(K_solve,0,0,0,0);
+  #endif
+
+  #ifdef PETSC_USE_LOG
+  PetscLogEventBegin(update_dotstep, 0,0,0,0);
+  #endif 
+    Update_dot_step( sol_vp, dot_step.get() );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(update_dotstep, 0,0,0,0);
+  #endif
+  
+    bc_mat->MatMultSol( dot_step.get() );
+  
+    SYS_T::commPrint(" --- finalstep is solved. \n");
+  
+    Update_pressure_velocity(cur_velo, cur_pres_sols[ss-1], dot_step.get());
+    
+    // Assemble velo and pres at the (n+1)-th time step into a solution vector
+    Update_solutions(cur_velo, cur_pres, cur_sol);
+    VecDestroy( &sol_vp );
+}
+
+void PTime_NS_HERK_Solver::rescale_inflow_velo( const double &stime,
+    const IFlowRate * const &flowrate, PDNSolution * const &velo ) const
+{
+  const int num_nbc = infnbc -> get_num_nbc();
+
+  for(int nbc_id=0; nbc_id<num_nbc; ++nbc_id)
+  {
+    const int numnode = infnbc -> get_Num_LD( nbc_id );
+
+    const double factor  = flowrate -> get_flow_rate( nbc_id, stime );
+    const double std_dev = flowrate -> get_flow_TI_std_dev( nbc_id );
+
+    for(int ii=0; ii<numnode; ++ii)
+    {
+      const int node_index = infnbc -> get_LDN( nbc_id, ii );
+      
+      const int base_idx[3] = { node_index*4+1, node_index*4+2, node_index*4+3 };
+
+      double base_vals[3];
+
+      VecGetValues(sol_base->solution, 3, base_idx, base_vals);
+
+      const double perturb_x = MATH_T::gen_double_rand_normal(0, std_dev);
+      const double perturb_y = MATH_T::gen_double_rand_normal(0, std_dev);
+      const double perturb_z = MATH_T::gen_double_rand_normal(0, std_dev);
+
+      const double vals[3] = { base_vals[0] * factor * (1.0 + perturb_x), 
+        base_vals[1] * factor * (1.0 + perturb_y),
+        base_vals[2] * factor * (1.0 + perturb_z) };
+
+      const int velo_idx[3] = { node_index*3, node_index*3+1, node_index*3+2 };
+
+      VecSetValues(velo->solution, 3, velo_idx, vals, INSERT_VALUES);
+    }
+  }
+
+  velo->Assembly_GhostUpdate();
+}
+
+// Please make sure the Vec vp is VecNest before using the function
+void PTime_NS_HERK_Solver::Update_dot_step(     
+  const Vec &vp, PDNSolution * const &step) const
+{
+  Vec lstep, v, p;
+  VecNestGetSubVec(vp, 0, &v);
+  VecNestGetSubVec(vp, 1, &p);
+  VecGhostGetLocalForm(step->solution, &lstep);
+
+  double * array_step, * array_v, * array_p;
+  VecGetArray(lstep, &array_step);
+
+  VecGetArray(v, &array_v);
+  VecGetArray(p, &array_p);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_step[ii*4 + 0] = array_p[ii];
+    array_step[ii*4 + 1] = array_v[ii*3 + 0];
+    array_step[ii*4 + 2] = array_v[ii*3 + 1];
+    array_step[ii*4 + 3] = array_v[ii*3 + 2];
+  }
+
+  VecRestoreArray(v, &array_v);
+  VecRestoreArray(p, &array_p);
+  VecRestoreArray(lstep, &array_step);
+
+  VecGhostRestoreLocalForm(step->solution, &lstep);
+  
+  step->GhostUpdate();
+}
+
+void PTime_NS_HERK_Solver::Update_pressure_velocity(     
+    PDNSolution * const &velo,
+    PDNSolution * const &pres,
+    const PDNSolution * const &step) const
+{
+  Vec lvelo, lpres, lstep;
+  double * array_velo, * array_pres, * array_step;
+
+  VecGhostGetLocalForm(velo->solution, &lvelo);    
+  VecGhostGetLocalForm(pres->solution, &lpres);    
+  VecGhostGetLocalForm(step->solution, &lstep);
+
+  VecGetArray(lvelo, &array_velo);
+  VecGetArray(lpres, &array_pres); 
+  VecGetArray(lstep, &array_step);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_pres[ii       ] -= array_step[ii*4 + 0];
+    array_velo[ii*3 + 0 ] -= array_step[ii*4 + 1];
+    array_velo[ii*3 + 1 ] -= array_step[ii*4 + 2];
+    array_velo[ii*3 + 2 ] -= array_step[ii*4 + 3];
+  }
+
+  VecRestoreArray(lvelo, &array_velo);    
+  VecRestoreArray(lpres, &array_pres);
+  VecRestoreArray(lstep, &array_step);
+  
+  VecGhostRestoreLocalForm(velo->solution, &lvelo);
+  VecGhostRestoreLocalForm(pres->solution, &lpres);
+  VecGhostRestoreLocalForm(step->solution, &lstep);
+
+  velo->GhostUpdate();
+  pres->GhostUpdate();  
+}
+
+void PTime_NS_HERK_Solver::Update_init_pressure_velocity(     
+    PDNSolution * const &velo,
+    PDNSolution * const &pres,
+    const PDNSolution * const &sol) const
+{
+  Vec lvelo, lpres, lsol;
+  double * array_velo, * array_pres, * array_sol;
+
+  VecGhostGetLocalForm(velo->solution, &lvelo);    
+  VecGhostGetLocalForm(pres->solution, &lpres);    
+  VecGhostGetLocalForm(sol->solution, &lsol);
+
+  VecGetArray(lvelo, &array_velo);
+  VecGetArray(lpres, &array_pres); 
+  VecGetArray(lsol, &array_sol);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_pres[ii       ] = array_sol[ii*4 + 0];
+    array_velo[ii*3 + 0 ] = array_sol[ii*4 + 1];
+    array_velo[ii*3 + 1 ] = array_sol[ii*4 + 2];
+    array_velo[ii*3 + 2 ] = array_sol[ii*4 + 3];
+  }
+
+  VecRestoreArray(lvelo, &array_velo);    
+  VecRestoreArray(lpres, &array_pres);
+  VecRestoreArray(lsol, &array_sol);
+  
+  VecGhostRestoreLocalForm(velo->solution, &lvelo);
+  VecGhostRestoreLocalForm(pres->solution, &lpres);
+  VecGhostRestoreLocalForm(sol->solution, &lsol);
+
+  velo->GhostUpdate();
+  pres->GhostUpdate();  
+}
+
+void PTime_NS_HERK_Solver::Update_solutions(     
+    const PDNSolution * const &velo,
+    const PDNSolution * const &pres,
+    PDNSolution * const &sol) const
+{
+  Vec lvelo, lpres, lsol;
+  double * array_velo, * array_pres, * array_sol;
+
+  VecGhostGetLocalForm(velo->solution, &lvelo);    
+  VecGhostGetLocalForm(pres->solution, &lpres);    
+  VecGhostGetLocalForm(sol->solution, &lsol);
+
+  VecGetArray(lvelo, &array_velo);
+  VecGetArray(lpres, &array_pres); 
+  VecGetArray(lsol, &array_sol);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_sol[ii*4 + 0] = array_pres[ii       ];
+    array_sol[ii*4 + 1] = array_velo[ii*3 + 0 ];
+    array_sol[ii*4 + 2] = array_velo[ii*3 + 1 ];
+    array_sol[ii*4 + 3] = array_velo[ii*3 + 2 ];
+  }
+
+  VecRestoreArray(lvelo, &array_velo);    
+  VecRestoreArray(lpres, &array_pres);
+  VecRestoreArray(lsol, &array_sol);    
+
+  VecGhostRestoreLocalForm(velo->solution, &lvelo);
+  VecGhostRestoreLocalForm(pres->solution, &lpres);
+  VecGhostRestoreLocalForm(sol->solution, &lsol);
+  
+  sol->GhostUpdate();
+}
+
+// EOF

--- a/examples/ns/src/PTime_NS_HERK_Solver_AccurateA.cpp
+++ b/examples/ns/src/PTime_NS_HERK_Solver_AccurateA.cpp
@@ -1,0 +1,456 @@
+#include "PTime_NS_HERK_Solver_AccurateA.hpp"
+
+PTime_NS_HERK_Solver_AccurateA::PTime_NS_HERK_Solver_AccurateA(
+    std::unique_ptr<MF_TA::SolverContext> in_solver_ctx,
+    std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
+    std::unique_ptr<Matrix_PETSc> in_bc_mat,
+    std::unique_ptr<ITimeMethod_RungeKutta> in_tmRK,
+    std::unique_ptr<IFlowRate> in_flrate,
+    std::unique_ptr<IFlowRate> in_dot_flrate,
+    std::unique_ptr<PDNSolution> in_sol_base,
+    std::unique_ptr<ALocal_InflowBC> in_infnbc, 
+    const std::string &input_name, const int &in_nlocalnode,
+    const int &input_record_freq, const double &input_final_time )
+: final_time(input_final_time), sol_record_freq(input_record_freq),
+  pb_name(input_name), nlocalnode(in_nlocalnode), solver_ctx(std::move(in_solver_ctx)), 
+  lsolver(std::move(in_lsolver)), bc_mat(std::move(in_bc_mat)), 
+  tmRK(std::move(in_tmRK)), flrate(std::move(in_flrate)), 
+  dot_flrate(std::move(in_dot_flrate)), sol_base(std::move(in_sol_base)),
+  infnbc(std::move(in_infnbc))
+{}
+
+std::string PTime_NS_HERK_Solver_AccurateA::Name_Generator(const int &counter) const
+{
+  return pb_name + std::to_string(900000000 + counter);
+}
+
+void PTime_NS_HERK_Solver_AccurateA::print_info() const
+{
+  SYS_T::commPrint("----------------------------------------------------------- \n");
+  SYS_T::commPrint("Time stepping solver setted up:\n");
+  SYS_T::commPrint("  final time: %e \n", final_time);
+  SYS_T::commPrint("  solution record frequency : %d \n", sol_record_freq);
+  SYS_T::commPrint("  solution base name: %s \n", pb_name.c_str());
+  SYS_T::commPrint("----------------------------------------------------------- \n");
+}
+
+void PTime_NS_HERK_Solver_AccurateA::Write_restart_file(const PDNTimeStep * const &timeinfo,
+    const std::string &solname ) const
+{
+  std::ofstream restart_file("restart_file.txt", std::ofstream::out | std::ofstream::trunc);
+  if( restart_file.is_open() )
+  {
+    restart_file<<timeinfo->get_index()<<std::endl;
+    restart_file<<timeinfo->get_time()<<std::endl;
+    restart_file<<timeinfo->get_step()<<std::endl;
+    restart_file<<solname.c_str()<<std::endl;
+    restart_file.close();
+  }
+  else
+    SYS_T::print_fatal("Error: PTimeSolver cannot open restart_file.txt");
+}
+
+void PTime_NS_HERK_Solver_AccurateA::TM_NS_HERK(
+    const bool &restart_init_assembly_flag, 
+    std::unique_ptr<PDNSolution> init_sol,
+    std::unique_ptr<PDNSolution> init_velo,
+    std::unique_ptr<PDNSolution> init_dot_velo,
+    std::unique_ptr<PDNSolution> init_pres,
+    std::unique_ptr<PDNTimeStep> time_info ) const
+{
+  // Make initial velo and pres compatible with initial sol
+  Update_init_pressure_velocity(init_velo.get(), init_pres.get(), init_sol.get());
+
+  const int ss = tmRK->get_RK_step();
+
+  // The velo solutions in each sub-step at the (n+1)-th time step
+  PDNSolution** cur_velo_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    cur_velo_sols[ii] = new PDNSolution(*init_velo);
+
+    // The velo solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_velo = new PDNSolution(*init_velo);
+  
+  // The dot_velo solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_dot_velo = new PDNSolution(*init_dot_velo);
+
+  // The pres solutions in each sub-step at the (n+1)-th time step
+  PDNSolution** cur_pres_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    cur_pres_sols[ii] = new PDNSolution(*init_pres);
+
+  // The pres solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_pres = new PDNSolution(*init_pres);
+
+  // The solution in the final step at the (n+1)-th time step
+  PDNSolution * cur_sol = new PDNSolution(*init_sol);
+
+  // The velo solutions in each sub-step at the n-th time step
+  PDNSolution** pre_velo_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    pre_velo_sols[ii] = new PDNSolution(*init_velo);
+
+  // The pres solutions in each sub-step at the n-th time step
+  PDNSolution** pre_pres_sols = new PDNSolution*[ss];
+  for(int ii = 0; ii < ss; ++ii)
+    pre_pres_sols[ii] = new PDNSolution(*init_pres);    
+
+  // The velo solution in the final step at the n-th time step
+  PDNSolution * pre_velo = new PDNSolution(*init_velo);
+
+  // The pres solution in the final step at the n-th time step
+  PDNSolution * pre_pres = new PDNSolution(*init_pres);
+
+  // The velo solution in the final step at the (n-1)-th time step
+  PDNSolution * pre_velo_before = new PDNSolution(*init_velo);
+
+  // If this is a restart run, do not re-write the solution binaries
+  if(restart_init_assembly_flag == false)
+  {
+    const auto sol_name = Name_Generator(time_info->get_index());
+    cur_sol->WriteBinary(sol_name);
+  }
+
+  SYS_T::commPrint("Time = %e, dt = %e, index = %d, %s \n",
+      time_info->get_time(), time_info->get_step(), time_info->get_index(),
+      SYS_T::get_time().c_str());
+
+  while (time_info->get_time() < final_time)
+  {   
+    HERK_Solve_NS(
+        time_info->get_time(), time_info->get_step(),
+        cur_velo_sols, cur_velo, cur_dot_velo,
+        cur_pres_sols, cur_pres, pre_velo_sols, pre_velo,
+        pre_pres_sols, pre_pres, pre_velo_before, cur_sol );
+
+    // Update the time step information
+    time_info->TimeIncrement();
+
+    SYS_T::commPrint("Time = %e, dt = %e, index = %d, %s \n",
+        time_info->get_time(), time_info->get_step(), time_info->get_index(),
+        SYS_T::get_time().c_str());
+
+    // Record solution if meets criteria
+    if( time_info->get_index()%sol_record_freq == 0 )
+    {
+      const auto sol_name = Name_Generator( time_info->get_index() );
+      cur_sol->WriteBinary(sol_name);
+    }
+
+    // Prepare for next time step
+    pre_velo_before->Copy(pre_velo);
+    pre_velo->Copy(cur_velo);
+    pre_pres->Copy(cur_pres);
+
+    for(int ii = 0; ii < ss; ++ii)
+    {
+      pre_velo_sols[ii]->Copy(cur_velo_sols[ii]);
+      pre_pres_sols[ii]->Copy(cur_pres_sols[ii]);
+    }  
+  }
+
+  for (int ii = 0; ii < ss; ++ii) 
+  {
+    delete cur_velo_sols[ii]; delete pre_velo_sols[ii]; 
+    delete cur_pres_sols[ii]; delete pre_pres_sols[ii];
+  }
+  delete[] cur_velo_sols; delete[] pre_velo_sols; delete[] cur_pres_sols; delete[] pre_pres_sols;
+  delete cur_velo; delete cur_dot_velo; delete cur_pres; delete cur_sol; 
+  delete pre_velo; delete pre_pres; delete pre_velo_before;
+}
+
+void PTime_NS_HERK_Solver_AccurateA::HERK_Solve_NS(
+    const double &curr_time, const double &dt,
+    PDNSolution ** const &cur_velo_sols,
+    PDNSolution * const &cur_velo,
+    PDNSolution * const &cur_dot_velo,
+    PDNSolution ** const &cur_pres_sols,
+    PDNSolution * const &cur_pres,
+    PDNSolution ** const &pre_velo_sols,
+    PDNSolution * const &pre_velo,
+    PDNSolution ** const &pre_pres_sols,
+    PDNSolution * const &pre_pres,
+    PDNSolution * const &pre_velo_before,
+    PDNSolution * const &cur_sol ) const
+{
+  #ifdef PETSC_USE_LOG
+    PetscLogEvent K_solve, update_dotstep;
+    PetscClassId classid_solve;
+    PetscClassIdRegister("matsolve", &classid_solve);
+    PetscLogEventRegister("K_solve", classid_solve, &K_solve);
+    PetscLogEventRegister("update_dotstep", classid_solve, &update_dotstep);
+  #endif
+
+  auto dot_step = SYS_T::make_unique<PDNSolution>( cur_sol );
+
+  // HERK's number of steps
+  const int ss = tmRK->get_RK_step();
+  
+  // The first sub-step, u_1 = u_n
+  cur_velo_sols[0] -> Copy(*pre_velo);
+    
+  SYS_T::commPrint(" ==> Start solving the SubStep -- substep = 1 is solved. \n");
+  
+  // Sub-step (starting from the second sub-step)
+  for(int ii = 1; ii < ss; ++ii)
+  {
+    // Make the velo in each sub step meet the Dirchlet boundary
+    rescale_inflow_velo(curr_time + tmRK->get_RK_c(ii) * dt, flrate.get(), cur_velo_sols[ii]);
+  
+    solver_ctx->gassem->Clear_G();  // K uses Matrix-free
+     
+    solver_ctx->gassem->Assem_residual_substep( ii, cur_velo_sols, cur_pres_sols,
+      pre_velo_sols, pre_velo, pre_pres_sols, pre_velo_before, tmRK.get(), 
+      curr_time, dt );     
+    
+    solver_ctx->gassem->Update_tangent_alpha_RK( tmRK->get_RK_a(ii, ii-1) );  
+    solver_ctx->gassem->Update_tangent_submatrix5();     
+   
+    Vec sol_vp;   
+    VecDuplicate( solver_ctx->gassem->G, &sol_vp );   
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(K_solve, 0,0,0,0);
+  #endif
+    lsolver->Solve( solver_ctx->gassem->G, sol_vp ); 
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(K_solve,0,0,0,0);
+  #endif
+
+  #ifdef PETSC_USE_LOG
+  PetscLogEventBegin(update_dotstep, 0,0,0,0);
+  #endif 
+    Update_dot_step( sol_vp, dot_step.get() );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(update_dotstep, 0,0,0,0);
+  #endif
+
+    bc_mat->MatMultSol( dot_step.get() );
+  
+    SYS_T::commPrint(" --- substep = %d is solved. \n", ii+1);
+  
+    Update_pressure_velocity(cur_velo_sols[ii], cur_pres_sols[ii-1], dot_step.get());
+
+    VecDestroy( &sol_vp );
+  }
+    // Final step
+    SYS_T::commPrint(" ==> Start solving the FinalStep: \n");
+  
+    // Make the velo in the last step meet the Dirchlet boundary
+    rescale_inflow_velo(curr_time + dt, flrate.get(), cur_velo);
+  
+    solver_ctx->gassem->Clear_G();
+  
+    solver_ctx->gassem->Assem_residual_finalstep( cur_velo_sols, cur_velo, 
+      cur_pres_sols, pre_velo_sols, pre_velo, pre_pres_sols, pre_velo_before,
+      tmRK.get(), curr_time, dt );
+
+    solver_ctx->gassem->Update_tangent_alpha_RK( tmRK->get_RK_b(ss-1) );  
+    solver_ctx->gassem->Update_tangent_submatrix5();  
+
+    Vec sol_vp;
+    VecDuplicate( solver_ctx->gassem->G, &sol_vp );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventBegin(K_solve, 0,0,0,0);
+  #endif 
+    lsolver->Solve( solver_ctx->gassem->G, sol_vp ); 
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(K_solve,0,0,0,0);
+  #endif
+
+  #ifdef PETSC_USE_LOG
+  PetscLogEventBegin(update_dotstep, 0,0,0,0);
+  #endif 
+    Update_dot_step( sol_vp, dot_step.get() );
+  #ifdef PETSC_USE_LOG
+    PetscLogEventEnd(update_dotstep, 0,0,0,0);
+  #endif
+  
+    bc_mat->MatMultSol( dot_step.get() );
+  
+    SYS_T::commPrint(" --- finalstep is solved. \n");
+  
+    Update_pressure_velocity(cur_velo, cur_pres_sols[ss-1], dot_step.get());
+
+    Update_solutions(cur_velo, cur_pres_sols[ss-1], cur_sol);
+    VecDestroy( &sol_vp );
+}
+
+void PTime_NS_HERK_Solver_AccurateA::rescale_inflow_velo( const double &stime,
+  const IFlowRate * const &flowrate, PDNSolution * const &velo ) const
+{
+  const int num_nbc = infnbc -> get_num_nbc();
+
+  for(int nbc_id=0; nbc_id<num_nbc; ++nbc_id)
+  {
+    const int numnode = infnbc -> get_Num_LD( nbc_id );
+
+    const double factor  = flowrate -> get_flow_rate( nbc_id, stime );
+    const double std_dev = flowrate -> get_flow_TI_std_dev( nbc_id );
+
+    for(int ii=0; ii<numnode; ++ii)
+    {
+      const int node_index = infnbc -> get_LDN( nbc_id, ii );
+      
+      const int base_idx[3] = { node_index*4+1, node_index*4+2, node_index*4+3 };
+
+      double base_vals[3];
+
+      VecGetValues(sol_base->solution, 3, base_idx, base_vals);
+
+      const double perturb_x = MATH_T::gen_double_rand_normal(0, std_dev);
+      const double perturb_y = MATH_T::gen_double_rand_normal(0, std_dev);
+      const double perturb_z = MATH_T::gen_double_rand_normal(0, std_dev);
+
+      const double vals[3] = { base_vals[0] * factor * (1.0 + perturb_x), 
+        base_vals[1] * factor * (1.0 + perturb_y),
+        base_vals[2] * factor * (1.0 + perturb_z) };
+
+      const int velo_idx[3] = { node_index*3, node_index*3+1, node_index*3+2 };
+
+      VecSetValues(velo->solution, 3, velo_idx, vals, INSERT_VALUES);
+    }
+  }
+
+  velo->Assembly_GhostUpdate();
+}
+
+// Please make sure the Vec vp is VecNest before using the function
+void PTime_NS_HERK_Solver_AccurateA::Update_dot_step(     
+  const Vec &vp, PDNSolution * const &step) const
+{
+  Vec lstep, v, p;
+  VecNestGetSubVec(vp, 0, &v);
+  VecNestGetSubVec(vp, 1, &p);
+  VecGhostGetLocalForm(step->solution, &lstep);
+
+  double * array_step, * array_v, * array_p;
+  VecGetArray(lstep, &array_step);
+
+  VecGetArray(v, &array_v);
+  VecGetArray(p, &array_p);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_step[ii*4 + 0] = array_p[ii];
+    array_step[ii*4 + 1] = array_v[ii*3 + 0];
+    array_step[ii*4 + 2] = array_v[ii*3 + 1];
+    array_step[ii*4 + 3] = array_v[ii*3 + 2];
+  }
+
+  VecRestoreArray(v, &array_v);
+  VecRestoreArray(p, &array_p);
+  VecRestoreArray(lstep, &array_step);
+
+  VecGhostRestoreLocalForm(step->solution, &lstep);
+  
+  step->GhostUpdate();
+}
+
+void PTime_NS_HERK_Solver_AccurateA::Update_pressure_velocity(     
+    PDNSolution * const &velo,
+    PDNSolution * const &pres,
+    const PDNSolution * const &step) const
+{
+  Vec lvelo, lpres, lstep;
+  double * array_velo, * array_pres, * array_step;
+
+  VecGhostGetLocalForm(velo->solution, &lvelo);    
+  VecGhostGetLocalForm(pres->solution, &lpres);    
+  VecGhostGetLocalForm(step->solution, &lstep);
+
+  VecGetArray(lvelo, &array_velo);
+  VecGetArray(lpres, &array_pres); 
+  VecGetArray(lstep, &array_step);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_pres[ii       ] -= array_step[ii*4 + 0];
+    array_velo[ii*3 + 0 ] -= array_step[ii*4 + 1];
+    array_velo[ii*3 + 1 ] -= array_step[ii*4 + 2];
+    array_velo[ii*3 + 2 ] -= array_step[ii*4 + 3];
+  }
+
+  VecRestoreArray(lvelo, &array_velo);    
+  VecRestoreArray(lpres, &array_pres);
+  VecRestoreArray(lstep, &array_step);
+  
+  VecGhostRestoreLocalForm(velo->solution, &lvelo);
+  VecGhostRestoreLocalForm(pres->solution, &lpres);
+  VecGhostRestoreLocalForm(step->solution, &lstep);
+
+  velo->GhostUpdate();
+  pres->GhostUpdate();  
+}
+
+void PTime_NS_HERK_Solver_AccurateA::Update_init_pressure_velocity(     
+  PDNSolution * const &velo,
+  PDNSolution * const &pres,
+  const PDNSolution * const &sol) const
+{
+  Vec lvelo, lpres, lsol;
+  double * array_velo, * array_pres, * array_sol;
+
+  VecGhostGetLocalForm(velo->solution, &lvelo);    
+  VecGhostGetLocalForm(pres->solution, &lpres);    
+  VecGhostGetLocalForm(sol->solution, &lsol);
+
+  VecGetArray(lvelo, &array_velo);
+  VecGetArray(lpres, &array_pres); 
+  VecGetArray(lsol, &array_sol);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_pres[ii       ] = array_sol[ii*4 + 0];
+    array_velo[ii*3 + 0 ] = array_sol[ii*4 + 1];
+    array_velo[ii*3 + 1 ] = array_sol[ii*4 + 2];
+    array_velo[ii*3 + 2 ] = array_sol[ii*4 + 3];
+  }
+
+  VecRestoreArray(lvelo, &array_velo);    
+  VecRestoreArray(lpres, &array_pres);
+  VecRestoreArray(lsol, &array_sol);
+  
+  VecGhostRestoreLocalForm(velo->solution, &lvelo);
+  VecGhostRestoreLocalForm(pres->solution, &lpres);
+  VecGhostRestoreLocalForm(sol->solution, &lsol);
+
+  velo->GhostUpdate();
+  pres->GhostUpdate();  
+}
+
+void PTime_NS_HERK_Solver_AccurateA::Update_solutions(     
+    const PDNSolution * const &velo,
+    const PDNSolution * const &pres,
+    PDNSolution * const &sol) const
+{
+  Vec lvelo, lpres, lsol;
+  double * array_velo, * array_pres, * array_sol;
+
+  VecGhostGetLocalForm(velo->solution, &lvelo);    
+  VecGhostGetLocalForm(pres->solution, &lpres);    
+  VecGhostGetLocalForm(sol->solution, &lsol);
+
+  VecGetArray(lvelo, &array_velo);
+  VecGetArray(lpres, &array_pres); 
+  VecGetArray(lsol, &array_sol);
+
+  for(int ii=0; ii<nlocalnode; ++ii)
+  {
+    array_sol[ii*4 + 0] = array_pres[ii       ];
+    array_sol[ii*4 + 1] = array_velo[ii*3 + 0 ];
+    array_sol[ii*4 + 2] = array_velo[ii*3 + 1 ];
+    array_sol[ii*4 + 3] = array_velo[ii*3 + 2 ];
+  }
+
+  VecRestoreArray(lvelo, &array_velo);    
+  VecRestoreArray(lpres, &array_pres);
+  VecRestoreArray(lsol, &array_sol);    
+
+  VecGhostRestoreLocalForm(velo->solution, &lvelo);
+  VecGhostRestoreLocalForm(pres->solution, &lpres);
+  VecGhostRestoreLocalForm(sol->solution, &lsol);
+  
+  sol->GhostUpdate();
+}
+
+// EOF

--- a/include/ExplicitRK_EMRK2p2s.hpp
+++ b/include/ExplicitRK_EMRK2p2s.hpp
@@ -1,0 +1,76 @@
+#ifndef EXPLICITRK_EMRK2P2S_HPP
+#define EXPLICITRK_EMRK2P2S_HPP
+// ==================================================================
+// Explicit Runge–Kutta method: explicit midpoint method
+// Two-stage scheme with second-order accuracy on solution
+//
+// Ref: J.C. Butcher. Numerical methods for ordinary differential equations, 2016
+//
+// Date: Apr. 14 2025
+// Author: Yujie Sun
+// ==================================================================
+#include "ITimeMethod_RungeKutta.hpp"
+
+class ExplicitRK_EMRK2p2s final : public ITimeMethod_RungeKutta 
+{
+  public:
+    ExplicitRK_EMRK2p2s() : ITimeMethod_RungeKutta(2) 
+    {
+      // c_i values
+      cc[0] = 0.0;
+      cc[1] = 0.5;
+
+      // b_i values
+      bb[0] = 0.0;
+      bb[1] = 1.0;
+
+      // a_ij values
+      aa[0 * ss + 0] = 0.0;  aa[0 * ss + 1] = 0.0;
+      aa[1 * ss + 0] = 0.5;  aa[1 * ss + 1] = 0.0;
+    }
+
+    ~ExplicitRK_EMRK2p2s() override = default;
+
+    double get_RK_a(const int &ii, const int &jj) const override
+    {
+      ASSERT((ii >= 0 && ii < ss && jj >= 0 && jj < ss), "Error: get_RK_a index out of range.\n");
+      return aa[ii * ss + jj];
+    }
+
+    double get_RK_b(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss), "Error: get_RK_b index out of range.\n");
+      return bb[ii];
+    }
+
+    double get_RK_c(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss), "Error: get_RK_c index out of range.\n");
+      return cc[ii];
+    }
+
+    void print_coefficients() const override
+    {
+      SYS_T::commPrint("Coefficients:\n");
+      SYS_T::commPrint("c: \n");
+      for (const auto& ci : cc) SYS_T::commPrint("%e \n", ci);
+      SYS_T::commPrint("\nb: \n");
+      for (const auto& bi : bb) SYS_T::commPrint("%e \n", bi);
+
+      SYS_T::commPrint("\na:\n");
+      for (int ii = 0; ii < ss; ++ii) 
+      {
+        for (int jj = 0; jj < ss; ++jj)
+          SYS_T::commPrint("%e ", aa[ii * ss + jj]);
+      
+        SYS_T::commPrint("\n");
+      }
+    }
+
+  private:
+    std::array<double, 2> cc{};
+    std::array<double, 2> bb{};
+    std::array<double, 4> aa{};
+};
+
+#endif

--- a/include/ExplicitRK_HeunRK2p2s.hpp
+++ b/include/ExplicitRK_HeunRK2p2s.hpp
@@ -1,0 +1,76 @@
+#ifndef EXPLICITRK_HEUNRK2P2S_HPP
+#define EXPLICITRK_HEUNRK2P2S_HPP
+// ==================================================================
+// Explicit Runge–Kutta method: Heun’s method
+// Two-stage scheme with second-order accuracy on solution
+//
+// Ref: J.C. Butcher. Numerical methods for ordinary differential equations, 2016
+//
+// Date: Apr. 14 2025
+// Author: Yujie Sun
+// ==================================================================
+#include "ITimeMethod_RungeKutta.hpp"
+
+class ExplicitRK_HeunRK2p2s final : public ITimeMethod_RungeKutta 
+{
+  public:
+    ExplicitRK_HeunRK2p2s() : ITimeMethod_RungeKutta(2) 
+    {
+      // c_i values
+      cc[0] = 0.0;
+      cc[1] = 1.0; 
+
+      // b_i values
+      bb[0] = 0.5; 
+      bb[1] = 0.5;
+
+      // a_ij values
+      aa[0 * ss + 0] = 0.0;  aa[0 * ss + 1] = 0.0;
+      aa[1 * ss + 0] = 1.0;  aa[1 * ss + 1] = 0.0;
+    }
+
+    ~ExplicitRK_HeunRK2p2s() override = default;
+
+    double get_RK_a(const int &ii, const int &jj) const override
+    {
+      ASSERT((ii >= 0 && ii < ss && jj >= 0 && jj < ss), "Error: get_RK_a index out of range.\n");
+      return aa[ii * ss + jj];
+    }
+
+    double get_RK_b(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss), "Error: get_RK_b index out of range.\n");
+      return bb[ii];
+    }
+
+    double get_RK_c(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss), "Error: get_RK_c index out of range.\n");
+      return cc[ii];
+    }
+
+    void print_coefficients() const override
+    {
+      SYS_T::commPrint("Coefficients:\n");
+      SYS_T::commPrint("c: \n");
+      for (const auto& ci : cc) SYS_T::commPrint("%e \n", ci);
+      SYS_T::commPrint("\nb: \n");
+      for (const auto& bi : bb) SYS_T::commPrint("%e \n", bi);
+
+      SYS_T::commPrint("\na:\n");
+      for (int ii = 0; ii < ss; ++ii) 
+      {
+        for (int jj = 0; jj < ss; ++jj)
+          SYS_T::commPrint("%e ", aa[ii * ss + jj]);
+      
+        SYS_T::commPrint("\n");
+      }
+    }
+
+  private:
+    std::array<double, 2> cc{};
+    std::array<double, 2> bb{};
+    std::array<double, 4> aa{};
+};
+
+#endif

--- a/include/ExplicitRK_PseudoSymplecticRK3p5q4s.hpp
+++ b/include/ExplicitRK_PseudoSymplecticRK3p5q4s.hpp
@@ -1,0 +1,89 @@
+#ifndef EXPLICITRK_PSEUDOSYMPLECTICRK3P5Q4S_HPP
+#define EXPLICITRK_PSEUDOSYMPLECTICRK3P5Q4S_HPP
+// ==================================================================
+// Explicit pseudo-symplectic Runge–Kutta method: 3p5q4s
+// Four-stage scheme with third-order accuracy on solution and fifth-order 
+// accuracy on energy conservation
+//
+// Ref: F. Capuano et al. Explicit Runge-Kutta schemes for incompressible flow 
+//      with improved energy-conservation properties. Journal of Computational Physics, 2017
+//
+// Date: Apr. 14 2025
+// Author: Yujie Sun
+// ==================================================================
+#include "ITimeMethod_RungeKutta.hpp"
+
+class ExplicitRK_PseudoSymplecticRK3p5q4s final : public ITimeMethod_RungeKutta 
+{
+  public:
+    ExplicitRK_PseudoSymplecticRK3p5q4s() : ITimeMethod_RungeKutta(4) 
+    {
+      const double c3 = 1.0/4.0;
+   
+      // c_i values 
+      cc[0] = 0.0;
+      cc[1] = (c3 - 1.0) / (4.0 * c3 - 3.0);
+      cc[2] = c3;
+      cc[3] = 1.0;
+
+      // b_i values
+      bb[0] = 1.0 / (12.0 * (c3 - 1.0));
+      bb[1] = ((4.0 * c3 - 3.0) * (4.0 * c3 - 3.0)) / (12.0 * (c3 - 1.0) * (2.0 * c3 - 1.0));
+      bb[2] = -1.0 / (12.0 * (c3 - 1.0) * (2.0 * c3 - 1.0));
+      bb[3] = (4.0 * c3 - 3.0) / (12.0 * (c3 - 1.0));
+
+      // a_ij values
+      aa[0 * ss + 0] = 0.0;
+      aa[1 * ss + 0] = (c3 - 1.0) / (4.0 * c3 - 3.0);
+      aa[2 * ss + 0] = c3 - ((2.0 * c3 - 1.0) * (4.0 * c3 - 3.0)) / (2.0 * (c3 - 1.0)); 
+      aa[2 * ss + 1] = ((2.0 * c3 - 1.0) * (4.0 * c3 - 3.0)) / (2.0 * (c3 - 1.0));
+      aa[3 * ss + 0] = - ((2.0 * c3 - 1.0) * (2.0 * c3 - 1.0)) / (2.0 * (c3 - 1.0)*(4.0 * c3 - 3.0)); 
+      aa[3 * ss + 1] = (6.0 * c3 * c3 - 8.0 * c3 + 3.0) / (2.0 * (c3 - 1.0) * (2.0 * c3 - 1.0));
+      aa[3 * ss + 2] = (c3 - 1.0) / ((2.0 * c3 - 1.0) * (4.0 * c3 - 3.0));
+    }
+
+    ~ExplicitRK_PseudoSymplecticRK3p5q4s() override = default;
+
+    double get_RK_a(const int &ii, const int &jj) const override
+    {
+      ASSERT((ii >= 0 && ii < ss && jj >= 0 && jj < ss), "Error: get_RK_a index out of range.\n");
+      return aa[ii * ss + jj];
+    }
+
+    double get_RK_b(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss),  "Error: get_RK_b index out of range.\n");
+      return bb[ii];
+    }
+
+    double get_RK_c(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss),"Error: get_RK_c index out of range.\n");
+      return cc[ii];
+    }
+
+    virtual void print_coefficients() const override
+    {
+      SYS_T::commPrint("Coefficients:\n");
+      SYS_T::commPrint("c: \n");
+      for (const auto& ci : cc) SYS_T::commPrint("%e \n", ci);
+      SYS_T::commPrint("\nb: \n");
+      for (const auto& bi : bb) SYS_T::commPrint("%e \n", bi);
+
+      SYS_T::commPrint("\na:\n");
+      for (int ii = 0; ii < ss; ++ii) 
+      {
+        for (int jj = 0; jj < ss; ++jj)
+          SYS_T::commPrint("%e ", aa[ii * ss + jj]);
+      
+        SYS_T::commPrint("\n");
+      }
+    }
+
+  private:
+    std::array<double, 4> cc{};
+    std::array<double, 4> bb{};
+    std::array<double, 16> aa{};
+};
+
+#endif

--- a/include/ExplicitRK_RalstonRK2p2s.hpp
+++ b/include/ExplicitRK_RalstonRK2p2s.hpp
@@ -1,0 +1,76 @@
+#ifndef EXPLICITRK_RALSTONRK2P2S_HPP
+#define EXPLICITRK_RALSTONRK2P2S_HPP
+// ==================================================================
+// Explicit Runge–Kutta method: Ralston’s method
+// Two-stage scheme with second-order accuracy on solution
+//
+// Ref: J.C. Butcher. Numerical methods for ordinary differential equations, 2016
+//
+// Date: Apr. 14 2025
+// Author: Yujie Sun
+// ==================================================================
+#include "ITimeMethod_RungeKutta.hpp"
+
+class ExplicitRK_RalstonRK2p2s final : public ITimeMethod_RungeKutta 
+{
+  public:
+    ExplicitRK_RalstonRK2p2s() : ITimeMethod_RungeKutta(2) 
+    {
+      // c_i values
+      cc[0] = 0.0;
+      cc[1] = 2.0 / 3.0;
+
+      // b_i values
+      bb[0] = 1.0 / 4.0;
+      bb[1] = 3.0 / 4.0; 
+
+      // a_ij values
+      aa[0 * ss + 0] = 0.0;     aa[0 * ss + 1] = 0.0;
+      aa[1 * ss + 0] = 2.0 / 3.0;  aa[1 * ss + 1] = 0.0;
+    }
+
+    ~ExplicitRK_RalstonRK2p2s() override = default;
+
+    double get_RK_a(const int &ii, const int &jj) const override
+    {
+      ASSERT((ii >= 0 && ii < ss && jj >= 0 && jj < ss), "Error: get_RK_a index out of range.\n");
+      return aa[ii * ss + jj];
+    }
+
+    double get_RK_b(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss), "Error: get_RK_b index out of range.\n");
+      return bb[ii];
+    }
+
+    double get_RK_c(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss), "Error: get_RK_c index out of range.\n");
+      return cc[ii];
+    }
+
+    void print_coefficients() const override
+    {
+      SYS_T::commPrint("Coefficients:\n");
+      SYS_T::commPrint("c: \n");
+      for (const auto& ci : cc) SYS_T::commPrint("%e \n", ci);
+      SYS_T::commPrint("\nb: \n");
+      for (const auto& bi : bb) SYS_T::commPrint("%e \n", bi);
+
+      SYS_T::commPrint("\na:\n");
+      for (int ii = 0; ii < ss; ++ii) 
+      {
+        for (int jj = 0; jj < ss; ++jj)
+          SYS_T::commPrint("%e ", aa[ii * ss + jj]);
+      
+        SYS_T::commPrint("\n");
+      }
+    }
+
+  private:
+    std::array<double, 2> cc{};
+    std::array<double, 2> bb{};
+    std::array<double, 4> aa{};
+};
+
+#endif

--- a/include/ExplicitRK_SSPRK3p3s.hpp
+++ b/include/ExplicitRK_SSPRK3p3s.hpp
@@ -1,0 +1,80 @@
+#ifndef EXPLICITRK_SSPRK3P3S_HPP
+#define EXPLICITRK_SSPRK3P3S_HPP
+// ==================================================================
+// Explicit Runge–Kutta method: strong-stability preserving method
+// Three-stage scheme with third-order accuracy on solution
+//
+// Ref: S. Gottlieb et al. Strong stability-preserving high-order time 
+//      discretization methods. SIAM Review, 2001
+//
+// Date: Apr. 14 2025
+// Author: Yujie Sun
+// ==================================================================
+#include "ITimeMethod_RungeKutta.hpp"
+
+class ExplicitRK_SSPRK3p3s final : public ITimeMethod_RungeKutta 
+{
+  public:
+    ExplicitRK_SSPRK3p3s() : ITimeMethod_RungeKutta(3) 
+    {
+      // c_i values
+      cc[0] = 0.0;
+      cc[1] = 1.0;
+      cc[2] = 0.5;
+
+      // b_i values
+      bb[0] = 1.0 / 6.0;
+      bb[1] = 1.0 / 6.0;
+      bb[2] = 2.0 / 3.0;
+
+      // a_ij values
+      aa[0 * ss + 0] = 0.0;  aa[0 * ss + 1] = 0.0;  aa[0 * ss + 2] = 0.0;
+      aa[1 * ss + 0] = 1.0;  aa[1 * ss + 1] = 0.0;  aa[1 * ss + 2] = 0.0;
+      aa[2 * ss + 0] = 0.25; aa[2 * ss + 1] = 0.25; aa[2 * ss + 2] = 0.0;
+    }
+
+    ~ExplicitRK_SSPRK3p3s() override = default;
+
+    double get_RK_a(const int &ii, const int &jj) const override
+    {
+      ASSERT((ii >= 0 && ii < ss && jj >= 0 && jj < ss), "Error: get_RK_a index out of range.\n");
+      return aa[ii * ss + jj];
+    }
+
+    double get_RK_b(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss),  "Error: get_RK_b index out of range.\n");
+      return bb[ii];
+    }
+
+    double get_RK_c(const int &ii) const override
+    {
+      ASSERT((ii >= 0 && ii < ss),"Error: get_RK_c index out of range.\n");
+      return cc[ii];
+    }
+
+    virtual void print_coefficients() const override
+    {
+      SYS_T::commPrint("Coefficients:\n");
+      SYS_T::commPrint("c: \n");
+      for (const auto& ci : cc) SYS_T::commPrint("%e \n", ci);
+      SYS_T::commPrint("\nb: \n");
+      for (const auto& bi : bb) SYS_T::commPrint("%e \n", bi);
+
+      SYS_T::commPrint("\na:\n");
+      for (int ii = 0; ii < ss; ++ii) 
+      {
+        for (int jj = 0; jj < ss; ++jj)
+          SYS_T::commPrint("%e ", aa[ii * ss + jj]);
+      
+        SYS_T::commPrint("\n");
+      }
+    }
+
+  private:
+    std::array<double, 3> cc{};
+    std::array<double, 3> bb{};
+    std::array<double, 9> aa{};
+};
+
+#endif

--- a/include/FlowRateDot_Sine2Zero.hpp
+++ b/include/FlowRateDot_Sine2Zero.hpp
@@ -1,0 +1,55 @@
+#ifndef FLOWRATEDOT_SINE2ZERO_HPP
+#define FLOWRATEDOT_SINE2ZERO_HPP
+// ============================================================================
+// FlowRateDot_Sine2Zero.hpp
+//
+// It is designed to match FlowRate_Cosine2Steady, using a sine function
+// to prescibe the starting dot flow rate
+//
+// Date Created: Nov. 04 2024
+// ============================================================================
+#include "Vec_Tools.hpp"
+#include "Math_Tools.hpp"
+#include "IFlowRate.hpp"
+
+class FlowRateDot_Sine2Zero : public IFlowRate
+{
+  public:
+    // This constructor will set a uniform thred_time for all inlets, and the
+    // target flow rate are determined from the file and set to be the flow rate
+    // at the initial time (i.e. time = 0.0) by setting target_flow_rate to be
+    // the sum of coef_a.
+    // Same as FlowRate_Cosine2Steady.
+    FlowRateDot_Sine2Zero( const std::string &filename );
+
+    virtual ~FlowRateDot_Sine2Zero() = default;
+
+    // From time 0 to in_thred_time,
+    // flow_rate =  start_rate + 0.5 * (target_rate - start_rate) * (1 -  cos (PI * time / in_thred_time)),
+    // dot_flow_rate = 0.5 * (target_rate - start_rate) * PI / in_thred_time * sin (PI * time / in_thred_time),
+    // From in_thred_time to infty, flow_rate = target_rate, dot_flow_rate = 0.0.
+    virtual double get_flow_rate( const int &nbc_id, const double &time ) const;
+
+    // Get the turbulance intensity
+    virtual double get_flow_TI_std_dev( const int &nbc_id ) const { return TI_std_dev[nbc_id]; }
+
+    // Get the start rate if the users want to now it
+    virtual double get_flow_start_rate( const int &nbc_id ) const { return start_flow_rate[nbc_id]; }
+
+    virtual int get_num_nbc() const { return num_nbc; }
+
+    virtual void print_info() const;
+
+  private:
+    int num_nbc;
+
+    std::vector<double> thred_time;
+    
+    std::vector<double> target_flow_rate;
+
+    std::vector<double> start_flow_rate;
+
+    std::vector<double> TI_std_dev;
+};
+
+#endif

--- a/include/FlowRateFactory.hpp
+++ b/include/FlowRateFactory.hpp
@@ -12,6 +12,7 @@
 #include "FlowRate_Unsteady.hpp"
 #include "FlowRate_Linear2Steady.hpp"
 #include "FlowRate_Cosine2Steady.hpp"
+#include "FlowRateDot_Sine2Zero.hpp"
 
 class FlowRateFactory
 {
@@ -31,6 +32,8 @@ class FlowRateFactory
           return SYS_T::make_unique<FlowRate_Linear2Steady>(inflow_filename);
         case 4:
           return SYS_T::make_unique<FlowRate_Cosine2Steady>(inflow_filename);
+        case 5:
+          return SYS_T::make_unique<FlowRateDot_Sine2Zero>(inflow_filename);
 
         default:
           SYS_T::print_fatal("Error: Inflow input file %s format cannot be recognized.\n", inflow_filename.c_str());
@@ -89,6 +92,12 @@ class FlowRateFactory
           || bc_type.compare("COSINE") == 0 )
       {
         filetype = 4;
+      }
+      else if( bc_type.compare("Sine") ==0
+          || bc_type.compare("sine") == 0
+          || bc_type.compare("SINE") == 0 )
+      {
+        filetype = 5;
       }       
       else
       {

--- a/include/ITimeMethod_RungeKutta.hpp
+++ b/include/ITimeMethod_RungeKutta.hpp
@@ -1,0 +1,42 @@
+#ifndef ITIMEMETHOD_RUNGEKUTTA_HPP
+#define ITIMEMETHOD_RUNGEKUTTA_HPP
+// ============================================================================
+// ITimeMethod_RungeKutta.hpp
+// Object: This is the interface for Runge-Kutta method classes.
+// It records:
+// 1. Number of steps;
+//
+// Author: Yujie Sun
+// Date created: Apr. 14 2025
+// ============================================================================
+#include <vector>
+#include "Sys_Tools.hpp"
+
+class ITimeMethod_RungeKutta 
+{
+  public:
+    // Constructor, initialize the number of steps
+    ITimeMethod_RungeKutta(int steps) : ss(steps) {}
+
+    virtual ~ITimeMethod_RungeKutta() = default;
+
+    // Print coefficient (for debugging or viewing)
+    virtual void print_coefficients() const 
+    {SYS_T::commPrint("Warning: print_coefficients is not implemented. \n");}
+
+    int get_RK_step() const { return ss; }
+
+    // Return the RK coefficients aij
+    virtual double get_RK_a(const int &ii, const int &jj) const = 0;
+
+    // Return the RK coefficients bi
+    virtual double get_RK_b(const int &ii) const = 0;
+
+    // Return the RK coefficients ci
+    virtual double get_RK_c(const int &ii) const = 0;
+
+  protected:
+    const int ss;  // num of steps
+};
+
+#endif

--- a/include/NodalBC.hpp
+++ b/include/NodalBC.hpp
@@ -45,6 +45,12 @@ class NodalBC : public INodalBC
     NodalBC( const std::vector<std::string> &vtkfileList, const int &nFunc );
 
     // --------------------------------------------------------------
+    // The list of vtk files specifies the Dirichlet nodes.
+    // The list of sla files specifies the periodical type BC nodes.
+    // --------------------------------------------------------------
+    NodalBC( const std::vector<std::string> &vtkfileList, const std::vector<std::string> &slafileList, const int &nFunc );
+
+    // --------------------------------------------------------------
     // The list of vtp files specifies the rotated Dirichlet nodes. 
     // No periodical type BC nodes.
     // --------------------------------------------------------------

--- a/src/Mesh/NodalBC.cpp
+++ b/src/Mesh/NodalBC.cpp
@@ -49,6 +49,67 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
 }
 
 NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
+  const std::vector<std::string> &slafileList,
+  const int &nFunc )
+{
+  dir_nodes.clear();
+  per_slave_nodes.clear();
+  per_master_nodes.clear();
+  num_per_nodes = 0;
+
+  for( int ii{0}; ii < VEC_T::get_size(vtkfileList); ++ii )
+  {
+    const auto vtkfile = vtkfileList[ii];
+    SYS_T::file_check( vtkfile );
+
+    const auto gnode = VTK_T::read_int_PointData(vtkfile, "GlobalNodeID");
+
+    for(unsigned int jj=0; jj<gnode.size(); ++jj)
+    {
+      SYS_T::print_fatal_if( gnode[jj]<0 || gnode[jj]>=nFunc, "Error: the nodal index %d is not in the range [0, %d)! \n", gnode[jj], nFunc);
+
+      dir_nodes.push_back( static_cast<unsigned int>( gnode[jj]) );
+    }
+  }
+
+  VEC_T::sort_unique_resize(dir_nodes);
+
+  num_dir_nodes = dir_nodes.size();
+
+  for( int ii{0}; ii < VEC_T::get_size(slafileList); ++ii )
+  {
+    const auto slafile = slafileList[ii];
+    SYS_T::file_check( slafile );
+
+    const auto sla_gnode = VTK_T::read_int_PointData(slafile, "GlobalNodeID");
+    const auto mas_gnode = VTK_T::read_int_PointData(slafile, "MasterNodeID");
+
+    for(unsigned int jj=0; jj<sla_gnode.size(); ++jj)
+    {
+      SYS_T::print_fatal_if( sla_gnode[jj]<0 || sla_gnode[jj]>=nFunc, "Error: the slave nodal index %d is not in the range [0, %d)! \n", sla_gnode[jj], nFunc);
+      SYS_T::print_fatal_if( mas_gnode[jj]<0 || mas_gnode[jj]>=nFunc, "Error: the master nodal index %d is not in the range [0, %d)! \n", mas_gnode[jj], nFunc);
+
+      per_slave_nodes.push_back( static_cast<unsigned int>( sla_gnode[jj]) );
+      per_master_nodes.push_back( static_cast<unsigned int>( mas_gnode[jj]) );
+    }
+  }
+
+  num_per_nodes = per_slave_nodes.size();
+
+  Create_ID( nFunc );
+
+  std::cout<<"===> NodalBC specified by \n";
+  for( const auto &vtkfile : vtkfileList )
+    std::cout<<"     "<<vtkfile<<"\n";
+  std::cout<<"     is generated."<<std::endl;
+
+  std::cout<<"===> Periodic NodalBC specified by \n";
+  for( const auto &slavtkfile : slafileList )
+    std::cout<<"     "<<slavtkfile<<"\n";
+  std::cout<<"     is generated."<<std::endl;
+}
+
+NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
     const std::string &rotated_file, 
     const std::string &fixed_file,    
     const int &nFunc )

--- a/src/Model/FlowRateDot_Sine2Zero.cpp
+++ b/src/Model/FlowRateDot_Sine2Zero.cpp
@@ -1,0 +1,166 @@
+#include "FlowRateDot_Sine2Zero.hpp"
+
+FlowRateDot_Sine2Zero::FlowRateDot_Sine2Zero( const std::string &filename )
+{
+  SYS_T::commPrint("FlowRateDot_Sine2Zero: data read from %s \n", filename.c_str() );
+
+  SYS_T::file_check( filename );
+  
+  std::ifstream reader;
+  reader.open( filename.c_str(), std::ifstream::in );
+
+  std::istringstream sstrm;
+  std::string sline;
+  std::string bc_type;
+
+  // The first non-commented, non-empty line should be
+  // Inflow num_nbc
+  while( std::getline(reader, sline) )
+  {
+    if( sline[0] !='#' && !sline.empty() )
+    {
+      sstrm.str(sline);
+      sstrm >> bc_type;
+      sstrm >> num_nbc;
+      sstrm.clear();
+      break;
+    }
+  }
+
+  std::vector< std::vector<double> > coef_a, coef_b;
+  std::vector<int> num_of_mode;
+  std::vector<double> w, period;
+
+  if( bc_type.compare("Sine") == 0 || bc_type.compare("SINE") == 0 || bc_type.compare("sine") == 0 )
+  {
+    coef_a.resize(num_nbc); coef_b.resize(num_nbc);
+    num_of_mode.resize(num_nbc); w.resize(num_nbc); period.resize(num_nbc);
+    thred_time.resize(num_nbc);
+    start_flow_rate.resize(num_nbc);
+    TI_std_dev.resize(num_nbc);
+  }
+  else
+    SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: inlet BC type in %s should be Inflow.\n", filename.c_str());
+
+  // Read in num_of_mode, w, period, coef_a, and coef_b per nbc
+  for(int nbc_id=0; nbc_id<num_nbc; ++nbc_id)
+  {
+    while( std::getline(reader, sline) )
+    {
+      // face_id num_of_mode w period
+      if( sline[0] !='#' && !sline.empty() )
+      {
+        sstrm.str(sline);
+        int face_id;
+        sstrm >> face_id;
+
+        if( face_id != nbc_id ) SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: nbc in %s should be listed in ascending order.\n", filename.c_str());
+
+        if(!(sstrm >> num_of_mode[nbc_id])) SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: num_of_mode of nbc %d is undefined!\n", nbc_id);
+        
+        if(!(sstrm >> w[nbc_id])) SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: w of nbc %d is undefined!\n", nbc_id);
+        
+        if(!(sstrm >> period[nbc_id])) SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: period of nbc %d is undefined!\n", nbc_id);
+
+        if(!(sstrm >> thred_time[nbc_id])) SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: thred_time of nbc %d is undefined!\n", nbc_id);
+
+        if(!(sstrm >> start_flow_rate[nbc_id]))
+        {
+          start_flow_rate[nbc_id] = 0.0;
+          SYS_T::commPrint("FlowRateDot_Sine2Zero: default start_flow_rate of nbc %d is 0.0\n", nbc_id);
+        }
+
+        if(!(sstrm >> TI_std_dev[nbc_id]))
+        {
+          TI_std_dev[nbc_id] = 0.0;
+          SYS_T::commPrint("FlowRateDot_Sine2Zero: default TI_std_dev of nbc %d is 0.0\n", nbc_id);
+        }
+
+        sstrm.clear();
+        break;
+      }
+    }
+
+    // Check the compatibility of period and w. If the difference
+    // is larger than 0.01, print a warning message
+    if( std::abs(2.0 * MATH_T::PI / period[nbc_id] - w[nbc_id] ) >= 0.01 ) SYS_T::commPrint( "\nFlowRateDot_Sine2Zero WARNING: nbc_id %d incompatible period and w, \n2xpi/period = %e and w = %e.\n", nbc_id, 2.0*static_cast<double>(MATH_T::PI)/period[nbc_id], w[nbc_id] );
+
+    coef_a[nbc_id].clear(); coef_b[nbc_id].clear(); 
+
+    while( std::getline(reader, sline) )
+    {
+      // coef_a
+      if( sline[0] !='#' && !sline.empty() )
+      {
+        sstrm.str(sline);
+        double temp_coef;
+        while( sstrm >> temp_coef ) coef_a[nbc_id].push_back( temp_coef );
+     
+        sstrm.clear(); 
+        break;
+      }
+    }
+
+    coef_a[nbc_id].shrink_to_fit();
+    
+    if( static_cast<int>(coef_a[nbc_id].size()) != num_of_mode[nbc_id]+1 )
+      SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: nbc_id %d a-coefficients in %s incompatible with the given number of modes.\n", nbc_id, filename.c_str());
+
+    while( std::getline(reader, sline) )
+    {
+      // coef_b
+      if( sline[0] !='#' && !sline.empty() )
+      {
+        sstrm.str(sline);
+        double temp_coef;
+        while( sstrm >> temp_coef ) coef_b[nbc_id].push_back( temp_coef );
+     
+        sstrm.clear(); 
+        break;
+      }
+    }
+
+    coef_b[nbc_id].shrink_to_fit();
+
+    if( static_cast<int>(coef_b[nbc_id].size()) != num_of_mode[nbc_id]+1 )
+      SYS_T::print_fatal("FlowRateDot_Sine2Zero Error: nbc_id %d b-coefficients in %s incompatible with the given number of modes.\n", nbc_id, filename.c_str());
+  }
+
+  // Finish reading the file and close it
+  reader.close();
+
+  // Generate the target flow rate as the sum of coef_a.
+  target_flow_rate.resize( num_nbc );
+
+  for(int ii=0; ii<num_nbc; ++ii) target_flow_rate[ii] = VEC_T::sum( coef_a[ii] );
+
+  MPI_Barrier(PETSC_COMM_WORLD);
+}
+
+double FlowRateDot_Sine2Zero::get_flow_rate( const int &nbc_id,
+    const double &time ) const
+{
+  double out_dot_rate = 0.0;
+
+  if( time < thred_time[nbc_id] && time >= 0.0 ) 
+    out_dot_rate = 0.5 * (target_flow_rate[nbc_id]- start_flow_rate[nbc_id]) * MATH_T::PI / thred_time[nbc_id] * std::sin(MATH_T::PI * time / thred_time[nbc_id]);
+
+  return out_dot_rate;
+}
+
+void FlowRateDot_Sine2Zero::print_info() const
+{
+  SYS_T::print_sep_line();
+  SYS_T::commPrint("     FlowRateDot_Sine2Zero:\n");
+  for(int nbc_id = 0; nbc_id < num_nbc; ++nbc_id)
+  {
+    SYS_T::commPrint("  -- nbc_id = %d \n", nbc_id);
+    SYS_T::commPrint("     start flow rate : %e \n", start_flow_rate[nbc_id]);
+    SYS_T::commPrint("     time to reach steady state : %e \n", thred_time[nbc_id]);
+    SYS_T::commPrint("     target flow rate : %e \n", target_flow_rate[nbc_id]);
+    SYS_T::commPrint("     turbulance intensity : %e \n", TI_std_dev[nbc_id]);
+  }
+  SYS_T::print_sep_line();
+}
+
+// EOF


### PR DESCRIPTION
对于HERK-VMS格式的实现。

其中对于（w, v'_n）忽略掉了，简化了实现
其中包含了传统tangent_residual的实现，这一实现跟gen-alpha的实现保持了风格的一致，可以用来作为reference比对实现的正确性。

* a draft of PGA_block_HERK

* PGA of subK

* PGA_Block update

* PGA_Block update

* PGA_Block update

* PLocA of block

* PLocA of block up

* PLocA of block update

* PlocA of block update

* PlocA of block update

* PGA update

* PGA and PLocA Debug

* PGA update

* PTime update

* add a new func of generating bc mat for block

* add a new case to implement the inflow of sine2zero

* driver update

* MatMult for the Matshell

* format

* minor

* matrix-free update: add a member in PGA to store the coef of tangent matrix

* PGA and PLoA update

* PTime UPDATE

* Matrix_free and PCSHELL update

* debug

* use the VecNest

* make sure that the output vec is VecNest

* debug for MF_T

* debug of tau for Darcy Question

* Don't print ksp in ksp_A and ksp_S

* store the c_u, c_p as the member of PLoc class

* adopt the tau design of Darcy problem

* VecGhostGetLocalForm should not be used for Vec that is not ghost

* add a new case for dot_flowrate:sine to zero

* gen_perm_bc instead of gen_perm_bc_block

* add a func to clear subK and G

* update: test1_code_copy1

* We don't solve the pressure in HERK

* add three Explicit RK22 methods

* add 2 headfile of RK22 class in driver

* add log func to record the time

* adopt the accurate A=A_bar+Atilde in PCshell

* cmakelist update

* pc adopt the accurate A

* kspview of lsoverA and lsoverS

* clean the Matrix_Free_tools

* clean the PTimeSolver_AccurateA

* clean the ns_herk_driver_accurateA

* clean PGA

* implement the restart

* delete space

* clean the comments

* clear the unused the func

* A memory error was corrected

* comments

* comments

* clean the unused func

* clean the comments

* fixed the memory leak

* add a Pseudo-symplectic Runge–Kutta methods: 3p5q4s

* Ref

* Resolved several compilation warnings

* support to read the slave surface in NodalBC

* format

* name

* update

* indent the code

* unnecessary include

* indent

* use std::to_string

* unified the rescale inflow_dot_velo and rescale_inflow_velo

* RK class update

* minor

* minor

* delete comments

* update

* update

* comments

* comments

* indent

* PLoc update

* PLoc update

* comments

* PGA comments

* curr time is unnecessary

* print lsolver infoe

* comments

* MF_T update

* space

* ExplicitRK update

* comments

* comments

* MF_T update

* comments

* comments

* minor formating

* dR_dxx is unnecessary in Assem_tangent_matrix

* The too long rows are split into separate lines

* tau_m clean

* tangent_residual

* comments

* indent

---------