### PR TITLE
Make ALocal_IEN.hpp self-contained: include <algorithm> and qualify std::find

### DIFF
--- a/include/ALocal_IEN.hpp
+++ b/include/ALocal_IEN.hpp
@@ -14,6 +14,7 @@
 // Author: Ju Liu
 // Date: Nov. 10th 2013
 // ============================================================================
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -85,7 +86,7 @@ class ALocal_IEN
     virtual bool isNode_in_Elem(int elem, int node) const
     {
       const std::vector<int> eIEN = get_LIEN( elem );
-      std::vector<int>::const_iterator it = find(eIEN.begin(), eIEN.end(), node);
+      std::vector<int>::const_iterator it = std::find(eIEN.begin(), eIEN.end(), node);
       return (it != eIEN.end());
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the header is self-contained and does not rely on transitive includes so it compiles independently and `std::find` is properly visible.

### Description
- Add `#include <algorithm>` to `include/ALocal_IEN.hpp` and replace the unqualified `find(...)` with `std::find(...)` inside `ALocal_IEN::isNode_in_Elem`.

### Testing
- No automated build or unit tests were run for this header-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45d37df5c832aa194e7aa43261aa2)