### PR TITLE
Use HDF5_T::read_intVector for node mapping and remove VIS_T::readNodeMapping

### DIFF
--- a/examples/ale_ns_rotate/vis.cpp
+++ b/examples/ale_ns_rotate/vis.cpp
@@ -22,8 +22,6 @@
 int main( int argc, char * argv[] )
 {
   const std::string element_part_file = "epart.h5";
-  const std::string anode_mapping_file = "node_mapping.h5";
-  const std::string pnode_mapping_file = "post_node_mapping.h5";
   const std::string part_file="postpart";
   
   std::string sol_bname("SOL_");
@@ -147,8 +145,8 @@ int main( int argc, char * argv[] )
 
   std::ostringstream time_index;
 
-  const auto anode_mapping = VIS_T::readNodeMapping(anode_mapping_file, "old_2_new");
-  const auto pnode_mapping = VIS_T::readNodeMapping(pnode_mapping_file, "new_2_old");
+  const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
+  const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {

--- a/examples/ale_ns_rotate/vis_wss_hex27.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex27.cpp
@@ -198,7 +198,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_quad = new FEAElement_Quad9_3D_der0( quad_vis->get_num_quadPts() );
 
   // Read the mappings of the nodal indices
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old");
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old");
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/ale_ns_rotate/vis_wss_hex8.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex8.cpp
@@ -198,7 +198,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_quad = new FEAElement_Quad4_3D_der0( quad_vis->get_num_quadPts() );
 
   // Read the mappings of the nodal indices
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old");
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old");
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/ale_ns_rotate/vis_wss_tet10.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet10.cpp
@@ -193,7 +193,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_tri = new FEAElement_Triangle6_3D_der0( quad_tri_vis-> get_num_quadPts() );
 
   // Read the mappings of the nodal indices
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old");
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old");
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/ale_ns_rotate/vis_wss_tet4.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet4.cpp
@@ -195,7 +195,7 @@ int main( int argc, char * argv[] )
   FEAElement * element = new FEAElement_Tet4( quad-> get_num_quadPts() );
 
   // Read the node mappings
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old");
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old");
 
   // Read solutions
   std::ostringstream time_index;

--- a/examples/fsi/vis.cpp
+++ b/examples/fsi/vis.cpp
@@ -15,10 +15,6 @@
 int main( int argc, char * argv[] )
 {
   const std::string element_part_file = "epart.h5";
-  const std::string an_v_mapping_file = "node_mapping_v.h5";
-  const std::string an_p_mapping_file = "node_mapping_p.h5";
-  const std::string pn_v_mapping_file = "post_node_mapping_v.h5";
-  const std::string pn_p_mapping_file = "post_node_mapping_p.h5";
   const std::string part_v_file="./ppart/postpart_v";
   const std::string part_p_file="./ppart/postpart_p";
 
@@ -132,12 +128,12 @@ int main( int argc, char * argv[] )
   std::ostringstream time_index;
 
   // Velocity and displacement node mappings
-  const auto an_v_mapping = VIS_T::readNodeMapping(an_v_mapping_file, "old_2_new");
-  const auto pn_v_mapping = VIS_T::readNodeMapping(pn_v_mapping_file, "new_2_old");
+  const auto an_v_mapping = HDF5_T::read_intVector("node_mapping_v.h5", "/", "old_2_new");
+  const auto pn_v_mapping = HDF5_T::read_intVector("post_node_mapping_v.h5", "/", "new_2_old");
 
   // Pressure node mappings
-  const auto an_p_mapping = VIS_T::readNodeMapping(an_p_mapping_file, "old_2_new");
-  const auto pn_p_mapping = VIS_T::readNodeMapping(pn_p_mapping_file, "new_2_old");
+  const auto an_p_mapping = HDF5_T::read_intVector("node_mapping_p.h5", "/", "old_2_new");
+  const auto pn_p_mapping = HDF5_T::read_intVector("post_node_mapping_p.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time += time_step)
   {

--- a/examples/fsi/vis_fluid.cpp
+++ b/examples/fsi/vis_fluid.cpp
@@ -15,10 +15,6 @@
 int main( int argc, char * argv[] )
 {
   const std::string element_part_file = "epart.h5";
-  const std::string an_v_mapping_file = "node_mapping_v.h5";
-  const std::string an_p_mapping_file = "node_mapping_p.h5";
-  const std::string pn_v_mapping_file = "post_node_mapping_v.h5";
-  const std::string pn_p_mapping_file = "post_node_mapping_p.h5";
   const std::string part_v_file="./ppart/postpart_v";
   const std::string part_p_file="./ppart/postpart_p";
 
@@ -150,12 +146,12 @@ int main( int argc, char * argv[] )
   std::ostringstream time_index;
 
   // Velocity and displacement node mappings
-  const auto an_v_mapping = VIS_T::readNodeMapping(an_v_mapping_file, "old_2_new");
-  const auto pn_v_mapping = VIS_T::readNodeMapping(pn_v_mapping_file, "new_2_old");
+  const auto an_v_mapping = HDF5_T::read_intVector("node_mapping_v.h5", "/", "old_2_new");
+  const auto pn_v_mapping = HDF5_T::read_intVector("post_node_mapping_v.h5", "/", "new_2_old");
 
   // Pressure node mappings
-  const auto an_p_mapping = VIS_T::readNodeMapping(an_p_mapping_file, "old_2_new");
-  const auto pn_p_mapping = VIS_T::readNodeMapping(pn_p_mapping_file, "new_2_old");
+  const auto an_p_mapping = HDF5_T::read_intVector("node_mapping_p.h5", "/", "old_2_new");
+  const auto pn_p_mapping = HDF5_T::read_intVector("post_node_mapping_p.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time += time_step)
   {

--- a/examples/fsi/vis_fsi_wss.cpp
+++ b/examples/fsi/vis_fsi_wss.cpp
@@ -94,7 +94,7 @@ int main( int argc, char * argv[] )
   cout<<"Wall mesh contains "<<nElem<<" elements and "<<nFunc<<" vertices.\n";
 
   // Read the node mappings
-  const auto analysis_new2old = VIS_T::readNodeMapping( "node_mapping_v.h5", "new_2_old" );
+  const auto analysis_new2old = HDF5_T::read_intVector( "node_mapping_v.h5", "/", "new_2_old" );
 
   // Read solution files
   std::string disp_sol_name(sol_bname), velo_sol_name(sol_bname);

--- a/examples/fsi/vis_fsi_wss_hex8.cpp
+++ b/examples/fsi/vis_fsi_wss_hex8.cpp
@@ -190,7 +190,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_quad = new FEAElement_Quad4_3D_der0( quad_vis->get_num_quadPts() );
 
   // Read the node mappings
-  const auto analysis_new2old = VIS_T::readNodeMapping( "node_mapping_v.h5", "new_2_old" );
+  const auto analysis_new2old = HDF5_T::read_intVector( "node_mapping_v.h5", "/", "new_2_old" );
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/fsi/vis_fsi_wss_tet4.cpp
+++ b/examples/fsi/vis_fsi_wss_tet4.cpp
@@ -147,7 +147,7 @@ int main( int argc, char * argv[] )
   FEAElement * element = new FEAElement_Tet4( quad-> get_num_quadPts() );
 
   // Read the node mappings
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping_v.h5", "new_2_old");
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping_v.h5", "/", "new_2_old");
 
   // Container for TAWSS & OSI
   std::vector<double> tawss( nFunc, 0.0 ); 

--- a/examples/fsi/vis_solid.cpp
+++ b/examples/fsi/vis_solid.cpp
@@ -15,10 +15,6 @@
 int main ( int argc , char * argv[] )
 {
   const std::string element_part_file = "epart.h5";
-  const std::string an_v_mapping_file = "node_mapping_v.h5";
-  const std::string an_p_mapping_file = "node_mapping_p.h5";
-  const std::string pn_v_mapping_file = "post_node_mapping_v.h5";
-  const std::string pn_p_mapping_file = "post_node_mapping_p.h5";
   const std::string part_v_file="./ppart/postpart_v";
   const std::string part_p_file="./ppart/postpart_p";
 
@@ -155,12 +151,12 @@ int main ( int argc , char * argv[] )
   std::ostringstream time_index;
 
   // Velocity and displacement node mappings
-  const auto an_v_mapping = VIS_T::readNodeMapping(an_v_mapping_file, "old_2_new");
-  const auto pn_v_mapping = VIS_T::readNodeMapping(pn_v_mapping_file, "new_2_old");
+  const auto an_v_mapping = HDF5_T::read_intVector("node_mapping_v.h5", "/", "old_2_new");
+  const auto pn_v_mapping = HDF5_T::read_intVector("post_node_mapping_v.h5", "/", "new_2_old");
 
   // Pressure node mappings
-  const auto an_p_mapping = VIS_T::readNodeMapping(an_p_mapping_file, "old_2_new");
-  const auto pn_p_mapping = VIS_T::readNodeMapping(pn_p_mapping_file, "new_2_old");
+  const auto an_p_mapping = HDF5_T::read_intVector("node_mapping_p.h5", "/", "old_2_new");
+  const auto pn_p_mapping = HDF5_T::read_intVector("post_node_mapping_p.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time += time_step)
   {

--- a/examples/linearPDE/elastodynamics/post_compare_manu.cpp
+++ b/examples/linearPDE/elastodynamics/post_compare_manu.cpp
@@ -65,8 +65,8 @@ int main( int argc, char * argv[] )
   std::unique_ptr<IQuadPts> quadv = QuadPtsFactory::createVolQuadrature(elemType, nqp_vol);
   std::unique_ptr<FEAElement> elementv = ElementFactory::createVolElement(elemType, nqp_vol);
 
-  const auto anode_mapping = VIS_T::readNodeMapping("node_mapping.h5", "old_2_new");
-  const auto pnode_mapping = VIS_T::readNodeMapping("post_node_mapping.h5", "new_2_old");
+  const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
+  const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
     
   PostVectSolution * pSolu = new PostVectSolution( sol_name,
       anode_mapping, pnode_mapping, pNode.get(), dof );

--- a/examples/linearPDE/elastodynamics/vis.cpp
+++ b/examples/linearPDE/elastodynamics/vis.cpp
@@ -15,8 +15,6 @@
 int main( int argc, char * argv[] ) 
 { 
   const std::string element_part_file = "epart.h5";
-  const std::string anode_mapping_file = "node_mapping.h5";
-  const std::string pnode_mapping_file = "post_node_mapping.h5";
   const std::string part_file="./ppart/part";
   constexpr int dof = 3;
 
@@ -116,8 +114,8 @@ int main( int argc, char * argv[] )
   
   std::ostringstream time_index;
 
-  const auto anode_mapping = VIS_T::readNodeMapping(anode_mapping_file, "old_2_new");
-  const auto pnode_mapping = VIS_T::readNodeMapping(pnode_mapping_file, "new_2_old");
+  const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
+  const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {

--- a/examples/linearPDE/transport/post_compare_manu.cpp
+++ b/examples/linearPDE/transport/post_compare_manu.cpp
@@ -59,8 +59,8 @@ int main( int argc, char * argv[] )
   std::unique_ptr<IQuadPts> quadv = QuadPtsFactory::createVolQuadrature(elemType, nqp_vol);
   std::unique_ptr<FEAElement> elementv = ElementFactory::createVolElement(elemType, nqp_vol);
 
-  const auto anode_mapping = VIS_T::readNodeMapping("node_mapping.h5", "old_2_new");
-  const auto pnode_mapping = VIS_T::readNodeMapping("post_node_mapping.h5", "new_2_old");
+  const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
+  const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
 
   PostVectSolution * pSolu = new PostVectSolution( sol_name,
       anode_mapping, pnode_mapping, pNode.get(), dof );

--- a/examples/linearPDE/transport/vis.cpp
+++ b/examples/linearPDE/transport/vis.cpp
@@ -15,8 +15,6 @@
 int main( int argc, char * argv[] ) 
 { 
   const std::string element_part_file = "epart.h5";
-  const std::string anode_mapping_file = "node_mapping.h5";
-  const std::string pnode_mapping_file = "post_node_mapping.h5";
   const std::string part_file="./ppart/part";
   constexpr int dof = 1;
 
@@ -110,8 +108,8 @@ int main( int argc, char * argv[] )
   
   std::ostringstream time_index;
 
-  const auto anode_mapping = VIS_T::readNodeMapping(anode_mapping_file, "old_2_new");
-  const auto pnode_mapping = VIS_T::readNodeMapping(pnode_mapping_file, "new_2_old");
+  const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
+  const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {

--- a/examples/ns/vis.cpp
+++ b/examples/ns/vis.cpp
@@ -16,8 +16,6 @@
 int main( int argc, char * argv[] )
 {
   const std::string element_part_file = "epart.h5";
-  const std::string anode_mapping_file = "node_mapping.h5";
-  const std::string pnode_mapping_file = "post_node_mapping.h5";
   const std::string part_file="postpart";
   const int dof = 4;
   
@@ -115,8 +113,8 @@ int main( int argc, char * argv[] )
 
   std::ostringstream time_index;
 
-  const auto anode_mapping = VIS_T::readNodeMapping(anode_mapping_file, "old_2_new");
-  const auto pnode_mapping = VIS_T::readNodeMapping(pnode_mapping_file, "new_2_old");
+  const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
+  const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {

--- a/examples/ns/vis_wss_hex27.cpp
+++ b/examples/ns/vis_wss_hex27.cpp
@@ -198,7 +198,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_quad = new FEAElement_Quad9_3D_der0( quad_vis->get_num_quadPts() );
 
   // Read the mappings of the nodal indices
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old" );
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old" );
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/ns/vis_wss_hex8.cpp
+++ b/examples/ns/vis_wss_hex8.cpp
@@ -198,7 +198,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_quad = new FEAElement_Quad4_3D_der0( quad_vis->get_num_quadPts() );
 
   // Read the mappings of the nodal indices
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old" );
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old" );
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/ns/vis_wss_tet10.cpp
+++ b/examples/ns/vis_wss_tet10.cpp
@@ -193,7 +193,7 @@ int main( int argc, char * argv[] )
   FEAElement * element_tri = new FEAElement_Triangle6_3D_der0( quad_tri_vis-> get_num_quadPts() );
 
   // Read the mappings of the nodal indices
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old" );
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old" );
 
   double * Rx = new double [v_nLocBas];
   double * Ry = new double [v_nLocBas];

--- a/examples/ns/vis_wss_tet4.cpp
+++ b/examples/ns/vis_wss_tet4.cpp
@@ -195,7 +195,7 @@ int main( int argc, char * argv[] )
   FEAElement * element = new FEAElement_Tet4( quad-> get_num_quadPts() );
 
   // Read the node mappings
-  const auto analysis_new2old = VIS_T::readNodeMapping("node_mapping.h5", "new_2_old" );
+  const auto analysis_new2old = HDF5_T::read_intVector("node_mapping.h5", "/", "new_2_old" );
 
   // Read solutions
   std::ostringstream time_index;

--- a/examples/test/sys_test.cpp
+++ b/examples/test/sys_test.cpp
@@ -96,7 +96,7 @@ int main()
   if(VEC_T::is_equal(old2new_map_1, old2new_map_2, 0)) std::cout<<"good!\n";
   else std::cout<<"bad\n";
 
-  std::vector<int> old2new_map_3 = VIS_T::readNodeMapping( node_mapping_file, "old_2_new", nNode );
+  std::vector<int> old2new_map_3 = HDF5_T::read_intVector( node_mapping_file.c_str(), "/", "old_2_new" );
 
   if(VEC_T::is_equal(old2new_map_1, old2new_map_3, 0)) std::cout<<"good!\n";
   else std::cout<<"bad\n";

--- a/include/Vis_Tools.hpp
+++ b/include/Vis_Tools.hpp
@@ -209,15 +209,6 @@ namespace VIS_T
   std::vector<int> read_epart( const std::string &epart_file, int esize );
 
   // ------------------------------------------------------------------------
-  // ! readNodeMapping: reads the old_2_new or new_2_old array into the nodemap 
-  //                  array, and check the length with node_size.
-  // \para node_mapping_file: the file that stores the mapping arrays
-  // \para mapping_type: data_name in the file: new_2_old / old_2_new
-  // ------------------------------------------------------------------------
-  std::vector<int> readNodeMapping( const std::string &node_mapping_file,
-        const char * const &mapping_type );
-
-  // ------------------------------------------------------------------------
   // ! readPETSc_vec: read a PETSc vector into memory as a double array
   //
   // Note: this function is rarely used alone, since the solution vector usually

--- a/src/Postproc_Tool/Vis_Tools.cpp
+++ b/src/Postproc_Tool/Vis_Tools.cpp
@@ -453,12 +453,6 @@ std::vector<int> VIS_T::read_epart( const std::string &epart_file, int esize )
   return elem_part;
 }
 
-std::vector<int> VIS_T::readNodeMapping( const std::string &node_mapping_file,
-    const char * const &mapping_type )
-{
-  return HDF5_T::read_intVector( node_mapping_file.c_str(), "/", mapping_type );
-}
-
 std::vector<double> VIS_T::readPETSc_vec(const std::string &solution_file_name)
 {
   Vec sol_temp;


### PR DESCRIPTION
### Motivation

- Replace the bespoke `VIS_T::readNodeMapping` helper with the centralized `HDF5_T::read_intVector` to read node-mapping arrays from HDF5 files and simplify/standardize I/O across postprocessing and visualization tools.

### Description

- Replaced calls to `VIS_T::readNodeMapping(...)` with `HDF5_T::read_intVector(..., "/", "<name>")` throughout multiple example visualization and postprocessing drivers and tests. 
- Removed the `VIS_T::readNodeMapping` declaration and its implementation from `Vis_Tools.hpp` and `Vis_Tools.cpp` respectively. 
- Deleted unused mapping-file string constants in several drivers where mappings are read directly by filename in the call. 
- Updated the test `examples/test/sys_test.cpp` to use `HDF5_T::read_intVector` for comparison.

### Testing

- Ran the mapping comparison test `examples/test/sys_test` which exercises the HDF5 readers for `old_2_new`/`new_2_old` and reported matching results (mapping equality). 
- Verified that the modified source files compile as part of the examples build (no compile errors observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf657e26d4832a81e843dca01a02cf)