### PR TITLE
Refactor HDF5 group handling to use HDF5_Group RAII

### DIFF
--- a/include/HDF5_Group.hpp
+++ b/include/HDF5_Group.hpp
@@ -73,6 +73,7 @@ class HDF5_Group
     }
 
     hid_t id() const noexcept { return group_id; }
+    operator hid_t() const noexcept { return group_id; }
 
     bool is_valid() const noexcept { return group_id >= 0; }
 

--- a/include/HDF5_Reader.hpp
+++ b/include/HDF5_Reader.hpp
@@ -30,6 +30,7 @@
 #include <array>
 #include "Sys_Tools.hpp"
 #include "Vec_Tools.hpp"
+#include "HDF5_Group.hpp"
 #include "hdf5.h"
 
 class HDF5_Reader

--- a/include/HDF5_Writer.hpp
+++ b/include/HDF5_Writer.hpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <array>
 #include "Sys_Tools.hpp"
+#include "HDF5_Group.hpp"
 #include "hdf5.h"
 
 class HDF5_Writer

--- a/src/Mesh/EBC_Partition.cpp
+++ b/src/Mesh/EBC_Partition.cpp
@@ -99,7 +99,7 @@ void EBC_Partition::write_hdf5( const std::string &FileName,
 
   hid_t file_id = H5Fopen(fName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
 
-  hid_t g_id = H5Gcreate(file_id, GroupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); 
+  HDF5_Group g_id = HDF5_Group::create(file_id, GroupName.c_str()); 
 
   auto h5w = SYS_T::make_unique<HDF5_Writer>( file_id );
 
@@ -119,8 +119,7 @@ void EBC_Partition::write_hdf5( const std::string &FileName,
     {
       const std::string sub_gname = groupbase + std::to_string(ii);
 
-      hid_t group_id = H5Gcreate(g_id, sub_gname.c_str(), 
-          H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      HDF5_Group group_id = HDF5_Group::create(g_id, sub_gname.c_str());
 
       h5w->write_doubleVector( group_id, "local_cell_node_xyz", local_cell_node_xyz[ii] );
 
@@ -131,12 +130,8 @@ void EBC_Partition::write_hdf5( const std::string &FileName,
       h5w->write_intVector( group_id, "local_cell_node_pos", local_cell_node_pos[ii] );
 
       h5w->write_intVector( group_id, "local_cell_vol_id", local_cell_vol_id[ii] );
-
-      H5Gclose( group_id );
     }
   }
-
-  H5Gclose( g_id ); H5Fclose( file_id );
 }
 
 void EBC_Partition::print_info() const

--- a/src/Mesh/EBC_Partition_WallModel.cpp
+++ b/src/Mesh/EBC_Partition_WallModel.cpp
@@ -32,7 +32,7 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/weak", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/weak");
 
   h5w -> write_intScalar( g_id, "wall_model_type", wall_model_type );
 
@@ -46,8 +46,6 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
   }
   else
     ;   // stop writing if wall_model_type = 0
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/EBC_Partition_outflow.cpp
+++ b/src/Mesh/EBC_Partition_outflow.cpp
@@ -61,7 +61,7 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
 
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
-  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
+  HDF5_Group g_id = HDF5_Group::open( file_id, GroupName.c_str() );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {
@@ -69,17 +69,13 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
     {
       std::string subgroup_name( "ebcid_" );
       subgroup_name.append( std::to_string(ii) );
-      hid_t subgroup_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT );
+      HDF5_Group subgroup_id = HDF5_Group::open(g_id, subgroup_name.c_str() );
 
       h5w->write_doubleVector( subgroup_id, "intNA", face_int_NA[ii] );
       h5w->write_intVector( subgroup_id, "LID_all_face_nodes", LID_all_face_nodes[ii] );
       h5w->write_Vector_3( subgroup_id, "out_normal", outvec[ii].to_std_array() );
-
-      H5Gclose( subgroup_id );
     }
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/EBC_Partition_outflow_MF.cpp
+++ b/src/Mesh/EBC_Partition_outflow_MF.cpp
@@ -78,7 +78,7 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
 
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
-  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
+  HDF5_Group g_id = HDF5_Group::open( file_id, GroupName.c_str() );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {
@@ -86,17 +86,13 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
     {
       std::string subgroup_name( "ebcid_" );
       subgroup_name.append( std::to_string(ii) );
-      hid_t subgroup_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT );
+      HDF5_Group subgroup_id = HDF5_Group::open(g_id, subgroup_name.c_str() );
 
       h5w->write_doubleVector( subgroup_id, "intNA", face_int_NA[ii] );
       h5w->write_intVector( subgroup_id, "LID_all_face_nodes", LID_all_face_nodes[ii] );
       h5w->write_Vector_3( subgroup_id, "out_normal", outvec[ii].to_std_array() );
-
-      H5Gclose( subgroup_id );
     }
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Gmsh_FileIO.cpp
+++ b/src/Mesh/Gmsh_FileIO.cpp
@@ -912,8 +912,7 @@ void Gmsh_FileIO::write_sur_h5( int index_2d,
     // Record info
     std::string name_1d_domain(slash);
     name_1d_domain.append( std::to_string( static_cast<int>(ii) ) );
-    hid_t g_id = H5Gcreate( file_id, name_1d_domain.c_str(), 
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::create( file_id, name_1d_domain.c_str() );
 
     h5w->write_string(g_id, "name", phy_1d_name[ index_1d[ii] ] );
     h5w->write_intScalar(g_id, "phy_tag", index_1d[ii]);
@@ -926,8 +925,6 @@ void Gmsh_FileIO::write_sur_h5( int index_2d,
     h5w->write_intVector(g_id, "pt_idx", bcpt);
     h5w->write_intVector(g_id, "edge2elem", face2elem);
     h5w->write_doubleVector(g_id, "pt_coor", surpt);
-
-    H5Gclose(g_id);
   }
 }
 
@@ -1079,8 +1076,7 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     // Record info
     std::string name_2d_domain(slash);
     name_2d_domain.append( std::to_string( static_cast<int>(ii) ) );
-    hid_t g_id = H5Gcreate( file_id, name_2d_domain.c_str(),
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::create( file_id, name_2d_domain.c_str() );
 
     h5w->write_string(g_id, "name", phy_2d_name[ index_2d[ii] ] );
     h5w->write_intScalar(g_id, "phy_tag", index_2d[ii]);
@@ -1093,8 +1089,6 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     h5w->write_intVector(g_id, "pt_idx", bcpt);
     h5w->write_intVector(g_id, "face2elem", face2elem);
     h5w->write_doubleVector(g_id, "pt_coor", surpt);
-
-    H5Gclose(g_id);
   } // End-loop-over-2d-face
 }
 
@@ -1249,8 +1243,7 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     // Record info
     std::string name_2d_domain(slash);
     name_2d_domain.append( std::to_string( static_cast<int>(ii) ) );
-    hid_t g_id = H5Gcreate( file_id, name_2d_domain.c_str(),
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::create( file_id, name_2d_domain.c_str() );
 
     h5w->write_string(g_id, "name", phy_2d_name[ index_2d[ii] ] );
     h5w->write_intScalar(g_id, "phy_tag", index_2d[ii]);
@@ -1263,8 +1256,6 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     h5w->write_intVector(g_id, "pt_idx", bcpt);
     h5w->write_intVector(g_id, "face2elem", face2elem);
     h5w->write_doubleVector(g_id, "pt_coor", surpt);
-
-    H5Gclose(g_id);
   } // End-loop-over-2d-face
 }
 

--- a/src/Mesh/Interface_Partition.cpp
+++ b/src/Mesh/Interface_Partition.cpp
@@ -173,7 +173,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/sliding", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/sliding");
 
   h5w -> write_intScalar( g_id, "num_interface", num_pair );
 
@@ -190,7 +190,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
     std::string subgroup_name(groupbase);
     subgroup_name.append( std::to_string(ii) );
 
-    hid_t group_id = H5Gcreate(g_id, subgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group group_id = HDF5_Group::create(g_id, subgroup_name.c_str());
 
     h5w -> write_intScalar( group_id, "num_fixed_node", VEC_T::get_size(fixed_global_node[ii]) );
 
@@ -235,19 +235,13 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
       std::string subsubgroup_name(subgroupbase);
       subsubgroup_name.append( std::to_string(jj) );
 
-      hid_t subgroup_id = H5Gcreate(group_id, subsubgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      HDF5_Group subgroup_id = HDF5_Group::create(group_id, subsubgroup_name.c_str());
 
       h5w -> write_intVector( subgroup_id, "tagged_fixed_cell", tagged_fixed_ele[ii][jj] );
 
       h5w -> write_intVector( subgroup_id, "tagged_rotated_cell", tagged_rotated_ele[ii][jj] );
-
-      H5Gclose( subgroup_id );
     }
-
-    H5Gclose( group_id );
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition.cpp
+++ b/src/Mesh/NBC_Partition.cpp
@@ -86,7 +86,7 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
   auto h5writer = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5writer->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, GroupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, GroupName.c_str());
 
   h5writer->write_intVector( g_id, "LID", LID );
 
@@ -107,8 +107,6 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
   h5writer->write_intVector(g_id, "Num_LD",  Num_LD);
   h5writer->write_intVector(g_id, "Num_LPS", Num_LPS);
   h5writer->write_intVector(g_id, "Num_LPM", Num_LPM);
-
-  H5Gclose(g_id);
 }
 
 void NBC_Partition::print_info() const

--- a/src/Mesh/NBC_Partition_MF.cpp
+++ b/src/Mesh/NBC_Partition_MF.cpp
@@ -152,9 +152,9 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
   auto h5writer = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5writer->get_file_id();
 
-  hid_t g_nbc_id = H5Gopen(file_id, GroupName.c_str(), H5P_DEFAULT);
+  HDF5_Group g_nbc_id = HDF5_Group::open(file_id, GroupName.c_str());
 
-  hid_t g_id = H5Gcreate(g_nbc_id, "MF", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(g_nbc_id, "MF");
 
   h5writer->write_intVector( g_id, "LID", LID_MF );
 
@@ -175,8 +175,6 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
   h5writer->write_intVector(g_id, "Num_LD",  Num_LD);
   h5writer->write_intVector(g_id, "Num_LPS", Num_LPS);
   h5writer->write_intVector(g_id, "Num_LPM", Num_LPM);
-
-  H5Gclose(g_id); H5Gclose(g_nbc_id);
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_inflow.cpp
+++ b/src/Mesh/NBC_Partition_inflow.cpp
@@ -119,7 +119,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/inflow", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/inflow");
 
   h5w -> write_intScalar( g_id, "num_nbc", num_nbc );
 
@@ -128,8 +128,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
     std::string subgroup_name( "nbcid_" );
     subgroup_name.append( std::to_string(ii) );
 
-    hid_t group_id = H5Gcreate(g_id, subgroup_name.c_str(),
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group group_id = HDF5_Group::create(g_id, subgroup_name.c_str());
 
     h5w->write_intScalar( group_id, "Num_LD", Num_LD[ii] );
     
@@ -162,11 +161,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
     h5w->write_intVector( group_id, "local_node_pos", local_node_pos[ii] );
 
     h5w->write_intVector( group_id, "local_global_cell", local_global_cell[ii] );
-
-    H5Gclose( group_id );
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_inflow_MF.cpp
+++ b/src/Mesh/NBC_Partition_inflow_MF.cpp
@@ -36,19 +36,17 @@ void NBC_Partition_inflow_MF::write_hdf5( const std::string &FileName ) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gopen(file_id, "/inflow", H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::open(file_id, "/inflow");
 
   for(int ii=0; ii<num_nbc; ++ii)
   {
     std::string subgroup_name( "nbcid_" );
     subgroup_name.append( std::to_string(ii) );
 
-    hid_t group_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT);
+    HDF5_Group group_id = HDF5_Group::open(g_id, subgroup_name.c_str());
 
     h5w->write_intVector( group_id, "LDN_MF", LDN_MF[ii] );
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_rotated.cpp
+++ b/src/Mesh/NBC_Partition_rotated.cpp
@@ -98,7 +98,7 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/rotated_nbc", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/rotated_nbc");
 
   h5w->write_intScalar( g_id, "Num_LD", Num_LD );
   
@@ -130,8 +130,6 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
 
     h5w->write_intVector( g_id, "local_global_cell", local_global_cell );   
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -333,16 +333,13 @@ void Part_FEM::write( const std::string &inputFileName ) const
   const hid_t file_id = h5w->get_file_id();
 
   // group 1: local element
-  hid_t group_id_1 = H5Gcreate(file_id, "/Local_Elem", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_1 = HDF5_Group::create(file_id, "/Local_Elem");
 
   h5w->write_intScalar( group_id_1, "nlocalele", nlocalele );
   h5w->write_intVector( group_id_1, "elem_loc", elem_loc );
   h5w->write_intVector( group_id_1, "elem_rotated_tag", elem_rotated_tag );
-
-  H5Gclose( group_id_1 );
-
   // group 2: local node
-  hid_t group_id_2 = H5Gcreate( file_id, "/Local_Node", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+  HDF5_Group group_id_2 = HDF5_Group::create(file_id, "/Local_Node");
 
   h5w->write_intScalar( group_id_2, "nlocalnode", nlocalnode );
   h5w->write_intScalar( group_id_2, "nghostnode", nghostnode );
@@ -355,11 +352,8 @@ void Part_FEM::write( const std::string &inputFileName ) const
   h5w->write_intVector( group_id_2, "local_to_global", local_to_global );
   if(nghostnode > 0)
     h5w->write_intVector( group_id_2, "node_ghost", node_ghost );
-
-  H5Gclose( group_id_2 );
-
   // group 3: global mesh info
-  hid_t group_id_3 = H5Gcreate(file_id, "/Global_Mesh_Info", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_3 = HDF5_Group::create(file_id, "/Global_Mesh_Info");
 
   h5w->write_intScalar( group_id_3, "nElem", nElem );
   h5w->write_intScalar( group_id_3, "nFunc", nFunc );
@@ -373,19 +367,13 @@ void Part_FEM::write( const std::string &inputFileName ) const
   h5w->write_intScalar( group_id_3, "field_id", field_id );
   h5w->write_intScalar( group_id_3, "is_geo_field", (is_geo_field ? 1 : 0) );
   h5w->write_string( group_id_3, "field_name", field_name );
-
-  H5Gclose( group_id_3 );
-
   // group 4: part info
-  hid_t group_id_4 = H5Gcreate( file_id, "/Part_Info", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); 
+  HDF5_Group group_id_4 = HDF5_Group::create(file_id, "/Part_Info"); 
 
   h5w->write_intScalar( group_id_4, "cpu_rank", cpu_rank );
   h5w->write_intScalar( group_id_4, "cpu_size", cpu_size );
-
-  H5Gclose( group_id_4 );
-
   // group 5: LIEN
-  hid_t group_id_5 = H5Gcreate(file_id, "/LIEN", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_5 = HDF5_Group::create(file_id, "/LIEN");
 
   std::vector<int> row_LIEN(nlocalele * nLocBas, -1);
 
@@ -396,19 +384,14 @@ void Part_FEM::write( const std::string &inputFileName ) const
   }
 
   h5w -> write_intMatrix( group_id_5, "LIEN", row_LIEN, nlocalele, nLocBas);
-
-  H5Gclose( group_id_5 );
-
   // group 6: control points
   if( is_geo_field == true )
   {
-    hid_t group_id_6 = H5Gcreate(file_id, "/ctrlPts_loc", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group group_id_6 = HDF5_Group::create(file_id, "/ctrlPts_loc");
 
     h5w -> write_doubleVector( group_id_6, "ctrlPts_x_loc", ctrlPts_x_loc );
     h5w -> write_doubleVector( group_id_6, "ctrlPts_y_loc", ctrlPts_y_loc );
     h5w -> write_doubleVector( group_id_6, "ctrlPts_z_loc", ctrlPts_z_loc );
-
-    H5Gclose( group_id_6 );
   }
 }
 

--- a/src/Mesh/Part_FEM_FSI.cpp
+++ b/src/Mesh/Part_FEM_FSI.cpp
@@ -50,14 +50,11 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
   const hid_t file_id = h5w->get_file_id();
 
   // open group 1: local element
-  hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);
+  HDF5_Group group_id_1 = HDF5_Group::open(file_id, "/Local_Elem");
 
   h5w->write_intVector( group_id_1, "elem_phy_tag", elem_phy_tag );
-
-  H5Gclose( group_id_1 );
-
   // group 2: local node
-  hid_t group_id_2 = H5Gopen( file_id, "/Local_Node", H5P_DEFAULT );
+  HDF5_Group group_id_2 = HDF5_Group::open(file_id, "/Local_Node");
 
   h5w->write_intScalar( group_id_2, "nlocalnode_fluid", nlocalnode_fluid );
   h5w->write_intScalar( group_id_2, "nlocalnode_solid", nlocalnode_solid );
@@ -67,15 +64,10 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
 
   if( nlocalnode_solid > 0 )
     h5w->write_intVector( group_id_2, "node_loc_solid", node_loc_solid );
-
-  H5Gclose( group_id_2 );
-
   // group 7: DOF mapper
-  hid_t group_id_7 = H5Gcreate(file_id, "/DOF_mapper", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_7 = HDF5_Group::create(file_id, "/DOF_mapper");
 
   h5w -> write_intScalar( group_id_7, "start_idx", start_idx );
-
-  H5Gclose( group_id_7 );
 }
 
 // EOF

--- a/src/Mesh/Part_FEM_Rotated.cpp
+++ b/src/Mesh/Part_FEM_Rotated.cpp
@@ -48,14 +48,11 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
   const hid_t file_id = h5w->get_file_id();
 
   // open group 1: local element
-  hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);
+  HDF5_Group group_id_1 = HDF5_Group::open(file_id, "/Local_Elem");
 
   h5w->write_intVector( group_id_1, "elem_phy_tag", elem_tag );
-
-  H5Gclose( group_id_1 );
-
   // group 2: local node
-  hid_t group_id_2 = H5Gopen( file_id, "/Local_Node", H5P_DEFAULT );
+  HDF5_Group group_id_2 = HDF5_Group::open(file_id, "/Local_Node");
 
   h5w->write_intScalar( group_id_2, "nlocalnode_fixed", nlocalnode_fixed );
   h5w->write_intScalar( group_id_2, "nlocalnode_rotated", nlocalnode_rotated );
@@ -65,8 +62,6 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
 
   if( nlocalnode_rotated > 0 )
     h5w->write_intVector( group_id_2, "node_loc_rotated", node_loc_rotated );
-
-  H5Gclose( group_id_2 );
 }
 
 // EOF

--- a/src/System/HDF5_Reader.cpp
+++ b/src/System/HDF5_Reader.cpp
@@ -5,7 +5,7 @@ void HDF5_Reader::read_intArray(const char * const &group_name,
     hid_t &data_rank, hsize_t * &data_dims, int * &data  ) const
 {
   // open group file and data file
-  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
+  HDF5_Group group_id = HDF5_Group::open(file_id, group_name);
   hid_t data_id = H5Dopen(group_id, data_name, H5P_DEFAULT);
 
   // retrive dataspace of the dataset
@@ -42,7 +42,6 @@ void HDF5_Reader::read_intArray(const char * const &group_name,
   H5Sclose( mem_space );
   H5Sclose( data_space );
   H5Dclose( data_id );
-  H5Gclose( group_id );
 }
 
 void HDF5_Reader::read_doubleArray(const char * const &group_name,
@@ -50,7 +49,7 @@ void HDF5_Reader::read_doubleArray(const char * const &group_name,
     hid_t &data_rank, hsize_t * &data_dims, double * &data  ) const
 {
   // open group file and data file
-  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
+  HDF5_Group group_id = HDF5_Group::open(file_id, group_name);
   hid_t data_id  = H5Dopen(group_id, data_name, H5P_DEFAULT);
 
   // retrive dataspace of the dataset
@@ -84,7 +83,6 @@ void HDF5_Reader::read_doubleArray(const char * const &group_name,
   H5Sclose( mem_space );
   H5Sclose( data_space );
   H5Dclose( data_id );
-  H5Gclose( group_id );
 }
 
 int HDF5_Reader::read_intScalar( const char * const &group_name,
@@ -284,7 +282,7 @@ std::string HDF5_Reader::read_string( const char * const &group_name,
     const char * const &data_name ) const
 {
   // open group file and data file
-  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
+  HDF5_Group group_id = HDF5_Group::open(file_id, group_name);
   hid_t data_id  = H5Dopen(group_id, data_name, H5P_DEFAULT);
 
   hid_t filetype = H5Dget_type( data_id );
@@ -317,8 +315,6 @@ std::string HDF5_Reader::read_string( const char * const &group_name,
   H5Tclose( filetype );
   H5Sclose( data_space );
   H5Dclose( data_id );
-  H5Gclose( group_id );
-
   return string_out;
 }
 


### PR DESCRIPTION
### Motivation
- Replace scattered direct `H5Gcreate`/`H5Gopen`/`H5Gclose` usage with an RAII wrapper to avoid manual resource management and reduce leak/error risk.
- Allow existing HDF5 reader/writer calls to accept the RAII wrapper with minimal call-site changes.

### Description
- Added an implicit conversion operator `operator hid_t()` to `HDF5_Group` so it can be passed to existing HDF5 APIs that expect a `hid_t` handle.
- Replaced `H5Gcreate`/`H5Gopen` calls with `HDF5_Group::create` / `HDF5_Group::open` across mesh partitioning, Gmsh I/O and system HDF5 reader code and removed the now-unnecessary manual `H5Gclose` calls.
- Included `HDF5_Group.hpp` in `HDF5_Reader.hpp` and `HDF5_Writer.hpp` so the new type is available to the reader/writer interfaces.
- Applied call-site signature cleanup to remove explicit `H5P_DEFAULT` parameters where the wrapper factory overloads already handle defaults.

### Testing
- Ran a repository search with `rg` to confirm direct `H5Gcreate`/`H5Gopen`/`H5Gclose` no longer appear in `src/` and `include/` outside `HDF5_Group.hpp`, which succeeded.
- Searched for leftover `HDF5_Group::create/open` usages with `H5P_DEFAULT` and cleaned them up, verified via `rg`.
- Attempted to build with `cmake -S . -B build && cmake --build build -j2`, which failed because the repository root does not contain a `CMakeLists.txt` so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e247816f4c832a900f42d2e0562944)