### PR TITLE
Fix HDF5 group/file cleanup order in ale_ns_rotate preprocess

### DIFF
--- a/examples/ale_ns_rotate/preprocess.cpp
+++ b/examples/ale_ns_rotate/preprocess.cpp
@@ -474,7 +474,8 @@ int main( int argc, char * argv[] )
     h5w -> write_Vector_3( g_id, "point_rotated", point_rotated.to_std_array() );
     h5w -> write_Vector_3( g_id, "angular_direction", angular_direction.to_std_array() );
 
-    delete h5w; H5Gclose( g_id );
+    H5Gclose( g_id );
+    delete h5w;
 
     // Partition sliding interface and write to h5 file
     Interface_Partition * itfpart = new Interface_Partition(part, mnindex, interfaces, NBC_list);
@@ -586,7 +587,8 @@ int main( int argc, char * argv[] )
       H5Gclose( group_id );
     }
 
-    delete h5w; H5Gclose( g_id );
+    H5Gclose( g_id );
+    delete h5w;
   }
 
   cout<<"\n===> Mesh Partition Quality: "<<endl;


### PR DESCRIPTION
### Motivation
- Ensure the HDF5 parent group is closed before destroying the `HDF5_Writer` to avoid closing resources in the wrong order and potential use-after-free or file-close issues.
- The change targets the two write sites that create `/rotation` and `/sliding` groups and preserves existing subgroup close logic for `/sliding`.
- Recommend future refactor to `std::unique_ptr<HDF5_Writer>` or a stack-scoped writer to leverage RAII and avoid manual ordering mistakes.

### Description
- Replaced single-line cleanup `delete h5w; H5Gclose(g_id);` with an explicit two-line sequence `H5Gclose(g_id);` followed by `delete h5w;` at the `/rotation` write site.
- Applied the same two-line reorder at the `/sliding` write site while leaving per-subgroup `H5Gclose(group_id);` calls unchanged.
- Reformatted the cleanup into separate statements for clarity and safer destruction ordering.

### Testing
- Verified the updated cleanup statements and ordering using `rg -n "delete h5w|H5Gclose\( g_id \)|H5Gclose\( group_id \)" examples/ale_ns_rotate/preprocess.cpp` and inspected the modified lines with `nl`/`sed`; the checks succeeded.
- No compilation or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2118c8a00832a9061496b767e6d55)