### PR TITLE
Update IQuadPts and derived classes to pass int/double by value

### DIFF
--- a/include/FE_Tools.hpp
+++ b/include/FE_Tools.hpp
@@ -15,7 +15,7 @@ namespace FE_T
   // Generate outward normal vector from a tangential vector.
   // tan : the tangential vector
   // p0  : the starting point of the tangential vector
-  // p1  : the interior point 
+  // p1  : the interior point
   // return : the outward normal vector
   // Algorithm: p1->p0 gives the vector m,
   //            n = m - (m,t) t / (t,t).
@@ -23,21 +23,21 @@ namespace FE_T
   Vector_3 get_n_from_t( const Vector_3 &tan, const Vector_3 &p0, const Vector_3 &p1 );
 
   // --------------------------------------------------------------------------
-  // Calculate the circumscribing sphere's centre point and radius of four 
+  // Calculate the circumscribing sphere's centre point and radius of four
   // given points
   // --------------------------------------------------------------------------
   void get_tet_sphere_info(
-      const double &x0, const double &x1, const double &x2, const double &x3, 
+      const double &x0, const double &x1, const double &x2, const double &x3,
       const double &y0, const double &y1, const double &y2, const double &y3,
       const double &z0, const double &z1, const double &z2, const double &z3,
       double &xx, double &yy, double &zz, double &rr );
 
-  double get_tet_sphere_radius( 
-      const double &x0, const double &x1, const double &x2, const double &x3, 
+  double get_tet_sphere_radius(
+      const double &x0, const double &x1, const double &x2, const double &x3,
       const double &y0, const double &y1, const double &y2, const double &y3,
       const double &z0, const double &z1, const double &z2, const double &z3 );
 
-  Vector_3 get_tet_sphere_info( const Vector_3 &pt0, const Vector_3 &pt1, 
+  Vector_3 get_tet_sphere_info( const Vector_3 &pt0, const Vector_3 &pt1,
       const Vector_3 &pt2, const Vector_3 &pt3, double &radius );
 
   double get_circumradius( const std::array<Vector_3, 4> &pts );
@@ -67,7 +67,7 @@ namespace FE_T
   // return a scalar Prof(f) := int_omega f dx / int_omega 1 dx
   //                          = sum(f * gwts) / sum(gwts)
   // --------------------------------------------------------------------------
-  double L2Proj_DGP0( const double * const &f, 
+  double L2Proj_DGP0( const double * const &f,
       const double * const &gwts, const int &nqp );
 
   // --------------------------------------------------------------------------
@@ -112,7 +112,7 @@ namespace FE_T
   // This is a 3-by-3 matrix class that can calculate LU factorization of the
   // dense matrix. The components are stored in a 1-D array.
   //
-  // The array that stores the matrix is mat[9]. Logically, the matrix is 
+  // The array that stores the matrix is mat[9]. Logically, the matrix is
   //                     mat[0], mat[1], mat[2]
   //                     mat[3], mat[4], mat[5]
   //                     mat[6], mat[7], mat[8]
@@ -125,9 +125,9 @@ namespace FE_T
       Matrix_double_3by3_Array();
 
       // Explicitly define the matrix components
-      Matrix_double_3by3_Array( const double &a11, const double &a12, 
-          const double &a13, const double &a21, const double &a22, 
-          const double &a23, const double &a31, const double &a32, 
+      Matrix_double_3by3_Array( const double &a11, const double &a12,
+          const double &a13, const double &a21, const double &a22,
+          const double &a23, const double &a31, const double &a32,
           const double &a33 );
 
       // Destructor
@@ -169,7 +169,7 @@ namespace FE_T
       void LU_solve(const double &b1, const double &b2, const double &b3,
           double &x1, double &x2, double &x3) const;
 
-      // Transpose operation for the matrix 
+      // Transpose operation for the matrix
       void transpose();
 
       // Inverse of the matrix (based on cofactor). The pp is not
@@ -181,10 +181,10 @@ namespace FE_T
 
       // Vector multiplication y = Ax
       // make sure the x y vector has length 3.
-      void VecMult( const double * const &xx, double * const &yy ) const; 
+      void VecMult( const double * const &xx, double * const &yy ) const;
 
       // Matrix multiplication
-      void MatMult( const Matrix_double_3by3_Array &mleft, 
+      void MatMult( const Matrix_double_3by3_Array &mleft,
           const Matrix_double_3by3_Array &mright );
 
       // print mat in matrix format
@@ -207,8 +207,8 @@ namespace FE_T
   // derivatives of element basis functions. The components are stored
   // in a 1-D array.
   //
-  // The array that stores the matrix is mat[36]. Logically, the matrix is 
-  //                    
+  // The array that stores the matrix is mat[36]. Logically, the matrix is
+  //
   //    mat[0],  mat[1],  mat[2],  mat[3],  mat[4],  mat[5]
   //    mat[6],  mat[7],  mat[8],  mat[9],  mat[10], mat[11]
   //    mat[12], mat[13], mat[14], mat[15], mat[16], mat[17]
@@ -236,7 +236,7 @@ namespace FE_T
 
     private:
       double Mat[36];
-      
+
       int pp[6];
   };
 
@@ -250,7 +250,7 @@ namespace FE_T
       // Input: \para vol_eleType     : the element type of the volume element
       //        \para boundary_id     : the boundary index defined specifically
       //        \para lower_quad_rule : the quadrature rlue of the lower-dimensional element
-      QuadPts_on_face(const FEType &vol_elemType, const int &face_id, 
+      QuadPts_on_face(const FEType &vol_elemType, int face_id,
           const IQuadPts * const lower_quad_rule);
 
       ~QuadPts_on_face() override = default;
@@ -261,7 +261,7 @@ namespace FE_T
 
       int get_num_quadPts() const override {return num_pts;}
 
-      double get_qp(const int &ii, const int &comp) const override
+      double get_qp(int ii, int comp) const override
       {return qp[dim * ii + comp];}
 
     private:
@@ -272,7 +272,7 @@ namespace FE_T
       // disallow default constructor
       QuadPts_on_face() = delete;
   };
-      
+
 } // End of FE_T
 
 #endif

--- a/include/IQuadPts.hpp
+++ b/include/IQuadPts.hpp
@@ -13,24 +13,24 @@ class IQuadPts
 {
   public:
     IQuadPts() = default;
-    
+
     virtual ~IQuadPts() = default;
 
     virtual void print_info() const
     {
       if( get_dim() == 4 )
       {
-        for(int ii=0; ii<get_num_quadPts(); ++ii) SYS_T::commPrint( "%d \t qw = %e \t qp = [%e \t %e \t %e \t %e] \n", 
+        for(int ii=0; ii<get_num_quadPts(); ++ii) SYS_T::commPrint( "%d \t qw = %e \t qp = [%e \t %e \t %e \t %e] \n",
             ii, get_qw(ii), get_qp(ii,0), get_qp(ii,1), get_qp(ii,2), get_qp(ii,3) );
       }
       else if( get_dim() == 3 )
       {
-        for(int ii=0; ii<get_num_quadPts(); ++ii) SYS_T::commPrint( "%d \t qw = %e \t qp = [%e \t %e \t %e] \n", 
+        for(int ii=0; ii<get_num_quadPts(); ++ii) SYS_T::commPrint( "%d \t qw = %e \t qp = [%e \t %e \t %e] \n",
             ii, get_qw(ii), get_qp(ii,0), get_qp(ii,1), get_qp(ii,2) );
       }
       else if( get_dim() == 2 )
       {
-        for(int ii=0; ii<get_num_quadPts(); ++ii) SYS_T::commPrint( "%d \t qw = %e \t qp = [%e \t %e] \n", 
+        for(int ii=0; ii<get_num_quadPts(); ++ii) SYS_T::commPrint( "%d \t qw = %e \t qp = [%e \t %e] \n",
             ii, get_qw(ii), get_qp(ii,0), get_qp(ii,1) );
       }
       else
@@ -38,9 +38,9 @@ class IQuadPts
         SYS_T::print_fatal("Error: get_dim() = %d has not been implemented.\n", get_dim() );
       }
     }
-   
+
     // ------------------------------------------------------------------------
-    // get_num_quadPts : returns the number of quadrature points 
+    // get_num_quadPts : returns the number of quadrature points
     // ------------------------------------------------------------------------
     virtual int get_num_quadPts() const = 0;
 
@@ -84,20 +84,20 @@ class IQuadPts
     virtual int get_dim() const = 0;
 
     // ------------------------------------------------------------------------
-    // get_qp : access the ii-th quadrature point, for dim = 1 classes.    
+    // get_qp : access the ii-th quadrature point, for dim = 1 classes.
     //          0 <= ii < get_num_quadPts()
     // ------------------------------------------------------------------------
-    virtual double get_qp(const int &ii) const
+    virtual double get_qp(int ii) const
     {
       SYS_T::print_fatal("Error: IQuadPts::get_qp is not implemented.\n");
       return 0.0;
     }
-    
+
     // ------------------------------------------------------------------------
     // get_qw : access the ii-th quadrature weight
     //          0 <= ii < get_num_quadPts()
     // ------------------------------------------------------------------------
-    virtual double get_qw(const int &ii) const
+    virtual double get_qw(int ii) const
     {
       SYS_T::print_fatal("Error: IQuadPts::get_qw is not implemented. \n");
       return 0.0;
@@ -105,19 +105,19 @@ class IQuadPts
 
     // ------------------------------------------------------------------------
     // get_qp : access the ii-th quadrature point's comp-th component
-    //          This function is designed for quadrature points in 
+    //          This function is designed for quadrature points in
     //          multidimensions.
     //          0 <= ii < get_num_quadPts()
     //          0 <= comp < get_dim()
     // ------------------------------------------------------------------------
-    virtual double get_qp(const int &ii, const int &comp) const
+    virtual double get_qp(int ii, int comp) const
     {
       SYS_T::print_fatal("Error: IQuadPts::get_qp is not implemented.\n");
       return 0.0;
     }
 
     // For User-defined QuadPts
-    virtual void set_qp(const double &xi, const double &eta)
+    virtual void set_qp(double xi, double eta)
     {
       SYS_T::print_fatal("Error: IQuadPts::set_qp is not implemented.\n");
     }

--- a/include/QuadPts_Gauss_1D.hpp
+++ b/include/QuadPts_Gauss_1D.hpp
@@ -2,7 +2,7 @@
 #define QUADPTS_GAUSS_1D_HPP
 // ============================================================================
 // QuadPts_Gauss_1D.hpp
-// This is the class that gives Gauss quadrature rule for the integration on a 
+// This is the class that gives Gauss quadrature rule for the integration on a
 // domain [min, max] with any number of points.
 //
 // Date: Sept. 24th 2013
@@ -17,28 +17,28 @@ class QuadPts_Gauss_1D final : public IQuadPts
 {
   public:
     // Construct in_num_pts-point rule for [min, max] domain
-    QuadPts_Gauss_1D( const int &in_num_pts, const double &min = 0.0, const double &max = 1.0 );
-    
+    QuadPts_Gauss_1D( int in_num_pts, double min = 0.0, double max = 1.0 );
+
     ~QuadPts_Gauss_1D() override = default;
 
     void print_info() const override;
 
     int get_dim() const override {return 1;}
-    
+
     int get_num_quadPts() const override {return num_pts;}
-    
-    double get_qp(const int &ii) const override {return qp[ii];}
-   
-    double get_qw(const int &ii) const override {return qw[ii];}
+
+    double get_qp(int ii) const override {return qp[ii];}
+
+    double get_qw(int ii) const override {return qw[ii];}
 
   private:
     // number of quadrature points
     const int num_pts;
-    
+
     // quadrature points and weights
     std::vector<double> qp {};
     std::vector<double> qw {};
-    
+
     // use Newton-Raphson iteration to find the Gauss quadrature
     // points-weights. This algorithm is obtained from the dealii
     // code, quadrature_lib.cc file.

--- a/include/QuadPts_Gauss_Hex.hpp
+++ b/include/QuadPts_Gauss_Hex.hpp
@@ -2,7 +2,7 @@
 #define QUADPTS_GAUSS_HEX_HPP
 // ==================================================================
 // QuadPts_Gauss_Hex.hpp
-// The Gaussian quadrature rule for a Hexagon domain defined by 
+// The Gaussian quadrature rule for a Hexagon domain defined by
 //         [r_min, r_max] x [s_min, s_max] x [t_min, t_max]
 //
 // Date Created: Sep 7 2023
@@ -12,20 +12,20 @@
 class QuadPts_Gauss_Hex final : public IQuadPts
 {
   public:
-    // Construct a quadrature rule with in_num_pts_x points in the r-direction, 
+    // Construct a quadrature rule with in_num_pts_x points in the r-direction,
     // in_num_pts_y in the s-direction, and in_num_pts_z in the t-direction
-    QuadPts_Gauss_Hex( const int &in_num_pts_x, 
-        const int &in_num_pts_y, const int &in_num_pts_z,
-        const double &r_min = 0.0, const double &r_max = 1.0,
-        const double &s_min = 0.0, const double &s_max = 1.0,
-        const double &t_min = 0.0, const double &t_max = 1.0 );
-    
+    QuadPts_Gauss_Hex( int in_num_pts_x,
+        int in_num_pts_y, int in_num_pts_z,
+        double r_min = 0.0, double r_max = 1.0,
+        double s_min = 0.0, double s_max = 1.0,
+        double t_min = 0.0, double t_max = 1.0 );
+
     // Construct a quadrature rule with given number of quadrature points in
     // all directions.
-    QuadPts_Gauss_Hex( const int &in_num_pts_1d, 
-        const double &r_min = 0.0, const double &r_max = 1.0, 
-        const double &s_min = 0.0, const double &s_max = 1.0,
-        const double &t_min = 0.0, const double &t_max = 1.0 );
+    QuadPts_Gauss_Hex( int in_num_pts_1d,
+        double r_min = 0.0, double r_max = 1.0,
+        double s_min = 0.0, double s_max = 1.0,
+        double t_min = 0.0, double t_max = 1.0 );
 
     ~QuadPts_Gauss_Hex() override = default;
 
@@ -41,16 +41,16 @@ class QuadPts_Gauss_Hex final : public IQuadPts
 
     int get_num_quadPts_z() const override {return num_pts_z;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[3*ii+comp];}
 
-    double get_qw(const int &ii) const override
+    double get_qw(int ii) const override
     {return qw[ii];}
 
   private:
     const int num_pts, num_pts_x, num_pts_y, num_pts_z;
 
-    // qp : length 3 * num_pts. Stores the r-s-t coordinates of the 
+    // qp : length 3 * num_pts. Stores the r-s-t coordinates of the
     //      quadrature points.
     // qw : length num_pts. Stores the quadrature weights.
     std::vector<double> qp {};

--- a/include/QuadPts_Gauss_Quad.hpp
+++ b/include/QuadPts_Gauss_Quad.hpp
@@ -2,7 +2,7 @@
 #define QUADPTS_GAUSS_QUAD_HPP
 // ============================================================================
 // QuadPts_Gauss_Quad.hpp
-// The Gaussian quadrature rule for a quadrilateral domain defined by 
+// The Gaussian quadrature rule for a quadrilateral domain defined by
 //                  [r_min, r_max] x [s_min, s_max]
 //
 // Date Created: Sep. 7 2023
@@ -12,18 +12,18 @@
 class QuadPts_Gauss_Quad final : public IQuadPts
 {
   public:
-    // Construct a quadrature rule with in_num_pts_x points in the r-direction 
-    // and in_num_pts_y in the s-direction 
-    QuadPts_Gauss_Quad( const int &in_num_pts_x, const int &in_num_pts_y, 
-        const double &r_min = 0.0, const double &r_max = 1.0, 
-        const double &s_min = 0.0, const double &s_max = 1.0 );
-    
+    // Construct a quadrature rule with in_num_pts_x points in the r-direction
+    // and in_num_pts_y in the s-direction
+    QuadPts_Gauss_Quad( int in_num_pts_x, int in_num_pts_y,
+        double r_min = 0.0, double r_max = 1.0,
+        double s_min = 0.0, double s_max = 1.0 );
+
     // Construct a quadrature rule with given number of quadrature points in
     // both directions.
-    QuadPts_Gauss_Quad( const int &in_num_pts_1d, 
-        const double &r_min = 0.0, const double &r_max = 1.0, 
-        const double &s_min = 0.0, const double &s_max = 1.0 );
-   
+    QuadPts_Gauss_Quad( int in_num_pts_1d,
+        double r_min = 0.0, double r_max = 1.0,
+        double s_min = 0.0, double s_max = 1.0 );
+
     ~QuadPts_Gauss_Quad() override = default;
 
     void print_info() const override;
@@ -36,10 +36,10 @@ class QuadPts_Gauss_Quad final : public IQuadPts
 
     int get_num_quadPts_y() const override {return num_pts_y;}
 
-    double get_qp(const int &ii, const int &comp) const override 
+    double get_qp(int ii, int comp) const override
     {return qp[2*ii+comp];}
 
-    double get_qw(const int &ii) const override {return qw[ii];}
+    double get_qw(int ii) const override {return qw[ii];}
 
   private:
     const int num_pts, num_pts_x, num_pts_y;

--- a/include/QuadPts_Gauss_Tet.hpp
+++ b/include/QuadPts_Gauss_Tet.hpp
@@ -2,17 +2,17 @@
 #define QUADPTS_GAUSS_TET_HPP
 // ==================================================================
 // QuadPts_Gauss_Tet.hpp
-// The Gaussian quadrature rule for a tetrahedral domain defined by 
+// The Gaussian quadrature rule for a tetrahedral domain defined by
 // four vertex points:
 // [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]
-// 
+//
 // num_pts =  4, exact for quadratic polynomials, order of prec. 2
 // num_pts =  5, exact for cubic     polynomials, order of prec. 3
 // num_pts = 17, exact for quintic   polynomials, order of prec. 5
 // num_pts = 29, exact for sextic    polynomials, order of prec. 6
 //
 // Reference: T.J.R. Hughes FEM Book p.174
-//            J. Yu Symmetric Gaussian Quadrature Formulae for 
+//            J. Yu Symmetric Gaussian Quadrature Formulae for
 //            Tetrahedronal Regions, CMAME 43 1984:349-353
 //
 // Date Created: Jan. 18 2017
@@ -23,7 +23,7 @@
 class QuadPts_Gauss_Tet final : public IQuadPts
 {
   public:
-    QuadPts_Gauss_Tet( const int &in_num_pts );
+    QuadPts_Gauss_Tet( int in_num_pts );
 
     ~QuadPts_Gauss_Tet() override = default;
 
@@ -33,22 +33,22 @@ class QuadPts_Gauss_Tet final : public IQuadPts
 
     int get_num_quadPts() const override {return num_pts;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[4*ii+comp];}
 
-    double get_qw(const int &ii) const override
+    double get_qw(int ii) const override
     {return qw[ii];}
 
   private:
     const int num_pts;
 
-    // qp : length 4 * num_pts. Stores the r-s-t-u coordinates of the 
+    // qp : length 4 * num_pts. Stores the r-s-t-u coordinates of the
     //      quadrature points.
     //      u = 1 - r - s - t
     // qw : length num_pts. Stores the quadrature weights.
     std::vector<double> qp {};
     std::vector<double> qw {};
-    
+
     // gen_permutations : generate permutations of a, b, c such that the
     //                    vector out includes the following 12 patterns.
     //                    a b c c; a c b c; a c c b;
@@ -56,8 +56,8 @@ class QuadPts_Gauss_Tet final : public IQuadPts
     //                    c a b c; c b a c;
     //                    c a c b; c b c a;
     //                    c c a b; c c b a;
-    std::vector<double> gen_permutations( const double &a, 
-        const double &b, const double &c ) const;
+    std::vector<double> gen_permutations( double a,
+        double b, double c ) const;
 };
 
 #endif

--- a/include/QuadPts_Gauss_Triangle.hpp
+++ b/include/QuadPts_Gauss_Triangle.hpp
@@ -4,18 +4,18 @@
 // QuadPts_Gauss_Triangle.hpp
 // The Gaussian quadrature rule for a triangular domain defined by vertices
 // [0.0, 0.0], [1.0, 0.0], & [0.0, 1.0].
-// 
+//
 // num_pts =  3, deg. of precision 2
 // num_pts =  4, deg. of precision 3
 // num_pts =  6, deg. of precision 4
 // num_pts = 13, deg. of precision 7
 //
 // Reference: T.J.R.Hughes FEM book, pp 173-174.
-// 
+//
 // num_pts = 19, deg. of precision 8
 // num_pts = 37, deg. of precision 13
 //
-// DCUTRI: an algorithm for adaptive cubature over a collection of triangles, 
+// DCUTRI: an algorithm for adaptive cubature over a collection of triangles,
 // ACM Transactions on Mathematical Software,
 // Volume 18, Number 3, September 1992, pages 329-342.
 //
@@ -30,8 +30,8 @@
 class QuadPts_Gauss_Triangle final : public IQuadPts
 {
   public:
-    QuadPts_Gauss_Triangle( const int &in_num_pts );
-    
+    QuadPts_Gauss_Triangle( int in_num_pts );
+
     ~QuadPts_Gauss_Triangle() override = default;
 
     void print_info() const override;
@@ -40,10 +40,10 @@ class QuadPts_Gauss_Triangle final : public IQuadPts
 
     int get_num_quadPts() const override {return num_pts;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[3*ii+comp];}
 
-    double get_qw(const int &ii) const override
+    double get_qw(int ii) const override
     {return qw[ii];}
 
   private:

--- a/include/QuadPts_UserDefined_Triangle.hpp
+++ b/include/QuadPts_UserDefined_Triangle.hpp
@@ -9,20 +9,20 @@ class QuadPts_UserDefined_Triangle final : public IQuadPts
 {
   public:
     QuadPts_UserDefined_Triangle() { reset(); }
-    
+
     ~QuadPts_UserDefined_Triangle() override = default;
 
     int get_dim() const override {return 3;}
 
     int get_num_quadPts() const override {return 1;}
 
-    double get_qp(const int &comp) const override
+    double get_qp(int comp) const override
     {return qp[comp];}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[3 * ii + comp];}
 
-    void set_qp(const double &xi, const double &eta) override
+    void set_qp(double xi, double eta) override
     { qp = {{ xi,  eta, 1.0 - xi - eta }}; }
 
     void reset() override
@@ -35,8 +35,8 @@ class QuadPts_UserDefined_Triangle final : public IQuadPts
     {
       constexpr double epsilon = 1.0e-4;
 
-      if( qp[0]>=(0-epsilon) && qp[0]<=(1+epsilon) && 
-          qp[1]>=(0-epsilon) && qp[1]<=(1+epsilon) && 
+      if( qp[0]>=(0-epsilon) && qp[0]<=(1+epsilon) &&
+          qp[1]>=(0-epsilon) && qp[1]<=(1+epsilon) &&
           qp[2]>=(0-epsilon) )
         return true;
       else

--- a/include/QuadPts_debug.hpp
+++ b/include/QuadPts_debug.hpp
@@ -15,7 +15,7 @@ class QuadPts_debug final : public IQuadPts
 {
   public:
     QuadPts_debug( const std::vector<double> &in_qp,
-        const std::vector<double> &in_qw, const int &in_dim = 1 );
+        const std::vector<double> &in_qw, int in_dim = 1 );
 
     ~QuadPts_debug() override = default;
 
@@ -25,12 +25,12 @@ class QuadPts_debug final : public IQuadPts
 
     int get_num_quadPts() const override {return num_pts;}
 
-    double get_qp(const int &ii) const override {return qp[ii];}
+    double get_qp(int ii) const override {return qp[ii];}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[dim*ii + comp];}
 
-    double get_qw(const int &ii) const override {return qw[ii];}
+    double get_qw(int ii) const override {return qw[ii];}
 
   private:
     const int num_pts, dim;

--- a/include/QuadPts_vis_hex27.hpp
+++ b/include/QuadPts_vis_hex27.hpp
@@ -6,18 +6,18 @@
 // This is a class that stores the visualization sampling points in
 // a reference hexahedron.
 //
-// We use four points at [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], 
-//                       [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], 
-//                       [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.5, 0.0, 0.0], 
-//                       [1.0, 0.5, 0.0], [0.5, 1.0, 0.0], [0.0, 0.5, 0.0], 
-//                       [0.5, 0.0, 1.0], [1.0, 0.5, 1.0], [0.5, 1.0, 1.0], 
-//                       [0.0, 0.5, 1.0], [0.0, 0.0, 0.5], [1.0, 0.0, 0.5], 
-//                       [1.0, 1.0, 0.5], [0.0, 1.0, 0.5], [0.0, 0.5, 0.5], 
+// We use four points at [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0],
+//                       [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 1.0],
+//                       [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.5, 0.0, 0.0],
+//                       [1.0, 0.5, 0.0], [0.5, 1.0, 0.0], [0.0, 0.5, 0.0],
+//                       [0.5, 0.0, 1.0], [1.0, 0.5, 1.0], [0.5, 1.0, 1.0],
+//                       [0.0, 0.5, 1.0], [0.0, 0.0, 0.5], [1.0, 0.0, 0.5],
+//                       [1.0, 1.0, 0.5], [0.0, 1.0, 0.5], [0.0, 0.5, 0.5],
 //                       [1.0, 0.5, 0.5], [0.5, 0.0, 0.5], [0.5, 1.0, 0.5],
-//                       [0.5, 0.5, 0.0], [0.5, 0.5, 1.0], [0.5, 0.5, 0.5] 
+//                       [0.5, 0.5, 0.0], [0.5, 0.5, 1.0], [0.5, 0.5, 0.5]
 // They are the vertex points of the hexahedron.
-// 
-// Note: We store them like what we did in QuadPts_Gauss_Hex class, so the dim = 3.       
+//
+// Note: We store them like what we did in QuadPts_Gauss_Hex class, so the dim = 3.
 //
 // Date Created: Oct. 30 2023
 // ==================================================================
@@ -27,17 +27,17 @@ class QuadPts_vis_hex27 final : public IQuadPts
 {
   public:
     QuadPts_vis_hex27() = default;
-    
+
     ~QuadPts_vis_hex27() override = default;
 
-    void print_info() const override 
+    void print_info() const override
     {
       SYS_T::commPrint("\n===== Visualization Points for Hex27 ===== \n");
       IQuadPts::print_info();
       SYS_T::commPrint("========================================= \n");
     }
 
-    // it stores the coordinate of the quadrature points 
+    // it stores the coordinate of the quadrature points
     // in the sequence of x-y-z, so the dim is 3
     int get_dim() const override {return 3;}
 
@@ -48,40 +48,40 @@ class QuadPts_vis_hex27 final : public IQuadPts
 
     int get_num_quadPts_y() const override {return 3;}
 
-    int get_num_quadPts_z() const override {return 3;}     
+    int get_num_quadPts_z() const override {return 3;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[3*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.5;}
+    double get_qw(int ii) const override {return 0.5;}
 
   private:
-    const double qp[81] { 0.0, 0.0, 0.0, 
-        1.0, 0.0, 0.0, 
+    const double qp[81] { 0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
         1.0, 1.0, 0.0,
-        0.0, 1.0, 0.0, 
+        0.0, 1.0, 0.0,
         0.0, 0.0, 1.0,
         1.0, 0.0, 1.0,
         1.0, 1.0, 1.0,
         0.0, 1.0, 1.0,
-        0.5, 0.0, 0.0, 
-        1.0, 0.5, 0.0, 
+        0.5, 0.0, 0.0,
+        1.0, 0.5, 0.0,
         0.5, 1.0, 0.0,
-        0.0, 0.5, 0.0, 
+        0.0, 0.5, 0.0,
         0.5, 0.0, 1.0,
         1.0, 0.5, 1.0,
         0.5, 1.0, 1.0,
         0.0, 0.5, 1.0,
-        0.0, 0.0, 0.5, 
-        1.0, 0.0, 0.5, 
+        0.0, 0.0, 0.5,
+        1.0, 0.0, 0.5,
         1.0, 1.0, 0.5,
-        0.0, 1.0, 0.5, 
+        0.0, 1.0, 0.5,
         0.0, 0.5, 0.5,
         1.0, 0.5, 0.5,
         0.5, 0.0, 0.5,
-        0.5, 1.0, 0.5, 
-        0.5, 0.5, 0.0, 
-        0.5, 0.5, 1.0, 
+        0.5, 1.0, 0.5,
+        0.5, 0.5, 0.0,
+        0.5, 0.5, 1.0,
         0.5, 0.5, 0.5 };
 };
 

--- a/include/QuadPts_vis_hex8.hpp
+++ b/include/QuadPts_vis_hex8.hpp
@@ -8,8 +8,8 @@
 //
 // We use four points at [0,0,0], [1,0,0], [1,1,0], [0,1,0], [0,0,1], [1,0,1], [1,1,1], [0,1,1].
 // They are the vertex points of the hexahedron.
-// 
-// Note: We store them like what we did in QuadPts_Gauss_Hex class, so the dim = 3.       
+//
+// Note: We store them like what we did in QuadPts_Gauss_Hex class, so the dim = 3.
 //
 // Date Created: Oct. 24 2023
 // ==================================================================
@@ -19,7 +19,7 @@ class QuadPts_vis_hex8 final : public IQuadPts
 {
   public:
     QuadPts_vis_hex8() = default;
-    
+
     ~QuadPts_vis_hex8() override = default;
 
     void print_info() const override
@@ -29,7 +29,7 @@ class QuadPts_vis_hex8 final : public IQuadPts
       SYS_T::commPrint("========================================= \n");
     }
 
-    // it stores the coordinate of the quadrature points 
+    // it stores the coordinate of the quadrature points
     // in the sequence of x-y-z, so the dim is 4
     int get_dim() const override {return 3;}
 
@@ -42,10 +42,10 @@ class QuadPts_vis_hex8 final : public IQuadPts
 
     int get_num_quadPts_z() const override {return 2;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[3*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.5;}
+    double get_qw(int ii) const override {return 0.5;}
 
   private:
     const double qp[24] {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0,

--- a/include/QuadPts_vis_quad4.hpp
+++ b/include/QuadPts_vis_quad4.hpp
@@ -24,7 +24,7 @@ class QuadPts_vis_quad4 final : public IQuadPts
       SYS_T::commPrint("========================================== \n");
     }
 
-    // it stores the coordinate of the quadrature points 
+    // it stores the coordinate of the quadrature points
     // in the sequence of x-y, so the dim is 2
     int get_dim() const override {return 2;}
 
@@ -35,10 +35,10 @@ class QuadPts_vis_quad4 final : public IQuadPts
 
     int get_num_quadPts_y() const override {return 2;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[2*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.5;}
+    double get_qw(int ii) const override {return 0.5;}
 
   private:
     const double qp[8] { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 };

--- a/include/QuadPts_vis_quad9.hpp
+++ b/include/QuadPts_vis_quad9.hpp
@@ -18,14 +18,14 @@ class QuadPts_vis_quad9 final : public IQuadPts
 
     ~QuadPts_vis_quad9() override = default;
 
-    void print_info() const override 
+    void print_info() const override
     {
       SYS_T::commPrint("\n===== Visualization Points for Quad9 ===== \n");
       IQuadPts::print_info();
       SYS_T::commPrint("========================================== \n");
     }
 
-    // it stores the coordinate of the quadrature points 
+    // it stores the coordinate of the quadrature points
     // in the sequence of x-y, so the dim is 2
     int get_dim() const override {return 2;}
 
@@ -36,20 +36,20 @@ class QuadPts_vis_quad9 final : public IQuadPts
 
     int get_num_quadPts_y() const override {return 3;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[2*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.5;}
+    double get_qw(int ii) const override {return 0.5;}
 
   private:
-    const double qp[18] { 0.0, 0.0, 
-      1.0, 0.0, 
-      1.0, 1.0, 
-      0.0, 1.0, 
-      0.5, 0.0, 
-      1.0, 0.5, 
-      0.5, 1.0, 
-      0.0, 0.5, 
+    const double qp[18] { 0.0, 0.0,
+      1.0, 0.0,
+      1.0, 1.0,
+      0.0, 1.0,
+      0.5, 0.0,
+      1.0, 0.5,
+      0.5, 1.0,
+      0.0, 0.5,
       0.5, 0.5 };
 };
 

--- a/include/QuadPts_vis_tet10.hpp
+++ b/include/QuadPts_vis_tet10.hpp
@@ -6,9 +6,9 @@
 // This is a class that stores the visualization sampling points in
 // a reference tetrahedron.
 //
-// We use [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], 
-// [0.5, 0, 0], [0.5, 0.5, 0], [0, 0.5, 0], [0, 0, 0.5], 
-// [0.5, 0, 0.5], [0, 0.5, 0.5]. 
+// We use [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+// [0.5, 0, 0], [0.5, 0.5, 0], [0, 0.5, 0], [0, 0, 0.5],
+// [0.5, 0, 0.5], [0, 0.5, 0.5].
 // They are the vertex points for the quadratic tetrahedron.
 //
 // Note: We store them in area-coordinates, like what we did in the
@@ -26,7 +26,7 @@ class QuadPts_vis_tet10 final : public IQuadPts
 
     ~QuadPts_vis_tet10() override = default;
 
-    void print_info() const override 
+    void print_info() const override
     {
       SYS_T::commPrint("\n===== Visualization Points for Tet10 ===== \n");
       IQuadPts::print_info();
@@ -37,10 +37,10 @@ class QuadPts_vis_tet10 final : public IQuadPts
 
     int get_num_quadPts() const override {return 10;}
 
-    double get_qp(const int &ii, const int &comp) const override
+    double get_qp(int ii, int comp) const override
     {return qp[4*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.1/6.0;}
+    double get_qw(int ii) const override {return 0.1/6.0;}
 
   private:
     const double qp[40] { 0.0, 0.0, 0.0, 1.0,

--- a/include/QuadPts_vis_tet4.hpp
+++ b/include/QuadPts_vis_tet4.hpp
@@ -8,7 +8,7 @@
 //
 // We use four points at [0,0,0], [1,0,0], [0,1,0], [0,0,1].
 // They are the vertex points of the tetrahedron.
-// 
+//
 // Note: We store them in area-coordinates like what we did in
 //       QuadPts_Gauss_Tet class, so the dim = 4.
 //
@@ -34,13 +34,13 @@ class QuadPts_vis_tet4 final : public IQuadPts
 
     int get_num_quadPts() const override {return 4;}
 
-    double get_qp(const int &ii, const int &comp) const override 
+    double get_qp(int ii, int comp) const override
     {return qp[4*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.25/6.0;}
+    double get_qw(int ii) const override {return 0.25/6.0;}
 
   private:
-    const double qp[16] { 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 
+    const double qp[16] { 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 };
 };
 

--- a/include/QuadPts_vis_tri6.hpp
+++ b/include/QuadPts_vis_tri6.hpp
@@ -5,7 +5,7 @@
 //
 // This is a class of quadrature points for 6 node triangle element.
 //
-// We use [0.0 , 0.0], [1.0 , 0.0], [0.0 , 1.0], 
+// We use [0.0 , 0.0], [1.0 , 0.0], [0.0 , 1.0],
 //        [0.5 , 0.0], [0.5 , 0.5], [0.0 , 0.5].
 // These are the vertex points for the quadratic triangle elements.
 // ==================================================================
@@ -18,23 +18,23 @@ class QuadPts_vis_tri6 final : public IQuadPts
 
     ~QuadPts_vis_tri6() override = default;
 
-    void print_info() const override 
+    void print_info() const override
     {
       SYS_T::commPrint("\n===== Visualization Points for Tri6 ===== \n");
       IQuadPts::print_info();
       SYS_T::commPrint("========================================= \n");
     }
 
-    // it stores the area coordinate of the quadrature points 
+    // it stores the area coordinate of the quadrature points
     // in the sequence of r-s-t, so the dim is 3
     int get_dim() const override {return 3;}
 
     int get_num_quadPts() const override {return 6;}
 
-    double get_qp(const int &ii, const int &comp) const override 
+    double get_qp(int ii, int comp) const override
     {return qp[3*ii+comp];}
 
-    double get_qw(const int &ii) const override {return 0.5/6.0;}
+    double get_qw(int ii) const override {return 0.5/6.0;}
 
   private:
     const double qp[18] { 0.0, 0.0, 1.0,

--- a/src/Element/FE_Tools.cpp
+++ b/src/Element/FE_Tools.cpp
@@ -99,7 +99,7 @@ Vector_3 FE_T::get_n_from_t( const Vector_3 &tan, const Vector_3 &p0, const Vect
 }
 
 void FE_T::get_tet_sphere_info(
-    const double &x0, const double &x1, const double &x2, const double &x3, 
+    const double &x0, const double &x1, const double &x2, const double &x3,
     const double &y0, const double &y1, const double &y2, const double &y3,
     const double &z0, const double &z1, const double &z2, const double &z3,
     double &xx, double &yy, double &zz, double &rr )
@@ -145,8 +145,8 @@ double FE_T::get_tet_sphere_radius (
 }
 
 Vector_3 FE_T::get_tet_sphere_info( const Vector_3 &pt0,
-    const Vector_3 &pt1, const Vector_3 &pt2, const Vector_3 &pt3, 
-    double &radius ) 
+    const Vector_3 &pt1, const Vector_3 &pt2, const Vector_3 &pt3,
+    double &radius )
 {
   FE_T::Matrix_double_3by3_Array AA(
       2.0 * (pt1.x()-pt0.x()), 2.0 * (pt1.y()-pt0.y()), 2.0 * (pt1.z()-pt0.z()),
@@ -210,7 +210,7 @@ bool FE_T::search_closest_point( const Vector_3 &target_xyz,
   const double init_dist = Vec3::dist(point_xyz, target_xyz);
 
   // SYS_T::commPrint("      init_dist: %e\n", init_dist);
-  if (init_dist < 1e-9) return true;  // lucky enouugh 
+  if (init_dist < 1e-9) return true;  // lucky enouugh
   if (init_dist > 8) return false;
 
   // initialize the nonlinear iteration
@@ -322,7 +322,7 @@ namespace FE_T
     pp[0] = 0; pp[1] = 1; pp[2] = 2;
   }
 
-  Matrix_double_3by3_Array::Matrix_double_3by3_Array( 
+  Matrix_double_3by3_Array::Matrix_double_3by3_Array(
       const double &a11, const double &a12, const double &a13,
       const double &a21, const double &a22, const double &a23,
       const double &a31, const double &a32, const double &a33 )
@@ -331,7 +331,7 @@ namespace FE_T
     mat[3] = a21;  mat[4] = a22;  mat[5] = a23;
     mat[6] = a31;  mat[7] = a32;  mat[8] = a33;
 
-    pp[0] = 0; pp[1] = 1; pp[2] = 2; 
+    pp[0] = 0; pp[1] = 1; pp[2] = 2;
   }
 
   Matrix_double_3by3_Array& Matrix_double_3by3_Array::operator= (
@@ -361,7 +361,7 @@ namespace FE_T
     std::random_device rd;
     std::mt19937_64 gen( rd() );
     std::uniform_real_distribution<double> dis(min, max);
-    for(int ii=0; ii<9; ++ii) mat[ii] = dis(gen); 
+    for(int ii=0; ii<9; ++ii) mat[ii] = dis(gen);
 
     pp[0] = 0; pp[1] = 1; pp[2] = 2;
   }
@@ -509,7 +509,7 @@ namespace FE_T
   {
     double temp = mat[1]; mat[1] = mat[3]; mat[3] = temp;
     temp = mat[2]; mat[2] = mat[6]; mat[6] = temp;
-    temp = mat[5]; mat[5] = mat[7]; mat[7] = temp; 
+    temp = mat[5]; mat[5] = mat[7]; mat[7] = temp;
   }
 
   void Matrix_double_3by3_Array::inverse()
@@ -531,8 +531,8 @@ namespace FE_T
 
   double Matrix_double_3by3_Array::det() const
   {
-    return mat[0] * mat[4] * mat[8] + mat[1] * mat[5] * mat[6] 
-      + mat[2] * mat[3] * mat[7] - mat[2] * mat[4] * mat[6] 
+    return mat[0] * mat[4] * mat[8] + mat[1] * mat[5] * mat[6]
+      + mat[2] * mat[3] * mat[7] - mat[2] * mat[4] * mat[6]
       - mat[0] * mat[5] * mat[7] - mat[1] * mat[3] * mat[8];
   }
 
@@ -629,7 +629,7 @@ namespace FE_T
           Mat[6*kk+ii] = Mat[6*max_index+ii];
           Mat[6*max_index+ii] = temp;
         }
-      } 
+      }
 
       for(int ii=kk+1; ii<6; ++ii)
       {
@@ -675,7 +675,7 @@ namespace FE_T
     std::cout<<'\n'<<std::endl;
   }
 
-  QuadPts_on_face::QuadPts_on_face(const FEType &vol_elemType, const int &face_id, 
+  QuadPts_on_face::QuadPts_on_face(const FEType &vol_elemType, int face_id,
       const IQuadPts * const lower_quad_rule)
     : dim(lower_quad_rule->get_dim() + 1), num_pts( lower_quad_rule -> get_num_quadPts() )
   {
@@ -689,9 +689,9 @@ namespace FE_T
       //                   / |    `.
       //                  /  |       `.
       //                 /   |          `.
-      //                /    |             `.     
+      //                /    |             `.
       //               /     |                `.
-      //              /      |                   `.   
+      //              /      |                   `.
       //             /      ,0 - - - - - - - - - - -`2 - - -> s
       //            /     ,'  (u)               ,  "
       //           /    ,'                ,  "
@@ -707,18 +707,18 @@ namespace FE_T
         "Error: FE_T::QuadPts_on_face, wrong surface quadrature rule.\n" );
 
       qp.assign( 4 * lower_quad_rule->get_num_quadPts(), 0.0 );
-      
+
       switch(face_id)
       {
         case 0: // u = 0 : node1 = node0', node2 = node1', node3 = node2'       //      t                                     s'
           for(int ii {0}; ii < lower_quad_rule->get_num_quadPts(); ++ii)        //      ^                                     ^
           {                                                                     //      3                                     2'
-            qp[4*ii + 0] = lower_quad_rule->get_qp(ii, 2);  // r = t'           //      |  `.                     map         |  `.  
+            qp[4*ii + 0] = lower_quad_rule->get_qp(ii, 2);  // r = t'           //      |  `.                     map         |  `.
             qp[4*ii + 1] = lower_quad_rule->get_qp(ii, 0);  // s = r'           //      |     `.                 <----        |     `.
             qp[4*ii + 2] = lower_quad_rule->get_qp(ii, 1);  // t = s'           //      | front  `.                           |        `.
           }                                                                     //      |           `.                        |           `.
           break;                                                                //  (r) 1 - - - - - - 2 - - -> s         (t') 0'- - - - - - 1'- - -> r'
-        
+
         case 1: // r = 0 : node0 = node0', node3 = node1', node2 = node2'       //      s                                     s'
           for(int ii {0}; ii < lower_quad_rule->get_num_quadPts(); ++ii)        //      ^                                     ^
           {                                                                     //      2                                     2'
@@ -779,7 +779,7 @@ namespace FE_T
         "Error: FE_T::QuadPts_on_face, wrong surface quadrature rule.\n" );
 
       qp.assign( 3 * lower_quad_rule->get_num_quadPts(), 0.0 );
-      
+
       switch(face_id)
       {
         case 0: // t = 0 : node0 = node0', node3 = node1', node2 = node2', node1 = node3' //    r                          s'
@@ -799,7 +799,7 @@ namespace FE_T
             qp[3*ii + 2] = 1.0;                             // t = 1                      //    |   top    |       <----   |          |
           }                                                                               //    |          |               |          |
           break;                                                                          //    4 -------- 5 - -> r        0'-------- 1'- -> r'
-        
+
         case 2: // s = 0 : node0 = node0', node1 = node1', node5 = node2', node4 = node3' //    t                          s'
           for(int ii {0}; ii < lower_quad_rule->get_num_quadPts(); ++ii)                  //    ^                          ^
           {                                                                               //    |                          |
@@ -826,7 +826,7 @@ namespace FE_T
             qp[3*ii + 2] = lower_quad_rule->get_qp(ii, 0);  // t = r'                     //    |   right  |       <----   |          |
           }                                                                               //    |          |               |          |
           break;                                                                          //    3 -------- 7 - -> t        0'-------- 1'- -> r'
-        
+
         case 5: // r = 0 : node0 = node0', node4 = node1', node7 = node2', node3 = node3' //    s                          s'
           for(int ii {0}; ii < lower_quad_rule->get_num_quadPts(); ++ii)                  //    ^                          ^
           {                                                                               //    |                          |
@@ -835,7 +835,7 @@ namespace FE_T
             qp[3*ii + 2] = lower_quad_rule->get_qp(ii, 0);  // t = r'                     //    |   back   |       <----   |          |
           }                                                                               //    |          |               |          |
           break;                                                                          //    0 -------- 4 - -> t        0'-------- 1'- -> r'
-        
+
         default:
           SYS_T::print_fatal("Error: FE_T::QuadPts_on_face, wrong face id input.\n");
           break;

--- a/src/Mesh/QuadPts_Gauss_1D.cpp
+++ b/src/Mesh/QuadPts_Gauss_1D.cpp
@@ -1,7 +1,7 @@
 #include "QuadPts_Gauss_1D.hpp"
 
-QuadPts_Gauss_1D::QuadPts_Gauss_1D( const int &in_num_pts, const double &min, 
-    const double &max ) : num_pts(in_num_pts)
+QuadPts_Gauss_1D::QuadPts_Gauss_1D( int in_num_pts, double min,
+    double max ) : num_pts(in_num_pts)
 {
   // Make sure that min < max
   SYS_T::print_fatal_if( min >= max, "Error: QuadPts_Gauss_1D, the given range of quadrature domain is incorrect.\n");
@@ -122,12 +122,12 @@ QuadPts_Gauss_1D::QuadPts_Gauss_1D( const int &in_num_pts, const double &min,
       qw.push_back(0.090324080347429);
       qw.push_back(0.040637194180787);
       break;
-   
+
     case 10:
       qp.push_back(0.986953264258586);
       qp.push_back(0.932531683344492);
       qp.push_back(0.839704784149512);
-      qp.push_back(0.716697697064624); 
+      qp.push_back(0.716697697064624);
       qp.push_back(0.574437169490816);
       qp.push_back(0.425562830509184);
       qp.push_back(0.283302302935376);
@@ -157,7 +157,7 @@ QuadPts_Gauss_1D::QuadPts_Gauss_1D( const int &in_num_pts, const double &min,
   // Reverse the points and weights to make them in ascending order
   std::reverse(qp.begin(), qp.end());
   std::reverse(qw.begin(), qw.end());
-  
+
   // Now map the rule to the [min, max] domain via a linear change of interval
   // x = (max-min) xi + min
   // see en.wikipedia.org/wiki/Gaussian_quadrature

--- a/src/Mesh/QuadPts_Gauss_Hex.cpp
+++ b/src/Mesh/QuadPts_Gauss_Hex.cpp
@@ -1,10 +1,10 @@
 #include "QuadPts_Gauss_Hex.hpp"
 
-QuadPts_Gauss_Hex::QuadPts_Gauss_Hex( const int &in_num_pts_x,
-    const int &in_num_pts_y, const int &in_num_pts_z,
-    const double &x_min, const double &x_max,
-    const double &y_min, const double &y_max,
-    const double &z_min, const double &z_max )
+QuadPts_Gauss_Hex::QuadPts_Gauss_Hex( int in_num_pts_x,
+    int in_num_pts_y, int in_num_pts_z,
+    double x_min, double x_max,
+    double y_min, double y_max,
+    double z_min, double z_max )
 : num_pts( in_num_pts_x * in_num_pts_y * in_num_pts_z ),
   num_pts_x( in_num_pts_x ), num_pts_y( in_num_pts_y ), num_pts_z( in_num_pts_z )
 {
@@ -31,10 +31,10 @@ QuadPts_Gauss_Hex::QuadPts_Gauss_Hex( const int &in_num_pts_x,
   qw.shrink_to_fit();
 }
 
-QuadPts_Gauss_Hex::QuadPts_Gauss_Hex( const int &in_num_pts_1d, 
-    const double &x_min, const double &x_max, 
-    const double &y_min, const double &y_max,
-    const double &z_min, const double &z_max )
+QuadPts_Gauss_Hex::QuadPts_Gauss_Hex( int in_num_pts_1d,
+    double x_min, double x_max,
+    double y_min, double y_max,
+    double z_min, double z_max )
 : QuadPts_Gauss_Hex(in_num_pts_1d, in_num_pts_1d, in_num_pts_1d,
     x_min, x_max, y_min, y_max, z_min, z_max)
 {}
@@ -46,7 +46,7 @@ void QuadPts_Gauss_Hex::print_info() const
   SYS_T::commPrint("qp.size() = %d\n", qp.size());
   SYS_T::commPrint("qw.size() = %d\n", qw.size());
   for(int ii=0; ii<num_pts; ++ii)
-    SYS_T::commPrint("  %.15f %.15f %.15f %.15f\n", 
+    SYS_T::commPrint("  %.15f %.15f %.15f %.15f\n",
         qp[3*ii], qp[3*ii+1], qp[3*ii+2], qw[ii]);
   SYS_T::commPrint("=======================================\n");
 }

--- a/src/Mesh/QuadPts_Gauss_Quad.cpp
+++ b/src/Mesh/QuadPts_Gauss_Quad.cpp
@@ -1,9 +1,9 @@
 #include "QuadPts_Gauss_Quad.hpp"
 
-QuadPts_Gauss_Quad::QuadPts_Gauss_Quad( const int &in_num_pts_x,
-    const int &in_num_pts_y, 
-    const double &x_min, const double &x_max, 
-    const double &y_min, const double &y_max )
+QuadPts_Gauss_Quad::QuadPts_Gauss_Quad( int in_num_pts_x,
+    int in_num_pts_y,
+    double x_min, double x_max,
+    double y_min, double y_max )
 : num_pts( in_num_pts_x * in_num_pts_y ), num_pts_x( in_num_pts_x ), num_pts_y( in_num_pts_y )
 {
   qp.clear(); qw.clear();
@@ -26,9 +26,9 @@ QuadPts_Gauss_Quad::QuadPts_Gauss_Quad( const int &in_num_pts_x,
   qw.shrink_to_fit();
 }
 
-QuadPts_Gauss_Quad::QuadPts_Gauss_Quad( const int &in_num_pts_1d, 
-    const double &x_min, const double &x_max, 
-    const double &y_min, const double &y_max )
+QuadPts_Gauss_Quad::QuadPts_Gauss_Quad( int in_num_pts_1d,
+    double x_min, double x_max,
+    double y_min, double y_max )
 : QuadPts_Gauss_Quad(in_num_pts_1d, in_num_pts_1d, x_min, x_max, y_min, y_max)
 {}
 
@@ -39,7 +39,7 @@ void QuadPts_Gauss_Quad::print_info() const
   SYS_T::commPrint("qp.size() = %d\n", qp.size());
   SYS_T::commPrint("qw.size() = %d\n", qw.size());
   for(int ii=0; ii<num_pts; ++ii)
-    SYS_T::commPrint("  %.15f %.15f %.15f\n", 
+    SYS_T::commPrint("  %.15f %.15f %.15f\n",
         qp[2*ii], qp[2*ii+1], qw[ii]);
   SYS_T::commPrint("====================================\n");
 }

--- a/src/Mesh/QuadPts_Gauss_Tet.cpp
+++ b/src/Mesh/QuadPts_Gauss_Tet.cpp
@@ -1,10 +1,10 @@
 #include "QuadPts_Gauss_Tet.hpp"
 
-QuadPts_Gauss_Tet::QuadPts_Gauss_Tet( const int &in_num_pts ) : num_pts( in_num_pts )
+QuadPts_Gauss_Tet::QuadPts_Gauss_Tet( int in_num_pts ) : num_pts( in_num_pts )
 {
   qp.resize( 4 * num_pts );
   qw.resize( num_pts );
-  
+
   int offset;
   double a,b,c,w;
   std::vector<double> temp;
@@ -41,7 +41,7 @@ QuadPts_Gauss_Tet::QuadPts_Gauss_Tet( const int &in_num_pts ) : num_pts( in_num_
       c = (1.0 - a - b) / 2.0;
       temp = gen_permutations(a,b,c);
       for(int ii=0; ii<48; ++ii) qp[ii] = temp[ii];
-      
+
       for(int ii=0; ii<12; ++ii) qw[ii] = 0.04528559236327399;
 
       a = 0.7316369079576180;
@@ -61,7 +61,7 @@ QuadPts_Gauss_Tet::QuadPts_Gauss_Tet( const int &in_num_pts ) : num_pts( in_num_
       qp[offset+12] = b; qp[offset+13] = b; qp[offset+14] = b; qp[offset+15] = a;
       qw[15] = w;
 
-      qp[offset+16] = 0.25; qp[offset+17] = 0.25; 
+      qp[offset+16] = 0.25; qp[offset+17] = 0.25;
       qp[offset+18] = 0.25; qp[offset+19] = 0.25;
       qw[16] = 0.1884185567365411;
 
@@ -84,7 +84,7 @@ QuadPts_Gauss_Tet::QuadPts_Gauss_Tet( const int &in_num_pts ) : num_pts( in_num_
       temp = gen_permutations(a,b,c);
       offset = 48;
       for(int ii=0; ii<48; ++ii) qp[offset+ii] = temp[ii];
-      
+
       for(int ii=0; ii<12; ++ii) qw[12+ii] = w;
 
       a = 0.8277192480479295;
@@ -104,7 +104,7 @@ QuadPts_Gauss_Tet::QuadPts_Gauss_Tet( const int &in_num_pts ) : num_pts( in_num_
       qp[offset+12] = b; qp[offset+13] = b; qp[offset+14] = b; qp[offset+15] = a;
       qw[27] = w;
 
-      qp[offset+16] = 0.25; qp[offset+17] = 0.25; 
+      qp[offset+16] = 0.25; qp[offset+17] = 0.25;
       qp[offset+18] = 0.25; qp[offset+19] = 0.25;
       qw[28] = 0.09040129046014750;
 
@@ -128,13 +128,13 @@ void QuadPts_Gauss_Tet::print_info() const
   SYS_T::commPrint("qp.size() = %d\n", qp.size());
   SYS_T::commPrint("qw.size() = %d\n", qw.size());
   for(int ii=0; ii<num_pts; ++ii)
-    SYS_T::commPrint("  %.15f %.15f %.15f %.15f %.15f\n", 
+    SYS_T::commPrint("  %.15f %.15f %.15f %.15f %.15f\n",
         qp[4*ii], qp[4*ii+1], qp[4*ii+2], qp[4*ii+3], qw[ii]);
   SYS_T::commPrint("===========================================\n");
 }
 
-std::vector<double> QuadPts_Gauss_Tet::gen_permutations(const double &a,
-    const double &b, const double &c ) const
+std::vector<double> QuadPts_Gauss_Tet::gen_permutations(double a,
+    double b, double c ) const
 {
   return {a,b,c,c,
     a,c,b,c,

--- a/src/Mesh/QuadPts_Gauss_Triangle.cpp
+++ b/src/Mesh/QuadPts_Gauss_Triangle.cpp
@@ -1,6 +1,6 @@
 #include "QuadPts_Gauss_Triangle.hpp"
 
-QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pts( in_num_pts )
+QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( int in_num_pts ) : num_pts( in_num_pts )
 {
   qp.resize( 3 * num_pts );
   qw.resize( num_pts );
@@ -79,7 +79,7 @@ QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pt
       qp[3] = a; qp[4] = b; qp[5] = b; qw[1] = w;
       qp[6] = b; qp[7] = a; qp[8] = b; qw[2] = w;
       qp[9] = b; qp[10] = b; qp[11] = a; qw[3] = w;
-      
+
       a = 0.869739794195568;
       b = 0.065130102902216;
       w = 0.053347235608839;
@@ -116,7 +116,7 @@ QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pt
       w = 0.078357352244117;
       qp[12] = a; qp[13] = b; qp[14] = b; qw[4] = w;
       qp[15] = b; qp[16] = a; qp[17] = b; qw[5] = w;
-      qp[18] = b; qp[19] = b; qp[20] = a; qw[6] = w;  
+      qp[18] = b; qp[19] = b; qp[20] = a; qw[6] = w;
 
       a = 0.535795346449899;
       b = 0.232102326775050;
@@ -154,58 +154,58 @@ QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pt
       w = 0.008007799555564801597804123460;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
-  
+
       a = 0.171614914923835347556304795551;
       b = 0.414192542538082326221847602214;
       w = 0.046868898981821644823226732071;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
- 
+
       a = 0.539412243677190440263092985511;
       b = 0.230293878161404779868453507244;
-      w = 0.046590940183976487960361770070; 
+      w = 0.046590940183976487960361770070;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
 
       a = 0.772160036676532561750285570113;
       b = 0.113919981661733719124857214943;
-      w = 0.031016943313796381407646220131; 
+      w = 0.031016943313796381407646220131;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
 
       a = 0.009085399949835353883572964740;
-      b = 0.495457300025082323058213517632; 
+      b = 0.495457300025082323058213517632;
       w = 0.010791612736631273623178240136;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
 
@@ -214,10 +214,10 @@ QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pt
       w = 0.032195534242431618819414482205;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
 
@@ -227,41 +227,41 @@ QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pt
       w = 0.015445834210701583817692900053;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = c; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = c; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = c; qw[idx] = w;
 
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = c; qp[3*idx+2] = a; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = c; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = c; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
 
       a = 0.018620522802520968955913511549;
       b = 0.689441970728591295496647976487;
-      c = 0.291937506468887771754472382212;  
+      c = 0.291937506468887771754472382212;
       w = 0.017822989923178661888748319485;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = c; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = c; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = c; qw[idx] = w;
 
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = c; qp[3*idx+2] = a; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = c; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = c; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
 
@@ -271,19 +271,19 @@ QuadPts_Gauss_Triangle::QuadPts_Gauss_Triangle( const int &in_num_pts ) : num_pt
       w = 0.037038683681384627918546472190;
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = b; qp[3*idx+2] = c; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = a; qp[3*idx+1] = c; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = a; qp[3*idx+2] = c; qw[idx] = w;
 
       idx += 1;
       qp[3*idx] = b; qp[3*idx+1] = c; qp[3*idx+2] = a; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = c; qp[3*idx+1] = a; qp[3*idx+2] = b; qw[idx] = w;
-      
+
       idx += 1;
       qp[3*idx] = c; qp[3*idx+1] = b; qp[3*idx+2] = a; qw[idx] = w;
       break;
@@ -307,7 +307,7 @@ void QuadPts_Gauss_Triangle::print_info() const
   SYS_T::commPrint("qp.size() = %d\n", qp.size());
   SYS_T::commPrint("qw.size() = %d\n", qw.size());
   for(int ii=0; ii<num_pts; ++ii)
-    SYS_T::commPrint("  %.15f %.15f %.15f %.15f\n", 
+    SYS_T::commPrint("  %.15f %.15f %.15f %.15f\n",
         qp[3*ii], qp[3*ii+1], qp[3*ii+2], qw[ii]);
   SYS_T::commPrint("========================================\n");
 }

--- a/src/Mesh/QuadPts_debug.cpp
+++ b/src/Mesh/QuadPts_debug.cpp
@@ -1,10 +1,10 @@
 #include "QuadPts_debug.hpp"
 
-QuadPts_debug::QuadPts_debug( const std::vector<double> &in_qp, 
-    const std::vector<double> &in_qw, const int &in_dim )
+QuadPts_debug::QuadPts_debug( const std::vector<double> &in_qp,
+    const std::vector<double> &in_qw, int in_dim )
 : num_pts( VEC_T::get_size(in_qw) ), dim( in_dim ), qp( in_qp ), qw( in_qw )
 {
-  SYS_T::print_fatal_if( qp.size() != dim*qw.size(), 
+  SYS_T::print_fatal_if( qp.size() != dim*qw.size(),
       "Error: QuadPts_debug, input vector does not have the same length.\n");
 }
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary references for small scalar types by changing `const int &` and `const double &` parameters to pass-by-value `int` and `double` in the quadrature interface and implementations.
- Ensure consistent method signatures across the `IQuadPts` interface and all derived quadrature classes to avoid mismatches between declarations and definitions.

### Description
- Changed `IQuadPts` interface methods (`get_qp`, `get_qw`, `get_qp(..., comp)`, `set_qp`) to take `int` / `double` by value instead of `const &` and updated the implementation bodies accordingly in `include/IQuadPts.hpp`.
- Propagated the same signature changes to all derived quadrature classes and their implementations under `include/QuadPts_*`, `include/QuadPts_vis_*.hpp`, and `src/Mesh/QuadPts_*.cpp` so declarations and definitions match.
- Updated `FE_T::QuadPts_on_face` declaration and definition in `include/FE_Tools.hpp` and `src/Element/FE_Tools.cpp` to use value parameters for scalar arguments and to match the new `IQuadPts` conventions.
- Performed whitespace and trivial formatting cleanups in affected files to satisfy style checks.

### Testing
- Ran a targeted search `rg -n "const int\\s*&|const double\\s*&"` on the relevant headers and source files to confirm no remaining `const &` usages for these scalar parameters, and the check returned no remaining matches in the changed families (success).
- Ran `git diff --check` to ensure there are no trailing-whitespace or diff-check warnings after edits (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45a05bb4c832a939818109f19465a)