### PR TITLE
Consolidate HDF5 file handling via HDF5_Writer and remove raw H5Fopen/H5Fclose calls

### DIFF
--- a/src/Mesh/EBC_Partition_WallModel.cpp
+++ b/src/Mesh/EBC_Partition_WallModel.cpp
@@ -29,11 +29,10 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
 {
   const std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
+  const hid_t file_id = h5w->get_file_id();
 
   hid_t g_id = H5Gcreate(file_id, "/weak", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   h5w -> write_intScalar( g_id, "wall_model_type", wall_model_type );
 
@@ -48,7 +47,7 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
   else
     ;   // stop writing if wall_model_type = 0
 
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/EBC_Partition_outflow.cpp
+++ b/src/Mesh/EBC_Partition_outflow.cpp
@@ -59,10 +59,9 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
 
   const std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
-
   HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
+  const hid_t file_id = h5w->get_file_id();
+  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {
@@ -80,7 +79,7 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
     }
   }
 
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/EBC_Partition_outflow_MF.cpp
+++ b/src/Mesh/EBC_Partition_outflow_MF.cpp
@@ -76,10 +76,9 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
 
   const std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
-
   HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
+  const hid_t file_id = h5w->get_file_id();
+  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {
@@ -97,7 +96,7 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
     }
   }
 
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Interface_Partition.cpp
+++ b/src/Mesh/Interface_Partition.cpp
@@ -170,11 +170,10 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 {
   const std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
+  const hid_t file_id = h5w->get_file_id();
 
   hid_t g_id = H5Gcreate(file_id, "/sliding", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
 
   h5w -> write_intScalar( g_id, "num_interface", num_pair );
 
@@ -247,7 +246,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 
     H5Gclose( group_id );
   }
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Map_Node_Index.cpp
+++ b/src/Mesh/Map_Node_Index.cpp
@@ -63,14 +63,12 @@ void Map_Node_Index::write_hdf5( const std::string &fileName ) const
   fName.append(".h5");
   
   // file creation
-  hid_t file_id = H5Fcreate( fName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT );
-
-  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_TRUNC);
 
   h5w -> write_intVector( "old_2_new", old_2_new );
   h5w -> write_intVector( "new_2_old", new_2_old );
 
-  delete h5w; H5Fclose(file_id);
+  delete h5w;
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition.cpp
+++ b/src/Mesh/NBC_Partition.cpp
@@ -83,11 +83,10 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
 {
   const std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  HDF5_Writer * h5writer = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5writer->get_file_id();
 
   hid_t g_id = H5Gcreate(file_id, GroupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5writer = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5writer->write_intVector( g_id, "LID", LID );
 
@@ -109,7 +108,7 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
   h5writer->write_intVector(g_id, "Num_LPS", Num_LPS);
   h5writer->write_intVector(g_id, "Num_LPM", Num_LPM);
 
-  delete h5writer; H5Gclose(g_id); H5Fclose(file_id);
+  delete h5writer; H5Gclose(g_id);
 }
 
 void NBC_Partition::print_info() const

--- a/src/Mesh/NBC_Partition_MF.cpp
+++ b/src/Mesh/NBC_Partition_MF.cpp
@@ -149,9 +149,8 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
   
   const std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-
   HDF5_Writer * h5writer = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5writer->get_file_id();
 
   hid_t g_nbc_id = H5Gopen(file_id, GroupName.c_str(), H5P_DEFAULT);
 
@@ -178,7 +177,7 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
   h5writer->write_intVector(g_id, "Num_LPM", Num_LPM);
 
   delete h5writer;
-  H5Gclose(g_id); H5Gclose(g_nbc_id); H5Fclose(file_id);
+  H5Gclose(g_id); H5Gclose(g_nbc_id);
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_inflow.cpp
+++ b/src/Mesh/NBC_Partition_inflow.cpp
@@ -116,11 +116,10 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
 {
   std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5w->get_file_id();
 
   hid_t g_id = H5Gcreate(file_id, "/inflow", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5w -> write_intScalar( g_id, "num_nbc", num_nbc );
 
@@ -167,7 +166,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
     H5Gclose( group_id );
   }
 
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_inflow_MF.cpp
+++ b/src/Mesh/NBC_Partition_inflow_MF.cpp
@@ -33,11 +33,10 @@ void NBC_Partition_inflow_MF::write_hdf5( const std::string &FileName ) const
 
   std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5w->get_file_id();
 
   hid_t g_id = H5Gopen(file_id, "/inflow", H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   for(int ii=0; ii<num_nbc; ++ii)
   {
@@ -49,7 +48,7 @@ void NBC_Partition_inflow_MF::write_hdf5( const std::string &FileName ) const
     h5w->write_intVector( group_id, "LDN_MF", LDN_MF[ii] );
   }
 
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_rotated.cpp
+++ b/src/Mesh/NBC_Partition_rotated.cpp
@@ -95,11 +95,10 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
 {
   std::string fName = SYS_T::gen_partfile_name( FileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5w->get_file_id();
 
   hid_t g_id = H5Gcreate(file_id, "/rotated_nbc", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
 
   h5w->write_intScalar( g_id, "Num_LD", Num_LD );
   
@@ -132,7 +131,7 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
     h5w->write_intVector( g_id, "local_global_cell", local_global_cell );   
   }
 
-  delete h5w; H5Gclose( g_id ); H5Fclose( file_id );
+  delete h5w; H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -330,9 +330,8 @@ void Part_FEM::write( const std::string &inputFileName ) const
 {
   const std::string fName = SYS_T::gen_partfile_name( inputFileName, cpu_rank );
 
-  hid_t file_id = H5Fcreate(fName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_TRUNC);
+  const hid_t file_id = h5w->get_file_id();
 
   // group 1: local element
   hid_t group_id_1 = H5Gcreate(file_id, "/Local_Elem", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -415,7 +414,6 @@ void Part_FEM::write( const std::string &inputFileName ) const
 
   // Finish writing, clean up
   delete h5w;
-  H5Fclose(file_id);
 }
 
 void Part_FEM::print_part_ele() const

--- a/src/Mesh/Part_FEM_FSI.cpp
+++ b/src/Mesh/Part_FEM_FSI.cpp
@@ -46,9 +46,8 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
 
   const std::string fName = SYS_T::gen_partfile_name( inputFileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-
   HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5w->get_file_id();
 
   // open group 1: local element
   hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);
@@ -80,7 +79,6 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
 
   // Finish the writing of hdf5 file
   delete h5w;
-  H5Fclose(file_id);
 }
 
 // EOF

--- a/src/Mesh/Part_FEM_Rotated.cpp
+++ b/src/Mesh/Part_FEM_Rotated.cpp
@@ -44,9 +44,8 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
 
   const std::string fName = SYS_T::gen_partfile_name( inputFileName, cpu_rank );
 
-  hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-
   HDF5_Writer * h5w = new HDF5_Writer(fName, H5F_ACC_RDWR);
+  const hid_t file_id = h5w->get_file_id();
 
   // open group 1: local element
   hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);
@@ -71,7 +70,6 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
 
   // Finish the writing of hdf5 file
   delete h5w;
-  H5Fclose(file_id);
 }
 
 // EOF

--- a/src/Model/Tissue_prestress.cpp
+++ b/src/Model/Tissue_prestress.cpp
@@ -115,16 +115,15 @@ void Tissue_prestress::write_prestress_hdf5() const
   // Record to h5 file
   const std::string fName = SYS_T::gen_partfile_name( ps_fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fcreate(fName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-
-  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
+  HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_TRUNC );
+  const hid_t file_id = h5w->get_file_id();
 
   h5w -> write_intScalar( "ps_array_size", qua_prestress_array.size() );
 
   if( qua_prestress_array.size() > 0 )
     h5w -> write_doubleVector( file_id, "prestress", qua_prestress_array );
 
-  delete h5w; H5Fclose( file_id );
+  delete h5w;
 }
 
 // EOF


### PR DESCRIPTION
### Motivation

- Replace scattered direct HDF5 C-API file operations with the `HDF5_Writer` wrapper to centralize file ownership and avoid mismatched open/close semantics.

### Description

- Replace calls to `H5Fopen`/`H5Fcreate` with construction of `HDF5_Writer(fName, ...)` and obtain the underlying file id via `get_file_id()` across multiple partition and mesh writers.
- Remove explicit `H5Fclose(file_id)` calls where the `HDF5_Writer` is now responsible for file lifecycle and avoid creating duplicate `HDF5_Writer` instances in the same scope.
- Fix redundant/incorrect ordering where a writer was constructed after creating groups, by creating the writer first and reusing its `file_id` for group creation.
- Apply the same pattern across Mesh and Model classes including EBC/NBC partitions, Interface/Part_FEM variants, mapping writer, and prestress writer.

### Testing

- Project was compiled after the changes and the build completed successfully with no HDF5 linker or symbol errors.
- HDF5-based IO routines were exercised by the partition/file-write unit checks and completed without errors (no failing IO tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b27d8fc8832ab80726769c48865d)