### PR TITLE
Read `solver_cmd.h5` correctly in vis_wss example programs

### DIFF
--- a/examples/ale_ns_rotate/vis_wss_hex27.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex27.cpp
@@ -68,9 +68,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ale_ns_rotate/vis_wss_hex8.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex8.cpp
@@ -68,9 +68,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ale_ns_rotate/vis_wss_tet10.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet10.cpp
@@ -68,9 +68,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ale_ns_rotate/vis_wss_tet4.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet4.cpp
@@ -59,9 +59,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Now read the material properties from the solver cmd h5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-  
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
   
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ns/vis_wss_hex27.cpp
+++ b/examples/ns/vis_wss_hex27.cpp
@@ -68,9 +68,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ns/vis_wss_hex8.cpp
+++ b/examples/ns/vis_wss_hex8.cpp
@@ -68,9 +68,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ns/vis_wss_tet10.cpp
+++ b/examples/ns/vis_wss_tet10.cpp
@@ -68,9 +68,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Read the material property from the solver HDF5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
 
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 

--- a/examples/ns/vis_wss_tet4.cpp
+++ b/examples/ns/vis_wss_tet4.cpp
@@ -59,9 +59,7 @@ int main( int argc, char * argv[] )
   delete cmd_h5r;
 
   // Now read the material properties from the solver cmd h5 file
-  prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-  
-  cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  cmd_h5r = new HDF5_Reader( "solver_cmd.h5" );
   
   const double fluid_mu = cmd_h5r -> read_doubleScalar("/", "fl_mu");
 


### PR DESCRIPTION
### Motivation
- Fix an incorrect HDF5 reader usage where the code opened `solver_cmd.h5` via `H5Fopen` but then instantiated the `HDF5_Reader` on `preprocessor_cmd.h5`, causing the fluid viscosity (`fl_mu`) to be read from the wrong file.

### Description
- Replace the stray `H5Fopen` usage and the subsequent `preprocessor_cmd.h5` reader with a direct `HDF5_Reader("solver_cmd.h5")` call to read `fl_mu` in the vis WSS example programs; changes applied to `examples/ns/vis_wss_hex27.cpp`, `examples/ns/vis_wss_hex8.cpp`, `examples/ns/vis_wss_tet10.cpp`, and `examples/ns/vis_wss_tet4.cpp`.

### Testing
- Compiled the modified examples with the project build system and the affected `vis_wss_*` sources built successfully."}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19393f0e0832aad99d4a48d689c4b)