### PR TITLE
Refactor IVisDataPrep header include dependency

### DIFF
--- a/examples/ale_ns_rotate/src/VisDataPrep_NS.cpp
+++ b/examples/ale_ns_rotate/src/VisDataPrep_NS.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_NS.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_NS::VisDataPrep_NS()
 {

--- a/examples/fsi/src/VisDataPrep_ALE_NS.cpp
+++ b/examples/fsi/src/VisDataPrep_ALE_NS.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_ALE_NS.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_ALE_NS::VisDataPrep_ALE_NS()
 {

--- a/examples/fsi/src/VisDataPrep_FSI.cpp
+++ b/examples/fsi/src/VisDataPrep_FSI.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_FSI.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_FSI::VisDataPrep_FSI()
 {

--- a/examples/fsi/src/VisDataPrep_Hyperelastic.cpp
+++ b/examples/fsi/src/VisDataPrep_Hyperelastic.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_Hyperelastic.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_Hyperelastic::VisDataPrep_Hyperelastic( const bool &is_ref )
 {

--- a/examples/linearPDE/src/VisDataPrep_Elastodynamics.cpp
+++ b/examples/linearPDE/src/VisDataPrep_Elastodynamics.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_Elastodynamics.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_Elastodynamics::VisDataPrep_Elastodynamics()
 {

--- a/examples/linearPDE/src/VisDataPrep_Transport.cpp
+++ b/examples/linearPDE/src/VisDataPrep_Transport.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_Transport.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_Transport::VisDataPrep_Transport()
 {

--- a/examples/ns/src/VisDataPrep_NS.cpp
+++ b/examples/ns/src/VisDataPrep_NS.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_NS.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_NS::VisDataPrep_NS()
 {

--- a/include/IVisDataPrep.hpp
+++ b/include/IVisDataPrep.hpp
@@ -11,7 +11,6 @@
 //
 // Date: Dec. 17 2013
 // ==================================================================
-#include <string>
 #include <vector>
 #include "Sys_Tools.hpp"
 

--- a/include/IVisDataPrep.hpp
+++ b/include/IVisDataPrep.hpp
@@ -11,7 +11,11 @@
 //
 // Date: Dec. 17 2013
 // ==================================================================
-#include "PostVectSolution.hpp"
+#include <string>
+#include <vector>
+#include "Sys_Tools.hpp"
+
+class APart_Node;
 
 class IVisDataPrep
 {

--- a/tools/stress_recovery/src/VisDataPrep_Stress_Recovery.cpp
+++ b/tools/stress_recovery/src/VisDataPrep_Stress_Recovery.cpp
@@ -1,4 +1,6 @@
 #include "VisDataPrep_Stress_Recovery.hpp"
+#include "PostVectSolution.hpp"
+
 
 VisDataPrep_Stress_Recovery::VisDataPrep_Stress_Recovery()
 {


### PR DESCRIPTION
### Motivation
- Reduce header coupling and unnecessary transitive includes by removing `PostVectSolution.hpp` from the `IVisDataPrep` interface so implementations include it where needed.
- Improve compile-time hygiene and make `IVisDataPrep.hpp` a lightweight interface by forward-declaring `APart_Node` and only including minimal standard headers.

### Description
- Removed `#include "PostVectSolution.hpp"` from `include/IVisDataPrep.hpp` and added `#include <string>`, `#include <vector>`, `#include "Sys_Tools.hpp"`, and a forward declaration `class APart_Node;` in `IVisDataPrep.hpp`.
- Added `#include "PostVectSolution.hpp"` to the `.cpp` implementation files that actually construct `PostVectSolution`, specifically `examples/ns/src/VisDataPrep_NS.cpp`, `examples/fsi/src/VisDataPrep_Hyperelastic.cpp`, `examples/fsi/src/VisDataPrep_ALE_NS.cpp`, `examples/fsi/src/VisDataPrep_FSI.cpp`, `examples/linearPDE/src/VisDataPrep_Elastodynamics.cpp`, `examples/linearPDE/src/VisDataPrep_Transport.cpp`, `examples/ale_ns_rotate/src/VisDataPrep_NS.cpp`, and `tools/stress_recovery/src/VisDataPrep_Stress_Recovery.cpp`.
- Committed the refactor with message `Refactor IVisDataPrep include dependency` which updates 9 files and moves the dependency down to implementation units.

### Testing
- Ran `git diff --check` to validate there are no whitespace/format issues and it completed with no problems.
- Confirmed the `PostVectSolution.hpp` include now appears only in the implementation `.cpp` files that use it by inspecting the modified files (no automated build or unit tests were executed in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c3c13560832aab2dc91d2c71f159)