### PR TITLE
Restore missing H5Fclose calls for mesh HDF5 output

### DIFF
--- a/src/Mesh/Map_Node_Index.cpp
+++ b/src/Mesh/Map_Node_Index.cpp
@@ -73,6 +73,7 @@ void Map_Node_Index::write_hdf5( const std::string &fileName ) const
   h5w -> write_intVector( "new_2_old", new_2_old );
 
   delete h5w;
+  H5Fclose(file_id);
 }
 
 // EOF

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -416,6 +416,7 @@ void Part_FEM::write( const std::string &inputFileName ) const
 
   // Finish writing, clean up
   delete h5w;
+  H5Fclose(file_id);
 }
 
 void Part_FEM::print_part_ele() const


### PR DESCRIPTION
### Motivation
- Restore the HDF5 file close calls so the underlying `file_id` handles are properly released when writing mesh-related HDF5 output (`Part_FEM::write` and `Map_Node_Index::write_hdf5`).

### Description
- Re-added `H5Fclose(file_id);` after deleting the `HDF5_Writer` in `src/Mesh/Part_FEM.cpp` and `src/Mesh/Map_Node_Index.cpp` to ensure files are closed.

### Testing
- Ran `git diff` and `nl`/file-inspection commands to verify the two `H5Fclose` insertions and committed the change (commit `9f7124f`), and those verification commands succeeded.
- No full build or automated test suite was run for this small housekeeping change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e199219420832a907e54e88c124ba1)