### PR TITLE
Remove polymorphic qualifiers from Map_Node_Index

### DIFF
--- a/include/Map_Node_Index.hpp
+++ b/include/Map_Node_Index.hpp
@@ -30,19 +30,19 @@ class Map_Node_Index
     // Load the index mapping from file on disk
     Map_Node_Index( const char * const &fileName );
 
-    virtual ~Map_Node_Index() = default;
+    ~Map_Node_Index() = default;
 
     // Map the natural node numbering to the new numbering based on
     // mesh partition
-    virtual int get_old2new(const int &ii) const {return old_2_new[ii];}
+    int get_old2new(const int &ii) const {return old_2_new[ii];}
     
     // Map the new numbering back to the old, natural numbering for nodes
-    virtual int get_new2old(const int &ii) const {return new_2_old[ii];}
+    int get_new2old(const int &ii) const {return new_2_old[ii];}
     
-    virtual void print_info() const;
+    void print_info() const;
 
     // write the old_2_new and new_2_old mappings into an hdf5 file
-    virtual void write_hdf5( const std::string &fileName ) const;
+    void write_hdf5( const std::string &fileName ) const;
 
   private:
     std::vector<int> old_2_new, new_2_old;


### PR DESCRIPTION
### Motivation
- The class `Map_Node_Index` has no subclasses in the tree, so it should not be treated as a polymorphic base to avoid unnecessary virtual dispatch and clarify ABI intent.

### Description
- Removed `virtual` from the destructor and member functions in `include/Map_Node_Index.hpp`, converting `~Map_Node_Index()` to `~Map_Node_Index() = default;` and making `get_old2new`, `get_new2old`, `print_info`, and `write_hdf5` non-virtual while preserving their signatures and behavior.
- Change is narrow and confined to the header `include/Map_Node_Index.hpp` so call-site signatures remain unchanged and ABI usage is kept consistent.

### Testing
- Searched the codebase for derived classes with `rg "class .* : public Map_Node_Index"` and `rg "class\s+\w+\s*:\s*public\s+Map_Node_Index"`, and found none; the checks succeeded.
- Verified the header contains the updated non-virtual declarations with `rg -n "~Map_Node_Index|get_old2new|get_new2old|print_info\(|write_hdf5\(" include/Map_Node_Index.hpp`, which succeeded.
- Confirmed the modified file is present at `include/Map_Node_Index.hpp` and the diffs reflect only the removal of `virtual` qualifiers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e248492aec832abc1e3cc4c268839a)