### PR TITLE
Add explicit override specifiers to IGlobal_Part implementations

### DIFF
--- a/include/Global_Part_METIS.hpp
+++ b/include/Global_Part_METIS.hpp
@@ -49,25 +49,25 @@ class Global_Part_METIS : public IGlobal_Part
         const std::string &element_part_name = "epart",
         const std::string &node_part_name = "npart" );
 
-    virtual ~Global_Part_METIS();
+    ~Global_Part_METIS() override;
 
-    virtual idx_t get_epart( int ee ) const {return epart[ee];}
+    idx_t get_epart( int ee ) const override {return epart[ee];}
 
     // ------------------------------------------------------------------------
     // For multifield partition, we allow the access of partition results by
     // specifiying the field index, and nn ranges in 
     // [ 0 , mesh[field]->get_nFunc )
     // ------------------------------------------------------------------------
-    virtual idx_t get_npart( int nn, int field = 0 ) const
+    idx_t get_npart( int nn, int field = 0 ) const override
     {return npart[nn + field_offset[field]];}
 
-    virtual bool get_isMETIS() const {return true;};
+    bool get_isMETIS() const override {return true;};
 
-    virtual bool get_isDual() const {return isDual;};
+    bool get_isDual() const override {return isDual;};
 
-    virtual int get_dual_edge_ncommon() const {return dual_edge_ncommon;}
+    int get_dual_edge_ncommon() const override {return dual_edge_ncommon;}
 
-    virtual bool is_serial() const {return false;}
+    bool is_serial() const override {return false;}
 
   private:
     const bool isDual;

--- a/include/Global_Part_Reload.hpp
+++ b/include/Global_Part_Reload.hpp
@@ -17,20 +17,20 @@ class Global_Part_Reload : public IGlobal_Part
         const bool &isDualGraph, const std::string &element_part_name = "epart",
         const std::string &node_part_name = "npart" );
 
-    virtual ~Global_Part_Reload();
+    ~Global_Part_Reload() override;
 
-    virtual idx_t get_epart( int ee ) const {return static_cast<idx_t>(epart[ee]);}
+    idx_t get_epart( int ee ) const override {return static_cast<idx_t>(epart[ee]);}
 
-    virtual idx_t get_npart( int nn, int field ) const
+    idx_t get_npart( int nn, int field ) const override
     {return static_cast<idx_t>(npart[nn + field_offset[field]]);}
 
-    virtual bool get_isMETIS() const {return isMETIS;};
+    bool get_isMETIS() const override {return isMETIS;};
 
-    virtual bool get_isDual() const {return isDual;};
+    bool get_isDual() const override {return isDual;};
 
-    virtual int get_dual_edge_ncommon() const {return dual_edge_ncommon;}
+    int get_dual_edge_ncommon() const override {return dual_edge_ncommon;}
 
-    virtual bool is_serial() const {return isSerial;}
+    bool is_serial() const override {return isSerial;}
 
   private:
     bool isMETIS, isDual, isSerial;

--- a/include/Global_Part_Serial.hpp
+++ b/include/Global_Part_Serial.hpp
@@ -26,20 +26,20 @@ class Global_Part_Serial : public IGlobal_Part
         const std::string &element_part_name = "epart",
         const std::string &node_part_name = "npart" );
 
-    virtual ~Global_Part_Serial();
+    ~Global_Part_Serial() override;
 
-    virtual idx_t get_epart( int ee ) const {return epart[ee];}
+    idx_t get_epart( int ee ) const override {return epart[ee];}
 
-    virtual idx_t get_npart( int nn, int field = 0 ) const
+    idx_t get_npart( int nn, int field = 0 ) const override
     {return npart[nn + field_offset[field]];}
 
-    virtual bool get_isMETIS() const {return false;};
+    bool get_isMETIS() const override {return false;};
 
-    virtual bool get_isDual() const {return false;};
+    bool get_isDual() const override {return false;};
 
-    virtual int get_dual_edge_ncommon() const {return 0;}
+    int get_dual_edge_ncommon() const override {return 0;}
 
-    virtual bool is_serial() const {return true;}
+    bool is_serial() const override {return true;}
 
   private:
     idx_t * epart, * npart;


### PR DESCRIPTION
### Motivation

- Improve compile-time correctness by marking all methods that override `IGlobal_Part` with `override`, including destructors, to catch accidental signature mismatches.
- Keep existing behavior and signatures unchanged while modernizing declarations for `Global_Part_METIS`, `Global_Part_Serial`, and `Global_Part_Reload`.

### Description

- Updated `Global_Part_METIS`, `Global_Part_Serial`, and `Global_Part_Reload` headers to add `override` to all overriding methods: `get_epart`, `get_npart`, `get_isMETIS`, `get_isDual`, `get_dual_edge_ncommon`, `is_serial`, and the destructors as `~ClassName() override`.
- Changes are declaration-only and preserve method bodies and semantics; no implementation logic was modified.
- Files modified: `include/Global_Part_METIS.hpp`, `include/Global_Part_Serial.hpp`, and `include/Global_Part_Reload.hpp`.

### Testing

- Confirmed the new `override` declarations are present by running pattern searches with `rg`, e.g. `rg -n "~Global_Part_(METIS|Serial|Reload)\(\) override|get_epart\(.*\) const override|get_npart\(.*\) const override" include/Global_Part_*.hpp`, which reported the updated matches successfully.
- Inspected file regions with `nl`/`sed` to verify the destructor and method lines now include `override` and that surrounding code is unchanged.
- Verified the header diffs contain only specifier changes and no behavioral edits by reviewing the generated diffs for the three headers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4baea778c832a87e08bd9e94ce7f0)