### PR TITLE
Refactor non-example HDF5_Reader usage to smart pointers

### DIFF
--- a/include/HDF5_Reader.hpp
+++ b/include/HDF5_Reader.hpp
@@ -11,11 +11,10 @@
 //
 // A typical way of using this class is:
 //
-// HDF5_Reader * h5r = new HDF5_Reader( name_of_h5_file );
+// auto h5r = SYS_T::make_unique<HDF5_Reader>(name_of_h5_file);
 //
 // call read functions
-//
-// delete h5r;
+// (resource is released automatically when h5r goes out of scope)
 //
 // There are two modes for H5Fopen
 // H5F_ACC_RDONLY: the application will read only the file

--- a/src/Mesh/Global_Part_Reload.cpp
+++ b/src/Mesh/Global_Part_Reload.cpp
@@ -9,7 +9,7 @@ Global_Part_Reload::Global_Part_Reload( const int &cpu_size,
   const std::string efName = element_part_name + ".h5";
 
 
-  HDF5_Reader * eh5r = new HDF5_Reader( efName );
+  auto eh5r = SYS_T::make_unique<HDF5_Reader>(efName);
   
   int temp = eh5r -> read_intScalar("/", "isMETIS");
   if( temp == 1 ) isMETIS = true;
@@ -29,19 +29,16 @@ Global_Part_Reload::Global_Part_Reload( const int &cpu_size,
 
   epart = eh5r -> read_intVector("/", "part");
 
-  delete eh5r;
-
   // --------------------------------------------------------------------------
   const std::string nfName = node_part_name + ".h5";
 
 
-  HDF5_Reader * nh5r = new HDF5_Reader( nfName );
+  auto nh5r = SYS_T::make_unique<HDF5_Reader>(nfName);
 
   npart = nh5r -> read_intVector("/", "part");
   
   field_offset = nh5r -> read_intVector("/", "field_offset");
 
-  delete nh5r;
   // --------------------------------------------------------------------------
 
   SYS_T::print_fatal_if( cpu_size != cpusize, "Error: Global_Part_Reload cpu_size is incompatible with prior partition.\n" );

--- a/src/Mesh/Map_Node_Index.cpp
+++ b/src/Mesh/Map_Node_Index.cpp
@@ -35,13 +35,11 @@ Map_Node_Index::Map_Node_Index( const char * const &fileName )
   fName.append(".h5");
 
 
-  HDF5_Reader * h5r = new HDF5_Reader( fName );
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   old_2_new = h5r -> read_intVector("/", "old_2_new");
   new_2_old = h5r -> read_intVector("/", "new_2_old");
 
-  delete h5r;
-  
   std::cout<<"-- mapping generated. Memory usage: ";
   SYS_T::print_mem_size( double(old_2_new.size())*2.0*sizeof(int) );
   std::cout<<std::endl<<"=== Node index mapping loaded.\n";

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -125,7 +125,7 @@ Part_FEM::Part_FEM( const std::string &inputfileName, const int &in_cpu_rank )
 {
   const std::string fName = SYS_T::gen_partfile_name( inputfileName, in_cpu_rank );
 
-  HDF5_Reader * h5r = new HDF5_Reader( fName );
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   // local elements 
   elem_loc = h5r->read_intVector( "Local_Elem", "elem_loc" );
@@ -192,7 +192,6 @@ Part_FEM::Part_FEM( const std::string &inputfileName, const int &in_cpu_rank )
     ctrlPts_z_loc = h5r -> read_doubleVector("ctrlPts_loc", "ctrlPts_z_loc");
   }
 
-  delete h5r;
 }
 
 Part_FEM::~Part_FEM()

--- a/src/Mesh/Sliding_Interface_Tools.cpp
+++ b/src/Mesh/Sliding_Interface_Tools.cpp
@@ -8,7 +8,7 @@ namespace SI_T
     const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
 
-    HDF5_Reader * h5r = new HDF5_Reader( fName );
+    auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
     const std::string gname("/sliding");
 
@@ -59,7 +59,6 @@ namespace SI_T
       rotated_node_loc_pos[ii] = h5r -> read_intVector( subgroup_name.c_str(), "rotated_node_loc_pos" );
     }
 
-    delete h5r;
   }
 
   void SI_solution::update_node_sol(const PDNSolution * const &sol)

--- a/src/Model/Tissue_prestress.cpp
+++ b/src/Model/Tissue_prestress.cpp
@@ -35,7 +35,7 @@ Tissue_prestress::Tissue_prestress(
       if( SYS_T::file_exist(ps_fName) )
       {
 
-        HDF5_Reader * ps_h5r = new HDF5_Reader( ps_fName );
+        auto ps_h5r = SYS_T::make_unique<HDF5_Reader>(ps_fName);
 
         const int ps_size = ps_h5r -> read_intScalar("/", "ps_array_size"); 
 
@@ -43,7 +43,6 @@ Tissue_prestress::Tissue_prestress(
 
         qua_ps_array = ps_h5r -> read_doubleVector("/", "prestress");
 
-        delete ps_h5r;
       }
       else
         SYS_T::print_fatal("Error: prestress file %s cannot be found.\n", ps_fName.c_str());


### PR DESCRIPTION
### Motivation
- Replace manual `new`/`delete` usage of `HDF5_Reader` in non-example code paths with RAII so resource lifetime is automatic and leaks/double-deletes are avoided.

### Description
- Replaced `HDF5_Reader * h5r = new HDF5_Reader(...)` with `auto h5r = SYS_T::make_unique<HDF5_Reader>(...)` and removed corresponding `delete` calls in runtime code paths.
- Updated the `HDF5_Reader` usage comment in `include/HDF5_Reader.hpp` to show smart-pointer construction and note automatic release.
- Modified files: `src/Mesh/Sliding_Interface_Tools.cpp`, `src/Mesh/Global_Part_Reload.cpp`, `src/Mesh/Map_Node_Index.cpp`, `src/Mesh/Part_FEM.cpp`, `src/Model/Tissue_prestress.cpp`, and `include/HDF5_Reader.hpp`.

### Testing
- Ran `rg -n "new\s+HDF5_Reader" src include` to verify there are no remaining raw allocations and the check returned `NOT_FOUND` indicating success.
- Ran `git diff --check` to ensure no whitespace/format issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19d47a0e0832a9a3e2b0b62edd3a6)