### PR TITLE
Refactor HDF5_Reader call sites to use filename-based constructor

### DIFF
--- a/examples/ale_ns_rotate/driver.cpp
+++ b/examples/ale_ns_rotate/driver.cpp
@@ -227,12 +227,11 @@ int main(int argc, char *argv[])
   // ===== Data from Files =====
   // Read the info of rotation axis from h5file
   const std::string fName = SYS_T::gen_partfile_name( part_file, rank );
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
-  HDF5_Reader * h5r = new HDF5_Reader( file_id );
+  HDF5_Reader * h5r = new HDF5_Reader( fName );
   const std::string gname("/rotation");
   const Vector_3 point_rotated( h5r -> read_Vector_3( gname.c_str(), "point_rotated" ) );
   const Vector_3 angular_direction( h5r -> read_Vector_3( gname.c_str(), "angular_direction" ) );
-  delete h5r; H5Fclose( file_id );
+  delete h5r;
 
   // Control points' xyz coordinates
   auto fNode = SYS_T::make_unique<FEANode>(part_file, rank);

--- a/examples/ale_ns_rotate/prepost.cpp
+++ b/examples/ale_ns_rotate/prepost.cpp
@@ -24,9 +24,8 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if(sysret != 0, "ERROR: system call failed. \n");
 
   // Read preprocessor command-line arguements recorded in the .h5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   std::string fixed_geo_file = cmd_h5r -> read_string("/", "fixed_geo_file");
   std::string rotated_geo_file = cmd_h5r -> read_string("/", "rotated_geo_file");
@@ -36,7 +35,7 @@ int main( int argc, char * argv[] )
   int in_ncommon = cmd_h5r -> read_intScalar("/","in_ncommon");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("ns_prepost.yml");

--- a/examples/ale_ns_rotate/vis.cpp
+++ b/examples/ale_ns_rotate/vis.cpp
@@ -35,13 +35,12 @@ int main( int argc, char * argv[] )
   bool isXML = true, isRestart = false;
 
   // Read analysis code parameter if the solver_cmd.h5 exists
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== Initialize the MPI run =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/ale_ns_rotate/vis_wss_hex27.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex27.cpp
@@ -58,24 +58,23 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( SYS_T::get_MPI_size() != 1, "ERROR: vis_wss_hex27 is a serial program! \n");
 
   // Read the geometry file name from preprocessor hdf5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Enforce the element to be triquadratic hex for now
   if( elemType != FEType::Hex27 ) SYS_T::print_fatal("Error: element type should be triquadratic hex element.\n");

--- a/examples/ale_ns_rotate/vis_wss_hex8.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex8.cpp
@@ -58,24 +58,23 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( SYS_T::get_MPI_size() != 1, "ERROR: vis_wss_hex8 is a serial program! \n");
 
   // Read the geometry file name from preprocessor hdf5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Enforce the element to be trilinear hex for now
   if( elemType != FEType::Hex8 ) SYS_T::print_fatal("Error: element type should be trilinear hex element.\n");

--- a/examples/ale_ns_rotate/vis_wss_tet10.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet10.cpp
@@ -58,24 +58,23 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( SYS_T::get_MPI_size() != 1, "ERROR: vis_wss_tet10 is a serial program! \n");
 
   // Read the geometry file name from preprocessor hdf5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Enforce the element to be quadratic tet for now
   if( elemType != FEType::Tet10 ) SYS_T::print_fatal("Error: element type should be quadratic tet element.\n");

--- a/examples/ale_ns_rotate/vis_wss_tet4.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet4.cpp
@@ -49,24 +49,23 @@ int main( int argc, char * argv[] )
 
   // Directly read in the volumetric and wall file from the file
   // that record the preprocessor command lines.
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Now read the material properties from the solver cmd h5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
   
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // enforce this code is for linear element only
   SYS_T::print_fatal_if( elemType != FEType::Tet4, "Error: element type should be linear tet element.\n");

--- a/examples/fsi/prepost.cpp
+++ b/examples/fsi/prepost.cpp
@@ -31,9 +31,8 @@ int main( int argc, char * argv[] )
   const int num_fields = 2; // Two fields : pressure + velocity/displacement
   const std::vector<int> dof_fields {1, 3}; // pressure 1 ; velocity/displacement 3
 
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string sur_s_file_interior_wall = cmd_h5r -> read_string("/", "sur_s_file_interior_wall");
@@ -41,7 +40,7 @@ int main( int argc, char * argv[] )
   int in_ncommon = cmd_h5r -> read_intScalar("/","in_ncommon");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("fsi_prepost.yml");

--- a/examples/fsi/vis.cpp
+++ b/examples/fsi/vis.cpp
@@ -34,15 +34,14 @@ int main( int argc, char * argv[] )
   bool isClean = true;
 
   // Load analysis code parameter from solver_cmd.h5 file
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
   const int sol_rec_freq = cmd_h5r -> read_intScalar("/", "sol_record_freq");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== PETSc Initialization =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/fsi/vis_fluid.cpp
+++ b/examples/fsi/vis_fluid.cpp
@@ -34,15 +34,14 @@ int main( int argc, char * argv[] )
   bool isClean = true;
 
   // Load analysis code parameter from solver_cmd.h5 file
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
   const int sol_rec_freq = cmd_h5r -> read_intScalar("/", "sol_record_freq");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== PETSc Initialization =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/fsi/vis_fsi_wss.cpp
+++ b/examples/fsi/vis_fsi_wss.cpp
@@ -32,24 +32,22 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if(SYS_T::get_MPI_size() != 1, "ERROR: preprocessor needs to be run in serial.\n");
   
   // Read in the mesh file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_f_file_wall");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
   
-  hid_t anacmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT );
   
-  HDF5_Reader * ana_h5r = new HDF5_Reader( anacmd_file );
+  HDF5_Reader * ana_h5r = new HDF5_Reader( "solver_cmd.h5" );
   
   const std::string sol_bname = ana_h5r -> read_string("/", "sol_bName");
   
   const double fluid_mu = ana_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete ana_h5r; H5Fclose(anacmd_file);
+  delete ana_h5r;
 
   SYS_T::GetOptionInt("-time_index", time_index);
 

--- a/examples/fsi/vis_fsi_wss_hex8.cpp
+++ b/examples/fsi/vis_fsi_wss_hex8.cpp
@@ -57,26 +57,24 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if(SYS_T::get_MPI_size() != 1, "ERROR: preprocessor needs to be run in serial.\n");
   
   // Read in the mesh file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_f_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
   
-  hid_t anacmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT );
   
-  HDF5_Reader * ana_h5r = new HDF5_Reader( anacmd_file );
+  HDF5_Reader * ana_h5r = new HDF5_Reader( "solver_cmd.h5" );
   
   const std::string sol_bname = ana_h5r -> read_string("/", "sol_bName");
   
   const double fluid_mu = ana_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete ana_h5r; H5Fclose(anacmd_file);
+  delete ana_h5r;
 
   // Enforce the element to be trilinear hex for now
   if( elemType != FEType::Hex8 ) SYS_T::print_fatal("Error: element type should be trilinear hex element.\n");

--- a/examples/fsi/vis_fsi_wss_tet4.cpp
+++ b/examples/fsi/vis_fsi_wss_tet4.cpp
@@ -42,24 +42,22 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if(SYS_T::get_MPI_size() != 1, "ERROR: preprocessor needs to be run in serial.\n");
   
   // Read in the mesh file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_f_file_wall");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
   
-  hid_t anacmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT );
   
-  HDF5_Reader * ana_h5r = new HDF5_Reader( anacmd_file );
+  HDF5_Reader * ana_h5r = new HDF5_Reader( "solver_cmd.h5" );
   
   const std::string sol_bname = ana_h5r -> read_string("/", "sol_bName");
   
   const double fluid_mu = ana_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete ana_h5r; H5Fclose(anacmd_file);
+  delete ana_h5r;
 
   SYS_T::GetOptionInt("-time_start", time_start);
   SYS_T::GetOptionInt("-time_step", time_step);

--- a/examples/fsi/vis_solid.cpp
+++ b/examples/fsi/vis_solid.cpp
@@ -35,15 +35,14 @@ int main ( int argc , char * argv[] )
   bool isClean = true;
 
   // Load analysis code parameter from solver_cmd.h5 file
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
   const int sol_rec_freq = cmd_h5r -> read_intScalar("/", "sol_record_freq");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== PETSc Initialization =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/fsi/wall_ps_driver.cpp
+++ b/examples/fsi/wall_ps_driver.cpp
@@ -60,17 +60,15 @@ int main( int argc, char *argv[] )
 
   // We assume that a 3D solver has been called (to generate the wall traction)
   // and a suite of command line arguments has been saved to disk
-  hid_t solver_cmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( solver_cmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const int nqp_vol     = cmd_h5r -> read_intScalar(    "/", "nqp_vol");
   const int nqp_sur     = cmd_h5r -> read_intScalar(    "/", "nqp_sur");
 
-  delete cmd_h5r; H5Fclose(solver_cmd_file);
+  delete cmd_h5r;
 
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-  HDF5_Reader * pcmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * pcmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const std::string part_v_file = pcmd_h5r -> read_string(    "/", "part_file_v" );
   const std::string part_p_file = pcmd_h5r -> read_string(    "/", "part_file_p" );
@@ -78,7 +76,7 @@ int main( int argc, char *argv[] )
   const std::string elemType_str = pcmd_h5r -> read_string("/","elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete pcmd_h5r; H5Fclose(prepcmd_file);
+  delete pcmd_h5r;
 
   // Initialize PETSc
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/linearPDE/elastodynamics/vis.cpp
+++ b/examples/linearPDE/elastodynamics/vis.cpp
@@ -26,15 +26,14 @@ int main( int argc, char * argv[] )
   bool isXML = true, isRestart = false;
 
   // Read analysis code parameter if the solver_cmd.h5 exists
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt       = cmd_h5r -> read_doubleScalar("/","init_step");
   double module_E = cmd_h5r -> read_doubleScalar("/","youngs_module");
   double nu       = cmd_h5r -> read_doubleScalar("/","poissons_ratio");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== Initialize the MPI run =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/linearPDE/prepost.cpp
+++ b/examples/linearPDE/prepost.cpp
@@ -31,9 +31,8 @@ int main( int argc, char * argv[] )
   bool isDualGraph = true;
   
   // Read the problem setting recorded in the .h5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string elemType_str  = cmd_h5r -> read_string("/","elemType");
@@ -42,7 +41,7 @@ int main( int argc, char * argv[] )
   int in_ncommon       = cmd_h5r -> read_intScalar("/","in_ncommon");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("prepost.yml");

--- a/examples/linearPDE/transport/vis.cpp
+++ b/examples/linearPDE/transport/vis.cpp
@@ -26,13 +26,12 @@ int main( int argc, char * argv[] )
   bool isXML = true, isRestart = false;
 
   // Read analysis code parameter if the solver_cmd.h5 exists
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== Initialize the MPI run =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/ns/prepost.cpp
+++ b/examples/ns/prepost.cpp
@@ -24,9 +24,8 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if(sysret != 0, "ERROR: system call failed. \n");
 
   // Read preprocessor command-line arguements recorded in the .h5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string elemType_str = cmd_h5r -> read_string("/","elemType");
@@ -34,7 +33,7 @@ int main( int argc, char * argv[] )
   int in_ncommon = cmd_h5r -> read_intScalar("/","in_ncommon");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("ns_prepost.yml");

--- a/examples/ns/vis.cpp
+++ b/examples/ns/vis.cpp
@@ -27,13 +27,12 @@ int main( int argc, char * argv[] )
   bool isXML = true, isRestart = false;
 
   // Read analysis code parameter if the solver_cmd.h5 exists
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== Initialize the MPI run =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/ns/vis_wss_hex27.cpp
+++ b/examples/ns/vis_wss_hex27.cpp
@@ -58,24 +58,23 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( SYS_T::get_MPI_size() != 1, "ERROR: vis_wss_hex27 is a serial program! \n");
 
   // Read the geometry file name from preprocessor hdf5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Enforce the element to be triquadratic hex for now
   if( elemType != FEType::Hex27 ) SYS_T::print_fatal("Error: element type should be triquadratic hex element.\n");

--- a/examples/ns/vis_wss_hex8.cpp
+++ b/examples/ns/vis_wss_hex8.cpp
@@ -58,24 +58,23 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( SYS_T::get_MPI_size() != 1, "ERROR: vis_wss_hex8 is a serial program! \n");
 
   // Read the geometry file name from preprocessor hdf5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Enforce the element to be trilinear hex for now
   if( elemType != FEType::Hex8 ) SYS_T::print_fatal("Error: element type should be trilinear hex element.\n");

--- a/examples/ns/vis_wss_tet10.cpp
+++ b/examples/ns/vis_wss_tet10.cpp
@@ -58,24 +58,23 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( SYS_T::get_MPI_size() != 1, "ERROR: vis_wss_tet10 is a serial program! \n");
 
   // Read the geometry file name from preprocessor hdf5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Enforce the element to be quadratic tet for now
   if( elemType != FEType::Tet10 ) SYS_T::print_fatal("Error: element type should be quadratic tet element.\n");

--- a/examples/ns/vis_wss_tet4.cpp
+++ b/examples/ns/vis_wss_tet4.cpp
@@ -49,24 +49,23 @@ int main( int argc, char * argv[] )
 
   // Directly read in the volumetric and wall file from the file
   // that record the preprocessor command lines.
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   const std::string geo_file  = cmd_h5r -> read_string("/", "geo_file");
   const std::string wall_file = cmd_h5r -> read_string("/", "sur_file_wall");
   const std::string elemType_str = cmd_h5r -> read_string("/", "elemType");
   const FEType elemType = FE_T::to_FEType(elemType_str);
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // Now read the material properties from the solver cmd h5 file
   prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
   
-  cmd_h5r = new HDF5_Reader( prepcmd_file );
+  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
   
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // enforce this code is for linear element only
   SYS_T::print_fatal_if( elemType != FEType::Tet4, "Error: element type should be linear tet element.\n");

--- a/include/AGlobal_Mesh_Info.hpp
+++ b/include/AGlobal_Mesh_Info.hpp
@@ -17,9 +17,8 @@ class AGlobal_Mesh_Info
     {
       const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-      hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-      std::unique_ptr<HDF5_Reader> h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+      std::unique_ptr<HDF5_Reader> h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
       nElem    = h5r -> read_intScalar("Global_Mesh_Info", "nElem");
       nFunc    = h5r -> read_intScalar("Global_Mesh_Info", "nFunc");
@@ -27,7 +26,6 @@ class AGlobal_Mesh_Info
       probDim  = h5r -> read_intScalar("Global_Mesh_Info", "probDim");
       elemType = FE_T::to_FEType(h5r -> read_string("Global_Mesh_Info", "elemType"));
 
-      H5Fclose( file_id );
     }
 
     AGlobal_Mesh_Info( const HDF5_Reader * const &h5r )

--- a/include/ANL_Tools.hpp
+++ b/include/ANL_Tools.hpp
@@ -19,13 +19,11 @@ namespace ANL_T
   {
     const std::string fName = SYS_T::gen_partfile_name(fbasename, in_rank);
 
-    hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
-    auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+    auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
     const int val = h5r->read_intScalar(partname.c_str(), dataname.c_str());
 
-    H5Fclose(file_id);
     return val;
   }
 
@@ -48,13 +46,11 @@ namespace ANL_T
   {
     const std::string fName = SYS_T::gen_partfile_name(fbasename, in_rank);
 
-    hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
-    auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+    auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
     auto elemType = FE_T::to_FEType(h5r->read_string("Global_Mesh_Info", "elemType"));
 
-    H5Fclose(file_id);
     return elemType;
   }
 

--- a/src/Analysis_Tool/ALocal_EBC.cpp
+++ b/src/Analysis_Tool/ALocal_EBC.cpp
@@ -5,9 +5,8 @@ ALocal_EBC::ALocal_EBC( const std::string &fileBaseName,
 {
   std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   num_ebc = h5r -> read_intScalar(gname.c_str(), "num_ebc");
 
@@ -52,7 +51,6 @@ ALocal_EBC::ALocal_EBC( const std::string &fileBaseName,
     }
   }
 
-  H5Fclose( file_id );
 }
 
 ALocal_EBC::ALocal_EBC( const HDF5_Reader * const &h5r,

--- a/src/Analysis_Tool/ALocal_EBC_outflow.cpp
+++ b/src/Analysis_Tool/ALocal_EBC_outflow.cpp
@@ -7,8 +7,7 @@ ALocal_EBC_outflow::ALocal_EBC_outflow( const std::string &fileBaseName,
   // Read in the integral of basis function, LID, and outward normal vector
   // for the faces with id ebc
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
   
   intNA.resize(  num_ebc ); LID.resize( num_ebc );
   outvec.resize( num_ebc ); num_face_nodes.resize( num_ebc );
@@ -34,7 +33,6 @@ ALocal_EBC_outflow::ALocal_EBC_outflow( const std::string &fileBaseName,
     }
   }
 
-  H5Fclose( file_id );
 }
 
 ALocal_EBC_outflow::ALocal_EBC_outflow( const HDF5_Reader * const &h5r,

--- a/src/Analysis_Tool/ALocal_Elem.cpp
+++ b/src/Analysis_Tool/ALocal_Elem.cpp
@@ -5,9 +5,8 @@ ALocal_Elem::ALocal_Elem(const std::string &fileBaseName, int cpu_rank)
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   elem_loc = h5r->read_intVector( "/Local_Elem", "elem_loc" );
 
@@ -23,7 +22,6 @@ ALocal_Elem::ALocal_Elem(const std::string &fileBaseName, int cpu_rank)
   else
     elem_tag.clear();
     
-  H5Fclose( file_id );
 }
 
 ALocal_Elem::ALocal_Elem(const HDF5_Reader * const &h5r)

--- a/src/Analysis_Tool/ALocal_IEN.cpp
+++ b/src/Analysis_Tool/ALocal_IEN.cpp
@@ -5,9 +5,8 @@ ALocal_IEN::ALocal_IEN( const std::string &fileBaseName, int cpu_rank )
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   nlocalele = h5r -> read_intScalar("Local_Elem", "nlocalele");
 
@@ -16,7 +15,6 @@ ALocal_IEN::ALocal_IEN( const std::string &fileBaseName, int cpu_rank )
   int num_row, num_col;
   LIEN = h5r -> read_intMatrix("LIEN", "LIEN", num_row, num_col);
   
-  H5Fclose( file_id );
 
   SYS_T::print_fatal_if( num_row != nlocalele, "Error: ALocal_IEN::LIEN size does not match the number of element. \n");
 

--- a/src/Analysis_Tool/ALocal_InflowBC.cpp
+++ b/src/Analysis_Tool/ALocal_InflowBC.cpp
@@ -5,9 +5,8 @@ ALocal_InflowBC::ALocal_InflowBC(
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   const std::string gname("/inflow");
 
@@ -86,7 +85,6 @@ ALocal_InflowBC::ALocal_InflowBC(
     }
   } // end nbc_id-loop
 
-  H5Fclose( file_id );
 }
 
 ALocal_InflowBC::ALocal_InflowBC( const HDF5_Reader * const &h5r )

--- a/src/Analysis_Tool/ALocal_Interface.cpp
+++ b/src/Analysis_Tool/ALocal_Interface.cpp
@@ -4,9 +4,8 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   const std::string gname("/sliding");
 
@@ -131,7 +130,6 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
     }
   }
 
-  H5Fclose( file_id );
 }
 
 ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )

--- a/src/Analysis_Tool/ALocal_NBC.cpp
+++ b/src/Analysis_Tool/ALocal_NBC.cpp
@@ -6,9 +6,8 @@ ALocal_NBC::ALocal_NBC( const std::string &fileBaseName,
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   nlocghonode = h5r->read_intScalar( "Local_Node", "nlocghonode" );
   LID = h5r->read_intVector( gname.c_str(), "LID" );
@@ -51,7 +50,6 @@ ALocal_NBC::ALocal_NBC( const std::string &fileBaseName,
   SYS_T::print_fatal_if( int(LocalMaster.size()) != VEC_T::sum( Num_LPM ), "Error: ALocal_NBC, LocalMaster length does not match Num_LPM. \n" );
   SYS_T::print_fatal_if( int(LocalMasterSlave.size()) != VEC_T::sum( Num_LPM ), "Error: ALocal_NBC, LocalMasterSlave length does not match Num_LPM. \n" );
 
-  H5Fclose( file_id );
 
   // Generate the offsets 
   LD_offset.clear(); LPS_offset.clear(); LPM_offset.clear();

--- a/src/Analysis_Tool/ALocal_RotatedBC.cpp
+++ b/src/Analysis_Tool/ALocal_RotatedBC.cpp
@@ -5,9 +5,8 @@ ALocal_RotatedBC::ALocal_RotatedBC(
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   const std::string gname("/rotated_nbc"); 
 
@@ -70,7 +69,6 @@ ALocal_RotatedBC::ALocal_RotatedBC(
     local_node_pos.clear();
   }
 
-  H5Fclose( file_id );
 }
 
 ALocal_RotatedBC::ALocal_RotatedBC( const HDF5_Reader * const &h5r )

--- a/src/Analysis_Tool/ALocal_WeakBC.cpp
+++ b/src/Analysis_Tool/ALocal_WeakBC.cpp
@@ -5,9 +5,8 @@ ALocal_WeakBC::ALocal_WeakBC( const std::string &fileBaseName,
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   const std::string gname("/weak");
 
@@ -31,7 +30,6 @@ ALocal_WeakBC::ALocal_WeakBC( const std::string &fileBaseName,
     ele_face_id = {};
   }
 
-  H5Fclose( file_id );
 }
 
 ALocal_WeakBC::ALocal_WeakBC( const HDF5_Reader * const &h5r )

--- a/src/Analysis_Tool/APart_Node.cpp
+++ b/src/Analysis_Tool/APart_Node.cpp
@@ -5,9 +5,8 @@ APart_Node::APart_Node( const std::string &fbasename, int rank )
 {
   const std::string fName = SYS_T::gen_partfile_name( fbasename, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
   
   nlocalnode  = h5r->read_intScalar("Local_Node", "nlocalnode");
   nghostnode  = h5r->read_intScalar("Local_Node", "nghostnode");
@@ -26,7 +25,6 @@ APart_Node::APart_Node( const std::string &fbasename, int rank )
 
   dof = h5r->read_intScalar("Global_Mesh_Info", "dofNum");
 
-  H5Fclose( file_id );
 }
 
 APart_Node::APart_Node( const HDF5_Reader * const &h5r )

--- a/src/Analysis_Tool/APart_Node_FSI.cpp
+++ b/src/Analysis_Tool/APart_Node_FSI.cpp
@@ -5,9 +5,8 @@ APart_Node_FSI::APart_Node_FSI(const std::string &fileBaseName, int rank )
 {
   std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   const std::string gname("Local_Node");
 
@@ -20,7 +19,6 @@ APart_Node_FSI::APart_Node_FSI(const std::string &fileBaseName, int rank )
   if(nlocalnode_solid > 0)
     node_loc_solid = h5r -> read_intVector( gname.c_str(), "node_loc_solid" );
 
-  H5Fclose( file_id );
 }
 
 APart_Node_FSI::APart_Node_FSI(const HDF5_Reader * const &h5r)

--- a/src/Analysis_Tool/APart_Node_Rotated.cpp
+++ b/src/Analysis_Tool/APart_Node_Rotated.cpp
@@ -5,9 +5,8 @@ APart_Node_Rotated::APart_Node_Rotated(const std::string &fileBaseName, int rank
 {
   std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   const std::string gname("Local_Node");
 
@@ -20,7 +19,6 @@ APart_Node_Rotated::APart_Node_Rotated(const std::string &fileBaseName, int rank
   if(nlocalnode_rotated > 0)
     node_loc_rotated = h5r -> read_intVector( gname.c_str(), "node_loc_rotated" );
 
-  H5Fclose( file_id );
 }
 
 APart_Node_Rotated::APart_Node_Rotated(const HDF5_Reader * const &h5r)

--- a/src/Analysis_Tool/FEANode.cpp
+++ b/src/Analysis_Tool/FEANode.cpp
@@ -4,9 +4,8 @@ FEANode::FEANode( const std::string &fileBaseName, int cpu_rank )
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   ctrlPts_x = h5r -> read_doubleVector("ctrlPts_loc", "ctrlPts_x_loc");
   ctrlPts_y = h5r -> read_doubleVector("ctrlPts_loc", "ctrlPts_y_loc");
@@ -18,7 +17,6 @@ FEANode::FEANode( const std::string &fileBaseName, int cpu_rank )
   else
     VEC_T::clean( ctrlPts_w );
 
-  H5Fclose( file_id );
 }
 
 FEANode::FEANode( const HDF5_Reader * const &h5r )

--- a/src/Mesh/Global_Part_Reload.cpp
+++ b/src/Mesh/Global_Part_Reload.cpp
@@ -8,9 +8,8 @@ Global_Part_Reload::Global_Part_Reload( const int &cpu_size,
   // --------------------------------------------------------------------------
   const std::string efName = element_part_name + ".h5";
 
-  hid_t efile_id = H5Fopen( efName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  HDF5_Reader * eh5r = new HDF5_Reader( efile_id );
+  HDF5_Reader * eh5r = new HDF5_Reader( efName );
   
   int temp = eh5r -> read_intScalar("/", "isMETIS");
   if( temp == 1 ) isMETIS = true;
@@ -30,20 +29,19 @@ Global_Part_Reload::Global_Part_Reload( const int &cpu_size,
 
   epart = eh5r -> read_intVector("/", "part");
 
-  delete eh5r; H5Fclose( efile_id );
+  delete eh5r;
 
   // --------------------------------------------------------------------------
   const std::string nfName = node_part_name + ".h5";
 
-  hid_t nfile_id = H5Fopen( nfName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  HDF5_Reader * nh5r = new HDF5_Reader( nfile_id );
+  HDF5_Reader * nh5r = new HDF5_Reader( nfName );
 
   npart = nh5r -> read_intVector("/", "part");
   
   field_offset = nh5r -> read_intVector("/", "field_offset");
 
-  delete nh5r; H5Fclose( nfile_id );
+  delete nh5r;
   // --------------------------------------------------------------------------
 
   SYS_T::print_fatal_if( cpu_size != cpusize, "Error: Global_Part_Reload cpu_size is incompatible with prior partition.\n" );

--- a/src/Mesh/Map_Node_Index.cpp
+++ b/src/Mesh/Map_Node_Index.cpp
@@ -34,14 +34,13 @@ Map_Node_Index::Map_Node_Index( const char * const &fileName )
   std::string fName( fileName );
   fName.append(".h5");
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-  HDF5_Reader * h5r = new HDF5_Reader( file_id );
+  HDF5_Reader * h5r = new HDF5_Reader( fName );
 
   old_2_new = h5r -> read_intVector("/", "old_2_new");
   new_2_old = h5r -> read_intVector("/", "new_2_old");
 
-  delete h5r; H5Fclose( file_id );
+  delete h5r;
   
   std::cout<<"-- mapping generated. Memory usage: ";
   SYS_T::print_mem_size( double(old_2_new.size())*2.0*sizeof(int) );
@@ -73,7 +72,7 @@ void Map_Node_Index::write_hdf5( const std::string &fileName ) const
   h5w -> write_intVector( "old_2_new", old_2_new );
   h5w -> write_intVector( "new_2_old", new_2_old );
 
-  delete h5w; H5Fclose(file_id);
+  delete h5w;
 }
 
 // EOF

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -125,8 +125,7 @@ Part_FEM::Part_FEM( const std::string &inputfileName, const int &in_cpu_rank )
 {
   const std::string fName = SYS_T::gen_partfile_name( inputfileName, in_cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
-  HDF5_Reader * h5r = new HDF5_Reader( file_id );
+  HDF5_Reader * h5r = new HDF5_Reader( fName );
 
   // local elements 
   elem_loc = h5r->read_intVector( "Local_Elem", "elem_loc" );
@@ -193,7 +192,7 @@ Part_FEM::Part_FEM( const std::string &inputfileName, const int &in_cpu_rank )
     ctrlPts_z_loc = h5r -> read_doubleVector("ctrlPts_loc", "ctrlPts_z_loc");
   }
 
-  delete h5r; H5Fclose( file_id );
+  delete h5r;
 }
 
 Part_FEM::~Part_FEM()
@@ -417,7 +416,6 @@ void Part_FEM::write( const std::string &inputFileName ) const
 
   // Finish writing, clean up
   delete h5w;
-  H5Fclose(file_id);
 }
 
 void Part_FEM::print_part_ele() const

--- a/src/Mesh/Sliding_Interface_Tools.cpp
+++ b/src/Mesh/Sliding_Interface_Tools.cpp
@@ -7,9 +7,8 @@ namespace SI_T
   {
     const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-    hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
 
-    HDF5_Reader * h5r = new HDF5_Reader( file_id );
+    HDF5_Reader * h5r = new HDF5_Reader( fName );
 
     const std::string gname("/sliding");
 
@@ -60,7 +59,7 @@ namespace SI_T
       rotated_node_loc_pos[ii] = h5r -> read_intVector( subgroup_name.c_str(), "rotated_node_loc_pos" );
     }
 
-    delete h5r; H5Fclose( file_id );
+    delete h5r;
   }
 
   void SI_solution::update_node_sol(const PDNSolution * const &sol)

--- a/src/Model/Tissue_prestress.cpp
+++ b/src/Model/Tissue_prestress.cpp
@@ -34,9 +34,8 @@ Tissue_prestress::Tissue_prestress(
       const std::string ps_fName = SYS_T::gen_partfile_name( ps_fileBaseName, cpu_rank );
       if( SYS_T::file_exist(ps_fName) )
       {
-        hid_t ps_file_id = H5Fopen(ps_fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
-        HDF5_Reader * ps_h5r = new HDF5_Reader( ps_file_id );
+        HDF5_Reader * ps_h5r = new HDF5_Reader( ps_fName );
 
         const int ps_size = ps_h5r -> read_intScalar("/", "ps_array_size"); 
 
@@ -44,7 +43,7 @@ Tissue_prestress::Tissue_prestress(
 
         qua_ps_array = ps_h5r -> read_doubleVector("/", "prestress");
 
-        delete ps_h5r; H5Fclose(ps_file_id);
+        delete ps_h5r;
       }
       else
         SYS_T::print_fatal("Error: prestress file %s cannot be found.\n", ps_fName.c_str());

--- a/tools/solution_converter/conv_driver.cpp
+++ b/tools/solution_converter/conv_driver.cpp
@@ -54,22 +54,20 @@ int main( int argc, char * argv[] )
   SYS_T::file_check(sol_name);
 
   // Obtain the new_to_old vector from the old mapping
-  hid_t h5id_onm = H5Fopen(old_nmap.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * onm_h5r = new HDF5_Reader( h5id_onm );
+  HDF5_Reader * onm_h5r = new HDF5_Reader( old_nmap );
 
   std::vector<int> old_map = onm_h5r-> read_intVector( "/", "old_2_new" );
 
-  delete onm_h5r; H5Fclose(h5id_onm);
+  delete onm_h5r;
 
   // Obtain the old_to_new vector from the new mapping
-  hid_t h5id_nnm = H5Fopen(new_nmap.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * nnm_h5r = new HDF5_Reader( h5id_nnm );
+  HDF5_Reader * nnm_h5r = new HDF5_Reader( new_nmap );
 
   std::vector<int> new_map = nnm_h5r-> read_intVector( "/", "old_2_new" );
 
-  delete nnm_h5r; H5Fclose(h5id_nnm);
+  delete nnm_h5r;
 
   // Check the length of the two vectors, if they match, we assign
   // the lenght to the value of nFunc

--- a/tools/stress_recovery/vis_smooth.cpp
+++ b/tools/stress_recovery/vis_smooth.cpp
@@ -31,13 +31,12 @@ int main( int argc, char * argv[] )
   bool isXML = true, isRestart = false;
 
   // Read analysis code parameter if the solver_cmd.h5 exists
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  HDF5_Reader * cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
+  delete cmd_h5r;
 
   // ===== Initialize the MPI run =====
 #if PETSC_VERSION_LT(3,19,0)


### PR DESCRIPTION
### Motivation
- The HDF5 reader was changed to open files by filename (RAII) so call sites should stop passing raw `hid_t` handles and avoid duplicate `H5Fopen/H5Fclose` pairs.
- Updating call sites reduces file-handle lifecycle bugs and centralizes file ownership inside `HDF5_Reader`.

### Description
- Replaced usages that constructed `HDF5_Reader` with `hid_t` file handles to construct with the file name (e.g. `HDF5_Reader(fName)` or `make_unique<HDF5_Reader>(fName)`), and removed the corresponding local `H5Fopen`/`H5Fclose` calls.
- Updated core utility headers `include/ANL_Tools.hpp` and `include/AGlobal_Mesh_Info.hpp` to use filename-based construction.
- Applied the migration across analysis, mesh, model, example and tool code (many files under `src/Analysis_Tool/*`, `src/Mesh/*`, `src/Model/*`, `examples/*`, `tools/*`) so examples and utilities now pass filenames such as `"solver_cmd.h5"` or `fName` to `HDF5_Reader`.
- Removed redundant file-closure calls following the change so the `HDF5_Reader` instance now fully owns file lifetime (RAII).

### Testing
- Ran `git diff --check` to ensure no whitespace/errors and it succeeded.
- Searched the tree for the old handle-based constructor patterns and confirmed they were removed via pattern scans using `rg`, which succeeded.
- Attempted to run `cmake -S . -B build` but it failed because the repository root in the environment does not contain a `CMakeLists.txt`, so a full build/test could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18e6a36d4832a9127c37a7ce25fcd)