### PR TITLE
Refine APart_Node trivial getters with noexcept

### DIFF
--- a/include/APart_Node.hpp
+++ b/include/APart_Node.hpp
@@ -41,17 +41,17 @@ class APart_Node
     // problem's degrees-of-freedom, which is typically obtained by
     // ALocal_NBC->get_dof_LID();
     // ------------------------------------------------------------------------
-    virtual int get_dof() const {return dof;}
+    int get_dof() const noexcept {return dof;}
 
-    virtual int get_nlocalnode() const {return nlocalnode;}
+    int get_nlocalnode() const noexcept {return nlocalnode;}
     
-    virtual int get_nghostnode() const {return nghostnode;}
+    int get_nghostnode() const noexcept {return nghostnode;}
     
-    virtual int get_nbadnode() const {return nbadnode;}
+    int get_nbadnode() const noexcept {return nbadnode;}
     
-    virtual int get_nlocghonode() const {return nlocghonode;}
+    int get_nlocghonode() const noexcept {return nlocghonode;}
     
-    virtual int get_ntotalnode() const {return ntotalnode;}
+    int get_ntotalnode() const noexcept {return ntotalnode;}
 
     // ------------------------------------------------------------------------
     // local_to_global is a mapping that maps from the local node index
@@ -59,20 +59,20 @@ class APart_Node
     // Input: local nodal index with ranges 
     //        0 <= ii < nlocghonode == nlocalnode + nghostnode
     // ------------------------------------------------------------------------
-    virtual int get_local_to_global(int ii) const 
+    int get_local_to_global(int ii) const noexcept
     {return local_to_global[ii];}
 
     // ------------------------------------------------------------------------
     // node_ghost maps from [0, nghostnode) to their global/volume mesh index
     // 0 <= ii < nghostnode
     // ------------------------------------------------------------------------
-    virtual int get_node_ghost(int ii) const {return node_ghost[ii];}
+    int get_node_ghost(int ii) const noexcept {return node_ghost[ii];}
 
     // ------------------------------------------------------------------------
     // node_loc maps from [0, nlocalnode) to their global/volume mesh index
     // 0 <= index < nlocalnode
     // ------------------------------------------------------------------------
-    virtual int get_node_loc(int ii) const {return node_loc[ii];}
+    int get_node_loc(int ii) const noexcept {return node_loc[ii];}
 
     // ------------------------------------------------------------------------
     // Determine if a global mesh node with index belongs to this subdomain.
@@ -86,7 +86,7 @@ class APart_Node
     // ------------------------------------------------------------------------
     // Return this subdomain rank
     // ------------------------------------------------------------------------
-    virtual int get_rank() const {return cpu_rank;}
+    int get_rank() const noexcept {return cpu_rank;}
 
     virtual void print_info() const;
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary dynamic dispatch and make intent explicit for simple accessors that only return members or container entries by removing `virtual` and adding `noexcept` where safe.

### Description
- Converted the trivial getters in `include/APart_Node.hpp` to non-virtual, non-throwing functions by removing `virtual` and adding `noexcept` for `get_dof`, `get_nlocalnode`, `get_nghostnode`, `get_nbadnode`, `get_nlocghonode`, `get_ntotalnode`, `get_local_to_global`, `get_node_ghost`, `get_node_loc`, and `get_rank` while keeping their bodies unchanged.
- Left genuinely polymorphic functions (e.g. `is_node_local`, `print_info`, and FSI/Rotated extension methods) as `virtual` to preserve intended overriding behavior.
- Change is header-only and localized to `include/APart_Node.hpp` so external call sites continue to compile against the same signatures (now non-virtual) and semantics.

### Testing
- Ran source searches with `rg` to confirm the adjusted getters are not overridden in derived headers and that call sites use them via base pointers/references; the searches succeeded and showed no conflicting overrides (checked `include/APart_Node_FSI.hpp`, `include/APart_Node_Rotated.hpp`, `include/Matrix_PETSc.hpp`, and `include/PDNSolution.hpp`).
- Inspected the modified header region (`include/APart_Node.hpp`) to verify method bodies and indexing semantics remained identical; the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f7ab0b6c832a864b699dd8d8f1aa)