### PR TITLE
Refactor HDF5_Writer call sites to use filename-based constructor

### DIFF
--- a/examples/ale_ns_rotate/driver.cpp
+++ b/examples/ale_ns_rotate/driver.cpp
@@ -207,9 +207,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5",
-        H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("fl_density", fluid_density);
     cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
@@ -219,7 +217,7 @@ int main(int argc, char *argv[])
     cmdh5w->write_doubleScalar("angular_velo", angular_velo);
     cmdh5w->write_string("inflow_file", inflow_file);
     
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ale_ns_rotate/preprocess.cpp
+++ b/examples/ale_ns_rotate/preprocess.cpp
@@ -183,8 +183,7 @@ int main( int argc, char * argv[] )
   }
 
   // Record the problem setting into a HDF5 file: preprocessor_cmd.h5
-  hid_t cmd_file_id = H5Fcreate("preprocessor_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+  HDF5_Writer * cmdh5w = new HDF5_Writer("preprocessor_cmd.h5");
 
   cmdh5w->write_intScalar("num_inlet", num_inlet);
   cmdh5w->write_intScalar("num_outlet", num_outlet);
@@ -203,7 +202,7 @@ int main( int argc, char * argv[] )
   cmdh5w->write_string("rotated_interface_base", rotated_interface_base);
   cmdh5w->write_string("part_file", part_file);
 
-  delete cmdh5w; H5Fclose(cmd_file_id);
+  delete cmdh5w;
 
   // Read the volumetric mesh file from the vtu file: fixed_geo_file
   int nFunc, nElem;
@@ -471,7 +470,7 @@ int main( int argc, char * argv[] )
     const std::string fName = SYS_T::gen_partfile_name( part_file, part->get_cpu_rank() );
     hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
     hid_t g_id = H5Gcreate(file_id, "/rotation", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * h5w = new HDF5_Writer( file_id );
+    HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
     h5w -> write_Vector_3( g_id, "point_rotated", point_rotated.to_std_array() );
     h5w -> write_Vector_3( g_id, "angular_direction", angular_direction.to_std_array() );
 
@@ -561,7 +560,7 @@ int main( int argc, char * argv[] )
 
     hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
 
-    HDF5_Writer * h5w = new HDF5_Writer( file_id );
+    HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
     h5w -> write_intVector( g_id, "max_num_local_fixed_cell", max_fixed_nlocalele );
 

--- a/examples/fsi/driver.cpp
+++ b/examples/fsi/driver.cpp
@@ -210,8 +210,7 @@ int main(int argc, char *argv[])
   // ===== Record important parameters =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar(  "fl_density",      fluid_density);
     cmdh5w->write_doubleScalar(  "fl_mu",           fluid_mu);
@@ -233,7 +232,7 @@ int main(int argc, char *argv[])
     cmdh5w->write_string("time",              SYS_T::get_time() );
     cmdh5w->write_string("petsc-version",     PETSc_T::get_version() );
 
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/fsi/preprocess.cpp
+++ b/examples/fsi/preprocess.cpp
@@ -161,8 +161,7 @@ int main( int argc, char * argv[] )
 
   // ----- Write the input argument into a HDF5 file
   SYS_T::execute("rm -rf preprocessor_cmd.h5");
-  hid_t cmd_file_id = H5Fcreate("preprocessor_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+  HDF5_Writer * cmdh5w = new HDF5_Writer("preprocessor_cmd.h5");
 
   cmdh5w->write_intScalar("num_outlet",       num_outlet);
   cmdh5w->write_intScalar("num_inlet",        num_inlet);
@@ -186,7 +185,7 @@ int main( int argc, char * argv[] )
   cmdh5w->write_string("date",                SYS_T::get_date() );
   cmdh5w->write_string("time",                SYS_T::get_time() );
 
-  delete cmdh5w; H5Fclose(cmd_file_id);
+  delete cmdh5w;
   // ----- Finish writing
 
   // Read the geometry file for the whole FSI domain for the velocity /

--- a/examples/fsi/wall_ps_driver.cpp
+++ b/examples/fsi/wall_ps_driver.cpp
@@ -166,13 +166,12 @@ int main( int argc, char *argv[] )
   // ====== Record important parameters ======
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("wall_ps_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("wall_ps_cmd.h5");
     
     cmdh5w -> write_string(      "ps_file_name",       ps_file_name);
     cmdh5w -> write_doubleScalar("prestress_disp_tol", prestress_disp_tol );
 
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/linearPDE/elastodynamics/driver.cpp
+++ b/examples/linearPDE/elastodynamics/driver.cpp
@@ -144,8 +144,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("init_step", initial_step);
     cmdh5w->write_intScalar("sol_record_freq", sol_record_freq);
@@ -154,7 +153,7 @@ int main(int argc, char *argv[])
     cmdh5w->write_doubleScalar("youngs_module", module_E);
     cmdh5w->write_doubleScalar("poissons_ratio", nu);
 
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/linearPDE/preprocess.cpp
+++ b/examples/linearPDE/preprocess.cpp
@@ -91,8 +91,7 @@ int main( int argc, char * argv[] )
   std::cout << "=========================================" << std::endl;
 
   // Record the problem setting into a HDF5 file: preprocessor_cmd.h5
-  hid_t cmd_file_id = H5Fcreate("preprocessor_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+  HDF5_Writer * cmdh5w = new HDF5_Writer("preprocessor_cmd.h5");
 
   cmdh5w->write_intScalar("cpu_size", cpu_size);
   cmdh5w->write_intScalar("in_ncommon", in_ncommon);
@@ -102,7 +101,7 @@ int main( int argc, char * argv[] )
   cmdh5w->write_intScalar("dof_num", dofNum);
   cmdh5w->write_intScalar("dof_mat", dofMat);
 
-  delete cmdh5w; H5Fclose(cmd_file_id);
+  delete cmdh5w;
   
   // Read the volumetric mesh file from the vtu file: geo_file
   int nFunc, nElem;

--- a/examples/linearPDE/transport/driver.cpp
+++ b/examples/linearPDE/transport/driver.cpp
@@ -140,15 +140,14 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("init_step", initial_step);
     cmdh5w->write_intScalar("sol_record_freq", sol_record_freq);
     cmdh5w->write_intScalar("nqp_vol", nqp_vol);
     cmdh5w->write_intScalar("nqp_sur", nqp_sur);
 
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ns/driver.cpp
+++ b/examples/ns/driver.cpp
@@ -176,9 +176,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5",
-        H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("fl_density", fluid_density);
     cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
@@ -186,7 +184,7 @@ int main(int argc, char *argv[])
     cmdh5w->write_intScalar("sol_record_freq", sol_record_freq);
     cmdh5w->write_string("lpn_file", lpn_file);
     cmdh5w->write_string("inflow_file", inflow_file);
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ns/ns_herk_driver.cpp
+++ b/examples/ns/ns_herk_driver.cpp
@@ -151,9 +151,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5",
-        H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("fl_density", fluid_density);
     cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
@@ -162,7 +160,7 @@ int main(int argc, char *argv[])
     // cmdh5w->write_string("lpn_file", lpn_file);
     cmdh5w->write_string("inflow_file", inflow_file);
     cmdh5w->write_string("dot_inflow_file", dot_inflow_file);
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ns/ns_herk_driver_accurateA.cpp
+++ b/examples/ns/ns_herk_driver_accurateA.cpp
@@ -152,9 +152,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    hid_t cmd_file_id = H5Fcreate("solver_cmd.h5",
-        H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("fl_density", fluid_density);
     cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
@@ -163,7 +161,7 @@ int main(int argc, char *argv[])
     // cmdh5w->write_string("lpn_file", lpn_file);
     cmdh5w->write_string("inflow_file", inflow_file);
     cmdh5w->write_string("dot_inflow_file", dot_inflow_file);
-    delete cmdh5w; H5Fclose(cmd_file_id);
+    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -125,8 +125,7 @@ int main( int argc, char * argv[] )
   }
 
   // Record the problem setting into a HDF5 file: preprocessor_cmd.h5
-  hid_t cmd_file_id = H5Fcreate("preprocessor_cmd.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  HDF5_Writer * cmdh5w = new HDF5_Writer(cmd_file_id);
+  HDF5_Writer * cmdh5w = new HDF5_Writer("preprocessor_cmd.h5");
 
   cmdh5w->write_intScalar("num_inlet", num_inlet);
   cmdh5w->write_intScalar("num_outlet", num_outlet);
@@ -141,7 +140,7 @@ int main( int argc, char * argv[] )
   cmdh5w->write_string("sur_file_wall", sur_file_wall);
   cmdh5w->write_string("part_file", part_file);
 
-  delete cmdh5w; H5Fclose(cmd_file_id);
+  delete cmdh5w;
 
   // Read the volumetric mesh file from the vtu file: geo_file
   int nFunc, nElem;

--- a/src/Mesh/EBC_Partition_WallModel.cpp
+++ b/src/Mesh/EBC_Partition_WallModel.cpp
@@ -33,7 +33,7 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
 
   hid_t g_id = H5Gcreate(file_id, "/weak", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   h5w -> write_intScalar( g_id, "wall_model_type", wall_model_type );
 

--- a/src/Mesh/EBC_Partition_outflow.cpp
+++ b/src/Mesh/EBC_Partition_outflow.cpp
@@ -62,7 +62,7 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
   hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
   hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {

--- a/src/Mesh/EBC_Partition_outflow_MF.cpp
+++ b/src/Mesh/EBC_Partition_outflow_MF.cpp
@@ -79,7 +79,7 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
   hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
   hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {

--- a/src/Mesh/Gmsh_FileIO.cpp
+++ b/src/Mesh/Gmsh_FileIO.cpp
@@ -798,7 +798,7 @@ void Gmsh_FileIO::write_sur_h5( int index_2d,
   hid_t file_id = H5Fcreate(h5_file_name.c_str(), 
       H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( h5_file_name, H5F_ACC_RDWR );
 
   // Write 2D domain first
   const std::string slash("/");
@@ -965,7 +965,7 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
   hid_t file_id = H5Fcreate(h5_file_name.c_str(),
       H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( h5_file_name, H5F_ACC_RDWR );
 
   // Write the 3D domain at the root
   const std::string slash("/");
@@ -1138,7 +1138,7 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
   hid_t file_id = H5Fcreate(h5_file_name.c_str(),
       H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( h5_file_name, H5F_ACC_RDWR );
 
   // Write the 3D domain at the root
   const std::string slash("/");

--- a/src/Mesh/Interface_Partition.cpp
+++ b/src/Mesh/Interface_Partition.cpp
@@ -174,7 +174,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 
   hid_t g_id = H5Gcreate(file_id, "/sliding", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   h5w -> write_intScalar( g_id, "num_interface", num_pair );
 

--- a/src/Mesh/Map_Node_Index.cpp
+++ b/src/Mesh/Map_Node_Index.cpp
@@ -65,7 +65,7 @@ void Map_Node_Index::write_hdf5( const std::string &fileName ) const
   // file creation
   hid_t file_id = H5Fcreate( fName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT );
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5w -> write_intVector( "old_2_new", old_2_new );
   h5w -> write_intVector( "new_2_old", new_2_old );

--- a/src/Mesh/NBC_Partition.cpp
+++ b/src/Mesh/NBC_Partition.cpp
@@ -87,7 +87,7 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
 
   hid_t g_id = H5Gcreate(file_id, GroupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5writer = new HDF5_Writer(file_id);
+  HDF5_Writer * h5writer = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5writer->write_intVector( g_id, "LID", LID );
 

--- a/src/Mesh/NBC_Partition_MF.cpp
+++ b/src/Mesh/NBC_Partition_MF.cpp
@@ -151,7 +151,7 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
 
   hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
 
-  HDF5_Writer * h5writer = new HDF5_Writer(file_id);
+  HDF5_Writer * h5writer = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   hid_t g_nbc_id = H5Gopen(file_id, GroupName.c_str(), H5P_DEFAULT);
 

--- a/src/Mesh/NBC_Partition_inflow.cpp
+++ b/src/Mesh/NBC_Partition_inflow.cpp
@@ -120,7 +120,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
 
   hid_t g_id = H5Gcreate(file_id, "/inflow", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5w -> write_intScalar( g_id, "num_nbc", num_nbc );
 

--- a/src/Mesh/NBC_Partition_inflow_MF.cpp
+++ b/src/Mesh/NBC_Partition_inflow_MF.cpp
@@ -37,7 +37,7 @@ void NBC_Partition_inflow_MF::write_hdf5( const std::string &FileName ) const
 
   hid_t g_id = H5Gopen(file_id, "/inflow", H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   for(int ii=0; ii<num_nbc; ++ii)
   {

--- a/src/Mesh/NBC_Partition_rotated.cpp
+++ b/src/Mesh/NBC_Partition_rotated.cpp
@@ -99,7 +99,7 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
 
   hid_t g_id = H5Gcreate(file_id, "/rotated_nbc", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5w->write_intScalar( g_id, "Num_LD", Num_LD );
   

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -332,7 +332,7 @@ void Part_FEM::write( const std::string &inputFileName ) const
 
   hid_t file_id = H5Fcreate(fName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   // group 1: local element
   hid_t group_id_1 = H5Gcreate(file_id, "/Local_Elem", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/Mesh/Part_FEM_FSI.cpp
+++ b/src/Mesh/Part_FEM_FSI.cpp
@@ -48,7 +48,7 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
 
   hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   // open group 1: local element
   hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);

--- a/src/Mesh/Part_FEM_Rotated.cpp
+++ b/src/Mesh/Part_FEM_Rotated.cpp
@@ -46,7 +46,7 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
 
   hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer(file_id);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   // open group 1: local element
   hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);

--- a/src/Model/Tissue_prestress.cpp
+++ b/src/Model/Tissue_prestress.cpp
@@ -117,7 +117,7 @@ void Tissue_prestress::write_prestress_hdf5() const
 
   hid_t file_id = H5Fcreate(fName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
-  HDF5_Writer * h5w = new HDF5_Writer( file_id );
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   h5w -> write_intScalar( "ps_array_size", qua_prestress_array.size() );
 


### PR DESCRIPTION
### Motivation
- The `HDF5_Writer` API was extended to allow constructing the writer directly from a filename, so call sites should stop passing raw `hid_t` file handles into the writer. 
- Existing code often opened/created HDF5 files with `H5Fcreate`/`H5Fopen` and then constructed `HDF5_Writer` with the `file_id`, leading to duplicate lifetime/closing responsibilities. 
- Unify call patterns to construct `HDF5_Writer` from filenames (and `H5F_ACC_RDWR` when an open handle is still used for group operations) to simplify resource handling and match the updated writer behavior. 

### Description
- Replaced usages of `new HDF5_Writer(file_id)` and `new HDF5_Writer(cmd_file_id)` with `new HDF5_Writer(fName, H5F_ACC_RDWR)` or `new HDF5_Writer(<literal>.h5)` across example drivers, preprocessors, mesh writers and model writers. 
- Removed redundant manual `H5Fcreate`/`H5Fclose` pairs around command-recording files (`solver_cmd.h5`, `preprocessor_cmd.h5`, `wall_ps_cmd.h5`) and now rely on the writer constructor/destructor for file lifetime. 
- Fixed `Gmsh_FileIO` to use the `h5_file_name` variable when constructing `HDF5_Writer` and updated other mesh/model writers (`Part_FEM`, `Part_FEM_FSI`, `Part_FEM_Rotated`, `Map_Node_Index`, `NBC_*`, `EBC_*`, `Interface_Partition`, `Tissue_prestress`, etc.) to the filename-based construction. 
- Applied the change consistently across ~27 files to align all HDF5 writer call sites to the new API. 

### Testing
- Ran `git diff --check` to validate patch formatting and it returned clean results. (passed) 
- Searched the tree with `rg` for remaining `new HDF5_Writer(file_id)` and `new HDF5_Writer(cmd_file_id)` usages to ensure all old call sites were updated, and found no matches. (passed) 
- Committed the changes after verification that the refactor removed redundant `H5Fcreate`/`H5Fclose` usage in the example command-recording flows. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ac80c8a4832aba35b32314f600c1)