### PR TITLE
Simplify EBC_Partition accessors: remove virtual and use pass-by-value for ints

### DIFF
--- a/include/EBC_Partition.hpp
+++ b/include/EBC_Partition.hpp
@@ -30,32 +30,32 @@ class EBC_Partition
     virtual void write_hdf5( const std::string &FileName ) const
     { write_hdf5( FileName, "/ebc" ); }
 
-    virtual void print_info() const;
+    void print_info() const;
 
-    virtual int get_num_ebc() const {return num_ebc;}
+    int get_num_ebc() const {return num_ebc;}
 
-    virtual int get_num_local_cell_node(const int &ii) const
+    int get_num_local_cell_node(int ii) const
     {return num_local_cell_node[ii];}
 
-    virtual int get_num_local_cell(const int &ii) const
+    int get_num_local_cell(int ii) const
     {return num_local_cell[ii];}
 
-    virtual int get_cell_nLocBas(const int &ii) const
+    int get_cell_nLocBas(int ii) const
     {return cell_nLocBas[ii];}
 
-    virtual double get_local_cell_node_xyz(const int &ii, const int &jj) const
+    double get_local_cell_node_xyz(int ii, int jj) const
     {return local_cell_node_xyz[ii][jj];}
 
-    virtual int get_local_cell_ien(const int &ii, const int &jj) const
+    int get_local_cell_ien(int ii, int jj) const
     {return local_cell_ien[ii][jj];}
 
-    virtual int get_local_cell_node_vol_id(const int &ii, const int &jj) const
+    int get_local_cell_node_vol_id(int ii, int jj) const
     {return local_cell_node_vol_id[ii][jj];}
 
-    virtual int get_cell_local_node_pos(const int &ii, const int &jj) const
+    int get_cell_local_node_pos(int ii, int jj) const
     {return local_cell_node_pos[ii][jj];}
 
-    virtual int get_local_cell_vol_id(const int &ii, const int &jj) const
+    int get_local_cell_vol_id(int ii, int jj) const
     {return local_cell_vol_id[ii][jj];}
 
   protected:


### PR DESCRIPTION
### Motivation

- Reduce unnecessary virtual dispatch and simplify the API for small accessor methods by making them non-virtual. 
- Use pass-by-value for primitive integer parameters to avoid needless references and improve clarity for trivial getters.

### Description

- Removed the `virtual` qualifier from `print_info` and all trivial accessor methods such as `get_num_ebc`, `get_num_local_cell_node`, `get_num_local_cell`, `get_cell_nLocBas`, `get_local_cell_node_xyz`, `get_local_cell_ien`, `get_local_cell_node_vol_id`, `get_cell_local_node_pos`, and `get_local_cell_vol_id` in `include/EBC_Partition.hpp`.
- Changed signatures of the above accessors to take `int` parameters by value instead of `const int &` (and similarly for two-argument getters), e.g. `int get_num_local_cell(int ii) const` and `double get_local_cell_node_xyz(int ii, int jj) const`.
- Kept the destructor `virtual ~EBC_Partition() = default;` unchanged to preserve polymorphic destruction semantics.

### Testing

- Project was compiled successfully with the updated header (build invoked via `make`).
- Automated test suite was executed with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bf0c6c5c832abbafa6d5e23ca72d)