### PR TITLE
Refactor IGlobal_Part scalar index params to pass by value

### DIFF
--- a/include/Global_Part_METIS.hpp
+++ b/include/Global_Part_METIS.hpp
@@ -51,14 +51,14 @@ class Global_Part_METIS : public IGlobal_Part
 
     virtual ~Global_Part_METIS();
 
-    virtual idx_t get_epart( const int &ee ) const {return epart[ee];}
+    virtual idx_t get_epart( int ee ) const {return epart[ee];}
 
     // ------------------------------------------------------------------------
     // For multifield partition, we allow the access of partition results by
     // specifiying the field index, and nn ranges in 
     // [ 0 , mesh[field]->get_nFunc )
     // ------------------------------------------------------------------------
-    virtual idx_t get_npart( const int &nn, const int &field = 0 ) const 
+    virtual idx_t get_npart( int nn, int field = 0 ) const
     {return npart[nn + field_offset[field]];}
 
     virtual bool get_isMETIS() const {return true;};

--- a/include/Global_Part_Reload.hpp
+++ b/include/Global_Part_Reload.hpp
@@ -19,9 +19,9 @@ class Global_Part_Reload : public IGlobal_Part
 
     virtual ~Global_Part_Reload();
 
-    virtual idx_t get_epart( const int &ee ) const {return static_cast<idx_t>(epart[ee]);}
+    virtual idx_t get_epart( int ee ) const {return static_cast<idx_t>(epart[ee]);}
 
-    virtual idx_t get_npart( const int &nn, const int &field ) const 
+    virtual idx_t get_npart( int nn, int field ) const
     {return static_cast<idx_t>(npart[nn + field_offset[field]]);}
 
     virtual bool get_isMETIS() const {return isMETIS;};

--- a/include/Global_Part_Serial.hpp
+++ b/include/Global_Part_Serial.hpp
@@ -28,9 +28,9 @@ class Global_Part_Serial : public IGlobal_Part
 
     virtual ~Global_Part_Serial();
 
-    virtual idx_t get_epart( const int &ee ) const {return epart[ee];}
+    virtual idx_t get_epart( int ee ) const {return epart[ee];}
 
-    virtual idx_t get_npart( const int &nn, const int &field = 0 ) const 
+    virtual idx_t get_npart( int nn, int field = 0 ) const
     {return npart[nn + field_offset[field]];}
 
     virtual bool get_isMETIS() const {return false;};

--- a/include/IGlobal_Part.hpp
+++ b/include/IGlobal_Part.hpp
@@ -22,9 +22,9 @@ class IGlobal_Part
     
     virtual ~IGlobal_Part() = default;
 
-    virtual idx_t get_epart( const int &ee ) const = 0;
+    virtual idx_t get_epart( int ee ) const = 0;
     
-    virtual idx_t get_npart( const int &nn, const int &field = 0 ) const = 0;
+    virtual idx_t get_npart( int nn, int field = 0 ) const = 0;
 
     virtual bool get_isMETIS() const = 0;
     


### PR DESCRIPTION
### Motivation
- Small integer indices used by the global-partition interface are more idiomatically passed by value; this removes needless `const int&` indirection for scalars.
- Ensure the pure virtual interface and all overrides have exactly matching signatures so virtual dispatch and ABI remain consistent.
- Preserve existing behavior while simplifying parameter passing and reducing potential for accidental reference-related issues.

### Description
- Changed the `IGlobal_Part` pure virtual methods from `virtual idx_t get_epart(const int &ee) const` and `virtual idx_t get_npart(const int &nn, const int &field = 0) const` to `virtual idx_t get_epart(int ee) const` and `virtual idx_t get_npart(int nn, int field = 0) const` in `include/IGlobal_Part.hpp`.
- Updated the corresponding overrides in `include/Global_Part_METIS.hpp`, `include/Global_Part_Serial.hpp`, and `include/Global_Part_Reload.hpp` to use `int` parameters so signatures exactly match the base class; method bodies were left unchanged.
- No logic or behavior was modified beyond parameter passing conventions.

### Testing
- Ran `rg "get_epart\(|get_npart\(" include -n` to confirm all declarations/overrides were updated, and the search completed successfully.
- Ran `git diff --check` to verify there are no whitespace/style regressions, which reported no issues.
- Inspected the updated headers (line checks) to confirm signatures match between the interface and derived classes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ba03bb9c832aa88b59d318f9b91e)