### PR TITLE
Use pass-by-value for int parameters across FEAElement APIs

### DIFF
--- a/include/FEAElement.hpp
+++ b/include/FEAElement.hpp
@@ -90,10 +90,10 @@ class FEAElement
     // Users are responsible for allocating proper memory for basis, and delete 
     // the pointer after use.
     // ------------------------------------------------------------------------
-    virtual void get_R( const int &quaindex, double * const &basis ) const
+    virtual void get_R( int quaindex, double * const &basis ) const
     {SYS_T::commPrint("Warning: get_R is not implemented. \n");} 
 
-    virtual std::vector<double> get_R( const int &quaindex ) const
+    virtual std::vector<double> get_R( int quaindex ) const
     {SYS_T::commPrint("Warning: get_R is not implemented. \n"); return {};} 
 
     // ------------------------------------------------------------------------    
@@ -103,35 +103,35 @@ class FEAElement
     // the pointer after use.
     // ------------------------------------------------------------------------    
     // 3D case
-    virtual void get_gradR( const int &quaindex, double * const &basis_x,
+    virtual void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y, double * const &basis_z ) const 
     {SYS_T::commPrint("Warning: get_gradR is not implemented. \n");} 
 
     // 2D case
-    virtual void get_gradR( const int &quaindex, double * const &basis_x,
+    virtual void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y ) const 
     {SYS_T::commPrint("Warning: get_gradR is not implemented. \n");} 
 
     // 2D case:
-    virtual void get_R_gradR( const int &quaindex, double * const &basis, 
+    virtual void get_R_gradR( int quaindex, double * const &basis, 
         double * const &basis_x, double * const &basis_y ) const 
     {SYS_T::commPrint("Warning: get_R_gradR is not implemented. \n");} 
 
     // 3D case:
-    virtual void get_R_gradR( const int &quaindex, double * const &basis,
+    virtual void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y, double * const &basis_z ) const 
     {SYS_T::commPrint("Warning: get_R_gradR is not implemented. \n");}
 
     // ------------------------------------------------------------------------    
     // R, gradR, and Laplacian R
     // ------------------------------------------------------------------------    
-    virtual void get_3D_R_gradR_LaplacianR( const int &quaindex,
+    virtual void get_3D_R_gradR_LaplacianR( int quaindex,
         double * const &basis, double * const &basis_x, double * const &basis_y,
         double * const &basis_z, double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz ) const 
     {SYS_T::commPrint("Warning: get_3DLaplacianR is not implemented. \n");}
 
-    virtual void get_2D_R_gradR_LaplacianR( const int &quaindex,
+    virtual void get_2D_R_gradR_LaplacianR( int quaindex,
         double * const &basis, double * const &basis_x, double * const &basis_y,
         double * const &basis_xx, double * const &basis_yy ) const 
     {SYS_T::commPrint("Warning: get_2DLaplacianR is not implemented. \n");}
@@ -139,12 +139,12 @@ class FEAElement
     // ------------------------------------------------------------------------    
     // R, gradR, and grad gradR
     // ------------------------------------------------------------------------    
-    virtual void get_2D_R_dR_d2R( const int &quaindex, double * const &basis,
+    virtual void get_2D_R_dR_d2R( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y, double * const &basis_xx, 
         double * const &basis_yy, double * const &basis_xy ) const
     {SYS_T::commPrint("Warning: get_2D_R_dR_d2R is not implemented. \n");}
 
-    virtual void get_3D_R_dR_d2R( const int &quaindex, double * const &basis,
+    virtual void get_3D_R_dR_d2R( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y, double * const &basis_z,
         double * const &basis_xx, double * const &basis_yy, double * const &basis_zz,
         double * const &basis_xy, double * const &basis_xz, double * const &basis_yz ) 
@@ -153,7 +153,7 @@ class FEAElement
     // ------------------------------------------------------------------------    
     // Return the Jacobian determinant
     // ------------------------------------------------------------------------    
-    virtual double get_detJac(const int &quaindex) const
+    virtual double get_detJac(int quaindex) const
     {SYS_T::commPrint("Warning: get_detJac is not implemented.\n"); return 0.0;}
 
     // ------------------------------------------------------------------------    
@@ -161,13 +161,13 @@ class FEAElement
     // dy_dxi, ... dz_deta, dz_dzeta. The size of teh return vector is 9 for 3d,
     // and 4 for 2d, for exampel. 
     // ------------------------------------------------------------------------    
-    virtual std::array<double,9> get_Jacobian( const int &quaindex ) const
+    virtual std::array<double,9> get_Jacobian( int quaindex ) const
     {
       SYS_T::commPrint("Warning: get_Jacobian is not implemented. \n");
       return {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
     }
 
-    virtual std::array<double,4> get_Jacobian_2D( const int &quaindex ) const
+    virtual std::array<double,4> get_Jacobian_2D( int quaindex ) const
     {
       SYS_T::commPrint("Warning: get_Jacobian is not implemented. \n");
       return {{0.0, 0.0, 0.0, 0.0}};
@@ -178,13 +178,13 @@ class FEAElement
     // given. The output array dxi_dx is a 9 or 4 component array for 3D / 2D
     // case.
     // ------------------------------------------------------------------------    
-    virtual std::array<double,9> get_invJacobian( const int &quaindex ) const
+    virtual std::array<double,9> get_invJacobian( int quaindex ) const
     {
       SYS_T::commPrint("Warning: get_invJacobian is not implemented. \n");
       return {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
     }
 
-    virtual std::array<double,4> get_invJacobian_2D( const int &quaindex ) const
+    virtual std::array<double,4> get_invJacobian_2D( int quaindex ) const
     {
       SYS_T::commPrint("Warning: get_invJacobian is not implemented. \n");
       return {{0.0, 0.0, 0.0, 0.0}};
@@ -203,7 +203,7 @@ class FEAElement
     // surface.
     // This function is called in FEAElement_Triangle3_3D_der0.
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const
+    virtual Vector_3 get_2d_normal_out( int quaindex, double &area ) const
     {
       SYS_T::commPrint("Warning: get_2d_normal_out is not implemented. \n");
       return Vector_3();
@@ -218,7 +218,7 @@ class FEAElement
     // calculate the "root" of the tangential vector.
     // This function is, for example, called in FEAElement_Line2_3D_der0.
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_normal_out( const int &quaindex,
+    virtual Vector_3 get_normal_out( int quaindex,
         const std::vector<Vector_3> &sur_pt, const Vector_3 &int_pt, 
         double &length ) const
     {
@@ -226,7 +226,7 @@ class FEAElement
       return Vector_3();
     }
 
-    virtual Vector_3 get_normal_out( const int &quaindex,
+    virtual Vector_3 get_normal_out( int quaindex,
         const Vector_3 &sur_pt, const Vector_3 &int_pt, 
         double &length ) const
     {
@@ -237,7 +237,7 @@ class FEAElement
     // ------------------------------------------------------------------------
     // Build the volume element with a face id and the quad_rule on surface element.
     // ------------------------------------------------------------------------
-    virtual void buildBasis( const int &face_id,
+    virtual void buildBasis( int face_id,
         const IQuadPts * const &quad_rule_s,
         const double * const &ctrl_x, 
         const double * const &ctrl_y,
@@ -247,7 +247,7 @@ class FEAElement
     // ------------------------------------------------------------------------
     // dx_dr in parent domain
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_dx_dr( const int &quaindex,
+    virtual Vector_3 get_dx_dr( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const 
@@ -259,7 +259,7 @@ class FEAElement
     // ------------------------------------------------------------------------
     // dx_ds in parent domain
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_dx_ds( const int &quaindex,
+    virtual Vector_3 get_dx_ds( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const 
@@ -271,7 +271,7 @@ class FEAElement
     // ------------------------------------------------------------------------
     // d2x_drr in parent domain
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_d2x_drr( const int &quaindex,
+    virtual Vector_3 get_d2x_drr( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const 
@@ -283,7 +283,7 @@ class FEAElement
     // ------------------------------------------------------------------------
     // d2x_dss in parent domain
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_d2x_dss( const int &quaindex,
+    virtual Vector_3 get_d2x_dss( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const 
@@ -295,7 +295,7 @@ class FEAElement
     // ------------------------------------------------------------------------
     // d2x_drs in parent domain
     // ------------------------------------------------------------------------
-    virtual Vector_3 get_d2x_drs( const int &quaindex,
+    virtual Vector_3 get_d2x_drs( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const 
@@ -304,7 +304,7 @@ class FEAElement
       return Vector_3();
     }
 
-    virtual std::array<std::vector<double>, 3> get_face_ctrlPts( const int &face_id,
+    virtual std::array<std::vector<double>, 3> get_face_ctrlPts( int face_id,
         const double * const &volctrl_x,
         const double * const &volctrl_y,
         const double * const &volctrl_z ) const

--- a/include/FEAElementFactory.hpp
+++ b/include/FEAElementFactory.hpp
@@ -22,7 +22,7 @@ class ElementFactory
 {
   public:
     static std::unique_ptr<FEAElement> createVolElement(const FEType &elemType,
-        const int &nqp)
+        int nqp)
     {
       switch(elemType)
       {
@@ -41,7 +41,7 @@ class ElementFactory
     }
 
     static std::unique_ptr<FEAElement> createSurElement(const FEType &elemType,
-        const int &nqp)
+        int nqp)
     {
       switch (elemType)
       {

--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -84,7 +84,7 @@
 class FEAElement_Hex27 final : public FEAElement
 {
   public :
-    FEAElement_Hex27( const int &in_nqua );
+    FEAElement_Hex27( int in_nqua );
 
     ~FEAElement_Hex27() override = default;
 
@@ -111,38 +111,38 @@ class FEAElement_Hex27 final : public FEAElement
     
     // Get functions give access to function evaluations at the quadrature point 
     // corresponding to quaindex
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y, double * const &basis_z ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_z ) const override;
 
-    void get_3D_R_dR_d2R( const int &quaindex, 
+    void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 
         double * const &basis_y, double * const &basis_z,
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz, double * const &basis_xy, 
         double * const &basis_xz, double * const &basis_yz ) const override;
 
-    void get_3D_R_gradR_LaplacianR( const int &quaindex,
+    void get_3D_R_gradR_LaplacianR( int quaindex,
         double * const &basis, double * const &basis_x, 
         double * const &basis_y, double * const &basis_z, 
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz ) const override;
     
     // Get the Jacobian matrix dx/dr
-    std::array<double,9> get_Jacobian( const int &quaindex ) const override;
+    std::array<double,9> get_Jacobian( int quaindex ) const override;
 
     // Get the inverse Jacobian matrix dr/dx
-    std::array<double,9> get_invJacobian( const int &quaindex ) const override;
+    std::array<double,9> get_invJacobian( int quaindex ) const override;
 
     // Get the determinant of the Jacobian matrix
-    double get_detJac(const int &quaindex) const override {return detJac[quaindex];}
+    double get_detJac(int quaindex) const override {return detJac[quaindex];}
 
     // Build basis and build the boundary element
     //   Hex-Face-0 : Node 0 3 2 1 11 10 9 8 24
@@ -151,13 +151,13 @@ class FEAElement_Hex27 final : public FEAElement
     //   Hex-Face-3 : Node 1 2 6 5 9 18 13 17 21
     //   Hex-Face-4 : Node 3 7 6 2 19 14 18 10 23
     //   Hex-Face-5 : Node 0 4 7 3 16 15 19 11 20
-    void buildBasis( const int &face_id, const IQuadPts * const &quad_rule_s,
+    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
     // Get the outwardnormal on faces
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override
     {return quadrilateral_face->get_2d_normal_out( quaindex, area );}
 
   private:

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -38,7 +38,7 @@
 class FEAElement_Hex8 final : public FEAElement
 {
   public :
-    FEAElement_Hex8( const int &in_nqua );
+    FEAElement_Hex8( int in_nqua );
 
     ~FEAElement_Hex8() override = default;
 
@@ -65,38 +65,38 @@ class FEAElement_Hex8 final : public FEAElement
     
     // Get functions give access to function evaluations at the quadrature point 
     // corresponding to quaindex
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y, double * const &basis_z ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_z ) const override;
 
-    void get_3D_R_dR_d2R( const int &quaindex, 
+    void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 
         double * const &basis_y, double * const &basis_z,
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz, double * const &basis_xy, 
         double * const &basis_xz, double * const &basis_yz ) const override;
 
-    void get_3D_R_gradR_LaplacianR( const int &quaindex,
+    void get_3D_R_gradR_LaplacianR( int quaindex,
         double * const &basis, double * const &basis_x, 
         double * const &basis_y, double * const &basis_z, 
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz ) const override;
 
     // Get the Jacobian matrix dx/dr
-    std::array<double,9> get_Jacobian( const int &quaindex ) const override;
+    std::array<double,9> get_Jacobian( int quaindex ) const override;
 
     // Get the inverse Jacobian matrix dr/dx
-    std::array<double,9> get_invJacobian( const int &quaindex ) const override;
+    std::array<double,9> get_invJacobian( int quaindex ) const override;
 
     // Get the determinant of the Jacobian matrix
-    double get_detJac(const int &quaindex) const override {return detJac[quaindex];}
+    double get_detJac(int quaindex) const override {return detJac[quaindex];}
 
     // Build basis and build the boundary element
     //   Hex-Face-0 : Node 0 3 2 1
@@ -105,13 +105,13 @@ class FEAElement_Hex8 final : public FEAElement
     //   Hex-Face-3 : Node 1 2 6 5
     //   Hex-Face-4 : Node 3 7 6 2
     //   Hex-Face-5 : Node 0 4 7 3
-    void buildBasis( const int &face_id, const IQuadPts * const &quad_rule_s,
+    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
     // Get the outwardnormal on faces
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override
     {return quadrilateral_face->get_2d_normal_out( quaindex, area );}
 
   private:

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -14,7 +14,7 @@
 class FEAElement_Quad4 final : public FEAElement
 {
   public:
-    FEAElement_Quad4( const int &in_nqua );
+    FEAElement_Quad4( int in_nqua );
 
     ~FEAElement_Quad4() override = default;
 
@@ -35,27 +35,27 @@ class FEAElement_Quad4 final : public FEAElement
     double get_h( const double * const &ctrl_x,
         const double * const &ctrl_y ) const override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y ) const override;
 
-    void get_2D_R_dR_d2R( const int &quaindex,
+    void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_xx, double * const &basis_yy,
         double * const &basis_xy ) const override;
 
-    std::array<double,4> get_Jacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 
-    std::array<double,4> get_invJacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_invJacobian_2D(int quaindex) const override;
 
-    double get_detJac(const int &quaindex) const override
+    double get_detJac(int quaindex) const override
     {return Jac[8*numQuapts + quaindex];}
 
   private:

--- a/include/FEAElement_Quad4_3D_der0.hpp
+++ b/include/FEAElement_Quad4_3D_der0.hpp
@@ -35,7 +35,7 @@
 class FEAElement_Quad4_3D_der0 final : public FEAElement
 {
   public:
-    FEAElement_Quad4_3D_der0( const int &in_nqua );
+    FEAElement_Quad4_3D_der0( int in_nqua );
 
     ~FEAElement_Quad4_3D_der0() override = default;
 
@@ -54,20 +54,20 @@ class FEAElement_Quad4_3D_der0 final : public FEAElement
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
     // Assuming the quad nodes are arranged such that the outward
     // direction is given by dx_dr x dx_ds
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override;
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override;
     
     // If the quad nodes are NOT arranged in any particular order,
     // use an interior node to define the outward direction. 
-    Vector_3 get_normal_out( const int &quaindex, const Vector_3 &sur_pt,
+    Vector_3 get_normal_out( int quaindex, const Vector_3 &sur_pt,
         const Vector_3 &int_pt, double &len ) const override;
 
-    double get_detJac(const int &quaindex) const override {return detJac[quaindex];}
+    double get_detJac(int quaindex) const override {return detJac[quaindex];}
 
   private:
     static constexpr int nLocBas = 4;

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -14,7 +14,7 @@
 class FEAElement_Quad9 final : public FEAElement
 {
   public:
-    FEAElement_Quad9( const int &in_nqua );
+    FEAElement_Quad9( int in_nqua );
 
     ~FEAElement_Quad9() override = default;
 
@@ -35,27 +35,27 @@ class FEAElement_Quad9 final : public FEAElement
     double get_h( const double * const &ctrl_x,
         const double * const &ctrl_y ) const override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y ) const override;
 
-    void get_2D_R_dR_d2R( const int &quaindex,
+    void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_xx, double * const &basis_yy,
         double * const &basis_xy ) const override;
 
-    std::array<double,4> get_Jacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 
-    std::array<double,4> get_invJacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_invJacobian_2D(int quaindex) const override;
 
-    double get_detJac(const int &quaindex) const override
+    double get_detJac(int quaindex) const override
     {return Jac[8*numQuapts + quaindex];}
 
   private:

--- a/include/FEAElement_Quad9_3D_der0.hpp
+++ b/include/FEAElement_Quad9_3D_der0.hpp
@@ -35,7 +35,7 @@
 class FEAElement_Quad9_3D_der0 final : public FEAElement
 {
   public:
-    FEAElement_Quad9_3D_der0( const int &in_nqua );
+    FEAElement_Quad9_3D_der0( int in_nqua );
 
     ~FEAElement_Quad9_3D_der0() override = default;
 
@@ -54,20 +54,20 @@ class FEAElement_Quad9_3D_der0 final : public FEAElement
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
     // Assuming the quad nodes are arranged such that the outward
     // direction is given by dx_dr x dx_ds
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override;
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override;
     
     // If the quad nodes are NOT arranged in any particular order,
     // use an interior node to define the outward direction. 
-    Vector_3 get_normal_out( const int &quaindex, const Vector_3 &sur_pt,
+    Vector_3 get_normal_out( int quaindex, const Vector_3 &sur_pt,
         const Vector_3 &int_pt, double &len ) const override;
 
-    double get_detJac(const int &quaindex) const override {return detJac[quaindex];}
+    double get_detJac(int quaindex) const override {return detJac[quaindex];}
 
   private:
     static constexpr int nLocBas = 9;

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -41,7 +41,7 @@
 class FEAElement_Tet10 final : public FEAElement
 {
   public:
-    FEAElement_Tet10( const int &in_nqua );
+    FEAElement_Tet10( int in_nqua );
 
     ~FEAElement_Tet10() override = default;
 
@@ -71,48 +71,48 @@ class FEAElement_Tet10 final : public FEAElement
 
     // get_xxx functions give access to function evaluations at the
     // quadrature point corresponding to quaindex
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y, double * const &basis_z ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_z ) const override;
 
-    void get_3D_R_dR_d2R( const int &quaindex,
+    void get_3D_R_dR_d2R( int quaindex,
         double * const &basis, double * const &basis_x,
         double * const &basis_y, double * const &basis_z,
         double * const &basis_xx, double * const &basis_yy,
         double * const &basis_zz, double * const &basis_xy,
         double * const &basis_xz, double * const &basis_yz ) const override;
 
-    void get_3D_R_gradR_LaplacianR( const int &quaindex,
+    void get_3D_R_gradR_LaplacianR( int quaindex,
         double * const &basis, double * const &basis_x,
         double * const &basis_y, double * const &basis_z,
         double * const &basis_xx, double * const &basis_yy,
         double * const &basis_zz ) const override;
 
-    std::array<double,9> get_Jacobian( const int &quaindex ) const override;
+    std::array<double,9> get_Jacobian( int quaindex ) const override;
 
-    std::array<double,9> get_invJacobian( const int &quaindex ) const override;
+    std::array<double,9> get_invJacobian( int quaindex ) const override;
 
-    double get_detJac(const int &quaindex) const override {return detJac[quaindex];}
+    double get_detJac(int quaindex) const override {return detJac[quaindex];}
 
     // Build basis and build the boundary element
     //   Tet-Face-0 : Node 1 2 3 5 9 8
     //   Tet-Face-1 : Node 0 3 2 7 9 6
     //   Tet-Face-2 : Node 0 1 3 4 8 7
     //   Tet-Face-3 : Node 0 2 1 6 5 4
-    void buildBasis( const int &face_id, const IQuadPts * const &quad_rule_s,
+    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
     // Get the outwardnormal on faces
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override
     {return triangle_face->get_2d_normal_out( quaindex, area );}
 
   private:

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -15,7 +15,7 @@
 class FEAElement_Tet4 final : public FEAElement
 {
   public:
-    FEAElement_Tet4( const int &in_nqua );
+    FEAElement_Tet4( int in_nqua );
 
     ~FEAElement_Tet4() override = default;
 
@@ -45,53 +45,53 @@ class FEAElement_Tet4 final : public FEAElement
 
     // Get functions give access to function evaluations at the quadrature point 
     // corresponding to quaindex
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y, double * const &basis_z ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_z ) const override;
 
-    void get_3D_R_dR_d2R( const int &quaindex, 
+    void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 
         double * const &basis_y, double * const &basis_z,
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz, double * const &basis_xy, 
         double * const &basis_xz, double * const &basis_yz ) const override;
 
-    void get_3D_R_gradR_LaplacianR( const int &quaindex,
+    void get_3D_R_gradR_LaplacianR( int quaindex,
         double * const &basis, double * const &basis_x, 
         double * const &basis_y, double * const &basis_z, 
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_zz ) const override;
 
     // Get the Jacobian matrix dx/dr
-    std::array<double,9> get_Jacobian( const int &quaindex ) const override
+    std::array<double,9> get_Jacobian( int quaindex ) const override
     {
       ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_Jacobian function error.\n"  );
       return {{Jac[0], Jac[1], Jac[2], Jac[3], Jac[4], Jac[5], Jac[6], Jac[7], Jac[8]}};
     }
 
     // Get the inverse Jacobian matrix dr/dx
-    std::array<double,9> get_invJacobian( const int &quaindex ) const override
+    std::array<double,9> get_invJacobian( int quaindex ) const override
     {
       ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_invJacobian function error.\n"  );
       return {{Jac[9], Jac[10], Jac[11], Jac[12], Jac[13], Jac[14], Jac[15], Jac[16], Jac[17]}};
     }
 
     // Get the determinant of the Jacobian matrix
-    double get_detJac(const int &quaindex) const override {return detJac;}
+    double get_detJac(int quaindex) const override {return detJac;}
 
     // Build basis and build the boundary element
     //   Tet-Face-0 : Node 1 2 3
     //   Tet-Face-1 : Node 0 3 2
     //   Tet-Face-2 : Node 0 1 3
     //   Tet-Face-3 : Node 0 2 1
-    void buildBasis( const int &face_id, const IQuadPts * const &quad_rule_s,
+    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
@@ -102,10 +102,10 @@ class FEAElement_Tet4 final : public FEAElement
     // The node numbering of the face element guarantees the get_2d_normal_out
     // returns the outward normal vector
     // See FE_T::QuadPts_on_face function for more details.
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override
     {return triangle_face->get_2d_normal_out( quaindex, area );}
 
-    std::array<std::vector<double>, 3> get_face_ctrlPts( const int &face_id,
+    std::array<std::vector<double>, 3> get_face_ctrlPts( int face_id,
         const double * const &volctrl_x,
         const double * const &volctrl_y,
         const double * const &volctrl_z ) const override;

--- a/include/FEAElement_Triangle3.hpp
+++ b/include/FEAElement_Triangle3.hpp
@@ -14,7 +14,7 @@
 class FEAElement_Triangle3 final : public FEAElement
 {
   public:
-    FEAElement_Triangle3( const int &in_nqua );
+    FEAElement_Triangle3( int in_nqua );
 
     ~FEAElement_Triangle3() override = default;
 
@@ -35,27 +35,27 @@ class FEAElement_Triangle3 final : public FEAElement
     double get_h( const double * const &ctrl_x,
         const double * const &ctrl_y ) const override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
     
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y ) const override;
 
-    void get_2D_R_dR_d2R( const int &quaindex, 
+    void get_2D_R_dR_d2R( int quaindex, 
         double * const &basis, 
         double * const &basis_x, double * const &basis_y, 
         double * const &basis_xx, double * const &basis_yy, 
         double * const &basis_xy ) const override;
 
-    std::array<double,4> get_Jacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 
-    std::array<double,4> get_invJacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_invJacobian_2D(int quaindex) const override;
 
-    double get_detJac(const int &quaindex) const override {return detJac;}
+    double get_detJac(int quaindex) const override {return detJac;}
 
   private:
     static constexpr int nLocBas = 3;

--- a/include/FEAElement_Triangle3_3D_der0.hpp
+++ b/include/FEAElement_Triangle3_3D_der0.hpp
@@ -24,7 +24,7 @@
 class FEAElement_Triangle3_3D_der0 final : public FEAElement
 {
   public:
-    FEAElement_Triangle3_3D_der0( const int &in_nqua );
+    FEAElement_Triangle3_3D_der0( int in_nqua );
 
     ~FEAElement_Triangle3_3D_der0() override = default;
 
@@ -43,26 +43,26 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
     // Assumes the triangle nodes are arranged such that the outward
     // direction is given by dx_dr x dx_ds
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override;
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override;
 
     // If the triangle nodes are NOT arranged in any particular order,
     // use an interior node to define the outward direction.
-    Vector_3 get_normal_out( const int &quaindex, const Vector_3 &sur_pt,
+    Vector_3 get_normal_out( int quaindex, const Vector_3 &sur_pt,
         const Vector_3 &int_pt, double &area ) const override;
 
-    double get_detJac(const int &quaindex) const override {return detJac;}
+    double get_detJac(int quaindex) const override {return detJac;}
 
     // Return the derivatives of the physical coordinates with respect to the
     // element reference coordinate.
     // These functions are needed in the FE_T::search_closest_point function,
     // which is called inside the sliding interface formulation.
-    Vector_3 get_dx_dr( const int &quaindex,
+    Vector_3 get_dx_dr( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const override
@@ -72,7 +72,7 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
                        - ctrl_z[0] + ctrl_z[1] );
     }
     
-    Vector_3 get_dx_ds( const int &quaindex,
+    Vector_3 get_dx_ds( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const override
@@ -82,19 +82,19 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
                        - ctrl_z[0] + ctrl_z[2] );
     }
 
-    Vector_3 get_d2x_drr( const int &quaindex,
+    Vector_3 get_d2x_drr( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const override
     {return Vector_3(0.0, 0.0, 0.0);}
 
-    Vector_3 get_d2x_dss( const int &quaindex,
+    Vector_3 get_d2x_dss( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const override
     {return Vector_3(0.0, 0.0, 0.0);}
 
-    Vector_3 get_d2x_drs( const int &quaindex,
+    Vector_3 get_d2x_drs( int quaindex,
         const double * const &ctrl_x,
         const double * const &ctrl_y,
         const double * const &ctrl_z ) const override

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -15,7 +15,7 @@
 class FEAElement_Triangle6 final : public FEAElement
 {
   public:
-    FEAElement_Triangle6( const int &in_nqua );
+    FEAElement_Triangle6( int in_nqua );
 
     ~FEAElement_Triangle6() override = default;
 
@@ -36,27 +36,27 @@ class FEAElement_Triangle6 final : public FEAElement
     double get_h( const double * const &ctrl_x,
         const double * const &ctrl_y ) const override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( const int &quaindex, double * const &basis_x,
+    void get_gradR( int quaindex, double * const &basis_x,
         double * const &basis_y ) const override;
 
-    void get_R_gradR( const int &quaindex, double * const &basis,
+    void get_R_gradR( int quaindex, double * const &basis,
         double * const &basis_x, double * const &basis_y ) const override;
 
-    void get_2D_R_dR_d2R( const int &quaindex,
+    void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,
         double * const &basis_x, double * const &basis_y,
         double * const &basis_xx, double * const &basis_yy,
         double * const &basis_xy ) const override;
 
-    std::array<double,4> get_Jacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 
-    std::array<double,4> get_invJacobian_2D(const int &quaindex) const override;
+    std::array<double,4> get_invJacobian_2D(int quaindex) const override;
 
-    double get_detJac(const int &quaindex) const override
+    double get_detJac(int quaindex) const override
     {return Jac[8*numQuapts + quaindex];}
 
   private:

--- a/include/FEAElement_Triangle6_3D_der0.hpp
+++ b/include/FEAElement_Triangle6_3D_der0.hpp
@@ -35,7 +35,7 @@
 class FEAElement_Triangle6_3D_der0 final : public FEAElement
 {
   public:
-    FEAElement_Triangle6_3D_der0( const int &in_nqua );
+    FEAElement_Triangle6_3D_der0( int in_nqua );
 
     ~FEAElement_Triangle6_3D_der0() override = default;
 
@@ -54,20 +54,20 @@ class FEAElement_Triangle6_3D_der0 final : public FEAElement
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
 
-    void get_R( const int &quaindex, double * const &basis ) const override;
+    void get_R( int quaindex, double * const &basis ) const override;
 
-    std::vector<double> get_R( const int &quaindex ) const override;
+    std::vector<double> get_R( int quaindex ) const override;
 
     // Assuming the triangle nodes are arranged such that the outward
     // direction is given by dx_dr x dx_ds
-    Vector_3 get_2d_normal_out( const int &quaindex, double &area ) const override;
+    Vector_3 get_2d_normal_out( int quaindex, double &area ) const override;
     
     // If the triangle nodes are NOT arranged in any particular order,
     // use an interior node to define the outward direction. 
-    Vector_3 get_normal_out( const int &quaindex, const Vector_3 &sur_pt,
+    Vector_3 get_normal_out( int quaindex, const Vector_3 &sur_pt,
         const Vector_3 &int_pt, double &len ) const override;
 
-    double get_detJac(const int &quaindex) const override {return detJac[quaindex];}
+    double get_detJac(int quaindex) const override {return detJac[quaindex];}
 
   private:
     static constexpr int nLocBas = 6;

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Hex27.hpp"
 
-FEAElement_Hex27::FEAElement_Hex27( const int &in_nqua ) : numQuapts( in_nqua ) ,
+FEAElement_Hex27::FEAElement_Hex27( int in_nqua ) : numQuapts( in_nqua ) ,
   quadrilateral_face( SYS_T::make_unique<FEAElement_Quad9_3D_der0>(numQuapts) )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -325,14 +325,14 @@ double FEAElement_Hex27::get_h( const double * const &ctrl_x,
   return std::sqrt(d);
 }
 
-void FEAElement_Hex27::get_R( const int &quaindex, double * const &basis ) const
+void FEAElement_Hex27::get_R( int quaindex, double * const &basis ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii) basis[ii] = R[offset+ii];
 }
 
-std::vector<double> FEAElement_Hex27::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Hex27::get_R( int quaindex ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -340,7 +340,7 @@ std::vector<double> FEAElement_Hex27::get_R( const int &quaindex ) const
   return vec;
 }
 
-void FEAElement_Hex27::get_gradR( const int &quaindex, double * const &basis_x,
+void FEAElement_Hex27::get_gradR( int quaindex, double * const &basis_x,
     double * const &basis_y, double * const &basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_gradR function error.\n" );
@@ -353,7 +353,7 @@ void FEAElement_Hex27::get_gradR( const int &quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Hex27::get_R_gradR( const int &quaindex, double * const &basis,
+void FEAElement_Hex27::get_R_gradR( int quaindex, double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_z ) const
 {
@@ -368,7 +368,7 @@ void FEAElement_Hex27::get_R_gradR( const int &quaindex, double * const &basis,
   }
 }
 
-void FEAElement_Hex27::get_3D_R_dR_d2R( const int &quaindex,
+void FEAElement_Hex27::get_3D_R_dR_d2R( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -392,7 +392,7 @@ void FEAElement_Hex27::get_3D_R_dR_d2R( const int &quaindex,
   }
 }
 
-void FEAElement_Hex27::get_3D_R_gradR_LaplacianR( const int &quaindex,
+void FEAElement_Hex27::get_3D_R_gradR_LaplacianR( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -412,7 +412,7 @@ void FEAElement_Hex27::get_3D_R_gradR_LaplacianR( const int &quaindex,
   }
 }
 
-std::array<double,9> FEAElement_Hex27::get_Jacobian(const int &quaindex) const
+std::array<double,9> FEAElement_Hex27::get_Jacobian(int quaindex) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_Jacobian function error.\n" );
   return {{ dx_dr[9*quaindex], dx_dr[9*quaindex+1], dx_dr[9*quaindex+2],
@@ -420,7 +420,7 @@ std::array<double,9> FEAElement_Hex27::get_Jacobian(const int &quaindex) const
     dx_dr[9*quaindex+6], dx_dr[9*quaindex+7], dx_dr[9*quaindex+8] }};
 }
 
-std::array<double,9> FEAElement_Hex27::get_invJacobian(const int &quaindex) const
+std::array<double,9> FEAElement_Hex27::get_invJacobian(int quaindex) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_invJacobian function error.\n" );
   return {{ dr_dx[9*quaindex], dr_dx[9*quaindex+1], dr_dx[9*quaindex+2],
@@ -428,7 +428,7 @@ std::array<double,9> FEAElement_Hex27::get_invJacobian(const int &quaindex) cons
     dr_dx[9*quaindex+6], dr_dx[9*quaindex+7], dr_dx[9*quaindex+8] }};
 }
 
-void FEAElement_Hex27::buildBasis( const int &face_id, const IQuadPts * const &quad_s,
+void FEAElement_Hex27::buildBasis( int face_id, const IQuadPts * const &quad_s,
     const double * const &ctrl_x,
     const double * const &ctrl_y,
     const double * const &ctrl_z )

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Hex8.hpp"
 
-FEAElement_Hex8::FEAElement_Hex8( const int &in_nqua ) : numQuapts( in_nqua ) ,
+FEAElement_Hex8::FEAElement_Hex8( int in_nqua ) : numQuapts( in_nqua ) ,
   quadrilateral_face( SYS_T::make_unique<FEAElement_Quad4_3D_der0>(numQuapts) )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -196,14 +196,14 @@ double FEAElement_Hex8::get_h( const double * const &ctrl_x,
   return std::sqrt(d);
 }
 
-void FEAElement_Hex8::get_R( const int &quaindex, double * const &basis ) const
+void FEAElement_Hex8::get_R( int quaindex, double * const &basis ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii) basis[ii] = R[offset+ii];
 }
 
-std::vector<double> FEAElement_Hex8::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Hex8::get_R( int quaindex ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -211,7 +211,7 @@ std::vector<double> FEAElement_Hex8::get_R( const int &quaindex ) const
          R[offset+4], R[offset+5], R[offset+6], R[offset+7] };
 }
 
-void FEAElement_Hex8::get_gradR( const int &quaindex, double * const &basis_x,
+void FEAElement_Hex8::get_gradR( int quaindex, double * const &basis_x,
     double * const &basis_y, double * const &basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_gradR function error.\n" );
@@ -224,7 +224,7 @@ void FEAElement_Hex8::get_gradR( const int &quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Hex8::get_R_gradR( const int &quaindex, double * const &basis,
+void FEAElement_Hex8::get_R_gradR( int quaindex, double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_z ) const
 {
@@ -239,7 +239,7 @@ void FEAElement_Hex8::get_R_gradR( const int &quaindex, double * const &basis,
   }
 }
 
-void FEAElement_Hex8::get_3D_R_dR_d2R( const int &quaindex,
+void FEAElement_Hex8::get_3D_R_dR_d2R( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -263,7 +263,7 @@ void FEAElement_Hex8::get_3D_R_dR_d2R( const int &quaindex,
   }
 }
 
-void FEAElement_Hex8::get_3D_R_gradR_LaplacianR( const int &quaindex,
+void FEAElement_Hex8::get_3D_R_gradR_LaplacianR( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -283,7 +283,7 @@ void FEAElement_Hex8::get_3D_R_gradR_LaplacianR( const int &quaindex,
   }
 }
 
-std::array<double,9> FEAElement_Hex8::get_Jacobian(const int &quaindex) const
+std::array<double,9> FEAElement_Hex8::get_Jacobian(int quaindex) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_Jacobian function error.\n" );
   return {{ dx_dr[9*quaindex], dx_dr[9*quaindex+1], dx_dr[9*quaindex+2],
@@ -291,7 +291,7 @@ std::array<double,9> FEAElement_Hex8::get_Jacobian(const int &quaindex) const
     dx_dr[9*quaindex+6], dx_dr[9*quaindex+7], dx_dr[9*quaindex+8] }};
 }
 
-std::array<double,9> FEAElement_Hex8::get_invJacobian(const int &quaindex) const
+std::array<double,9> FEAElement_Hex8::get_invJacobian(int quaindex) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_invJacobian function error.\n" );
   return {{ dr_dx[9*quaindex], dr_dx[9*quaindex+1], dr_dx[9*quaindex+2],
@@ -299,7 +299,7 @@ std::array<double,9> FEAElement_Hex8::get_invJacobian(const int &quaindex) const
     dr_dx[9*quaindex+6], dr_dx[9*quaindex+7], dr_dx[9*quaindex+8] }};
 }
 
-void FEAElement_Hex8::buildBasis( const int &face_id, const IQuadPts * const &quad_s, 
+void FEAElement_Hex8::buildBasis( int face_id, const IQuadPts * const &quad_s, 
     const double * const &ctrl_x,
     const double * const &ctrl_y,
     const double * const &ctrl_z )

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Quad4.hpp"
 
-FEAElement_Quad4::FEAElement_Quad4( const int &in_nqua )
+FEAElement_Quad4::FEAElement_Quad4( int in_nqua )
 : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -131,7 +131,7 @@ double FEAElement_Quad4::get_h( const double * const &ctrl_x,
   return std::sqrt(d);
 }
 
-void FEAElement_Quad4::get_R( const int &quaindex, 
+void FEAElement_Quad4::get_R( int quaindex, 
     double * const &basis ) const
 {
   const int offset = quaindex * nLocBas;
@@ -139,13 +139,13 @@ void FEAElement_Quad4::get_R( const int &quaindex,
   basis[2] = R[offset+2]; basis[3] = R[offset+3];
 }
 
-std::vector<double> FEAElement_Quad4::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Quad4::get_R( int quaindex ) const
 {
   const int offset = quaindex * nLocBas;
   return { R[offset], R[offset+1], R[offset+2], R[offset+3] };
 }
 
-void FEAElement_Quad4::get_gradR( const int &quaindex, 
+void FEAElement_Quad4::get_gradR( int quaindex, 
     double * const &basis_x, double * const &basis_y ) const
 {
   const int offset = quaindex * nLocBas;
@@ -156,7 +156,7 @@ void FEAElement_Quad4::get_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Quad4::get_R_gradR( const int &quaindex, 
+void FEAElement_Quad4::get_R_gradR( int quaindex, 
     double * const &basis, double * const &basis_x, 
     double * const &basis_y ) const
 {
@@ -169,7 +169,7 @@ void FEAElement_Quad4::get_R_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Quad4::get_2D_R_dR_d2R( const int &quaindex,
+void FEAElement_Quad4::get_2D_R_dR_d2R( int quaindex,
     double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_xx, double * const &basis_yy,
@@ -188,12 +188,12 @@ void FEAElement_Quad4::get_2D_R_dR_d2R( const int &quaindex,
   }
 }
 
-std::array<double,4> FEAElement_Quad4::get_Jacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Quad4::get_Jacobian_2D(int quaindex) const
 {
   return {{ Jac[4*quaindex], Jac[4*quaindex+1], Jac[4*quaindex+2], Jac[4*quaindex+3] }};
 }
 
-std::array<double,4> FEAElement_Quad4::get_invJacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Quad4::get_invJacobian_2D(int quaindex) const
 {
   const int offset = 4 * numQuapts + 4 * quaindex;
   return {{ Jac[offset], Jac[offset+1], Jac[offset+2], Jac[offset+3] }};

--- a/src/Element/FEAElement_Quad4_3D_der0.cpp
+++ b/src/Element/FEAElement_Quad4_3D_der0.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Quad4_3D_der0.hpp"
 
-FEAElement_Quad4_3D_der0::FEAElement_Quad4_3D_der0( const int &in_nqua )
+FEAElement_Quad4_3D_der0::FEAElement_Quad4_3D_der0( int in_nqua )
 : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -53,7 +53,7 @@ void FEAElement_Quad4_3D_der0::buildBasis( const IQuadPts * const &quad,
 }
 
 void FEAElement_Quad4_3D_der0::get_R( 
-    const int &quaindex, double * const &basis ) const
+    int quaindex, double * const &basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Quad4_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -64,14 +64,14 @@ void FEAElement_Quad4_3D_der0::get_R(
 }
 
 std::vector<double> FEAElement_Quad4_3D_der0::get_R( 
-    const int &quaindex ) const
+    int quaindex ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Quad4_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   return { R[offset], R[offset+1], R[offset+2], R[offset+3] };
 }
 
-Vector_3 FEAElement_Quad4_3D_der0::get_2d_normal_out( const int &qua,
+Vector_3 FEAElement_Quad4_3D_der0::get_2d_normal_out( int qua,
     double &area ) const
 {
   ASSERT(qua >= 0 && qua < numQuapts, "FEAElement_Quad4_3D_der0::get_2d_normal_out function error.\n" );
@@ -79,7 +79,7 @@ Vector_3 FEAElement_Quad4_3D_der0::get_2d_normal_out( const int &qua,
   return un[qua]; 
 }
 
-Vector_3 FEAElement_Quad4_3D_der0::get_normal_out( const int &qua,
+Vector_3 FEAElement_Quad4_3D_der0::get_normal_out( int qua,
     const Vector_3 &sur_pt, const Vector_3 &int_pt, double &len ) const
 {
   // Construct a vector starting from the interior point to the triangle

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Quad9.hpp"
 
-FEAElement_Quad9::FEAElement_Quad9( const int &in_nqua ) : numQuapts( in_nqua )
+FEAElement_Quad9::FEAElement_Quad9( int in_nqua ) : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
 
@@ -171,21 +171,21 @@ double FEAElement_Quad9::get_h( const double * const &ctrl_x,
   return std::sqrt(d);
 }
 
-void FEAElement_Quad9::get_R( const int &quaindex, 
+void FEAElement_Quad9::get_R( int quaindex, 
     double * const &basis ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii) basis[ii] = R[offset+ii];
 }
 
-std::vector<double> FEAElement_Quad9::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Quad9::get_R( int quaindex ) const
 {
   const int offset = quaindex * nLocBas;
   std::vector<double> vec(R.begin() + offset, R.begin() + offset + 9);
   return vec;
 }
 
-void FEAElement_Quad9::get_gradR( const int &quaindex, 
+void FEAElement_Quad9::get_gradR( int quaindex, 
     double * const &basis_x, double * const &basis_y ) const
 {
   const int offset = quaindex * nLocBas;
@@ -196,7 +196,7 @@ void FEAElement_Quad9::get_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Quad9::get_R_gradR( const int &quaindex, 
+void FEAElement_Quad9::get_R_gradR( int quaindex, 
     double * const &basis, double * const &basis_x, 
     double * const &basis_y ) const
 {
@@ -209,7 +209,7 @@ void FEAElement_Quad9::get_R_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Quad9::get_2D_R_dR_d2R( const int &quaindex,
+void FEAElement_Quad9::get_2D_R_dR_d2R( int quaindex,
     double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_xx, double * const &basis_yy,
@@ -228,13 +228,13 @@ void FEAElement_Quad9::get_2D_R_dR_d2R( const int &quaindex,
   }
 }
 
-std::array<double,4> FEAElement_Quad9::get_Jacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Quad9::get_Jacobian_2D(int quaindex) const
 {
   return {{ Jac[4*quaindex], Jac[4*quaindex+1],
     Jac[4*quaindex+2], Jac[4*quaindex+3] }};
 }
 
-std::array<double,4> FEAElement_Quad9::get_invJacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Quad9::get_invJacobian_2D(int quaindex) const
 {
   const int offset = 4 * numQuapts + 4 * quaindex;
   return {{ Jac[offset], Jac[offset+1], Jac[offset+2], Jac[offset+3] }};

--- a/src/Element/FEAElement_Quad9_3D_der0.cpp
+++ b/src/Element/FEAElement_Quad9_3D_der0.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Quad9_3D_der0.hpp"
 
-FEAElement_Quad9_3D_der0::FEAElement_Quad9_3D_der0( const int &in_nqua )
+FEAElement_Quad9_3D_der0::FEAElement_Quad9_3D_der0( int in_nqua )
 : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -73,7 +73,7 @@ void FEAElement_Quad9_3D_der0::buildBasis( const IQuadPts * const &quad,
 }
 
 void FEAElement_Quad9_3D_der0::get_R( 
-    const int &quaindex, double * const &basis ) const
+    int quaindex, double * const &basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Quad9_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -81,7 +81,7 @@ void FEAElement_Quad9_3D_der0::get_R(
 }
 
 std::vector<double> FEAElement_Quad9_3D_der0::get_R( 
-    const int &quaindex ) const
+    int quaindex ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Quad9_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -89,7 +89,7 @@ std::vector<double> FEAElement_Quad9_3D_der0::get_R(
   return vec;
 }
 
-Vector_3 FEAElement_Quad9_3D_der0::get_2d_normal_out( const int &qua,
+Vector_3 FEAElement_Quad9_3D_der0::get_2d_normal_out( int qua,
     double &area ) const
 {
   ASSERT(qua >= 0 && qua < numQuapts, "FEAElement_Quad9_3D_der0::get_2d_normal_out function error.\n" );
@@ -97,7 +97,7 @@ Vector_3 FEAElement_Quad9_3D_der0::get_2d_normal_out( const int &qua,
   return un[qua]; 
 }
 
-Vector_3 FEAElement_Quad9_3D_der0::get_normal_out( const int &qua,
+Vector_3 FEAElement_Quad9_3D_der0::get_normal_out( int qua,
     const Vector_3 &sur_pt, const Vector_3 &int_pt, double &len ) const
 {
   // Construct a vector starting from the interior point to the triangle

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Tet10.hpp"
 
-FEAElement_Tet10::FEAElement_Tet10( const int &in_nqua ) : numQuapts( in_nqua ) ,
+FEAElement_Tet10::FEAElement_Tet10( int in_nqua ) : numQuapts( in_nqua ) ,
   triangle_face( SYS_T::make_unique<FEAElement_Triangle6_3D_der0>(numQuapts) )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -186,14 +186,14 @@ double FEAElement_Tet10::get_h( const double * const &ctrl_x,
       ctrl_z[0], ctrl_z[1], ctrl_z[2], ctrl_z[3] ); 
 }
 
-void FEAElement_Tet10::get_R( const int &quaindex, double * const &basis ) const
+void FEAElement_Tet10::get_R( int quaindex, double * const &basis ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii) basis[ii] = R[offset+ii];
 }
 
-std::vector<double> FEAElement_Tet10::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Tet10::get_R( int quaindex ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -201,7 +201,7 @@ std::vector<double> FEAElement_Tet10::get_R( const int &quaindex ) const
     R[offset+4], R[offset+5], R[offset+6], R[offset+7], R[offset+8], R[offset+9] };
 }
 
-void FEAElement_Tet10::get_gradR( const int &quaindex, double * const &basis_x,
+void FEAElement_Tet10::get_gradR( int quaindex, double * const &basis_x,
     double * const &basis_y, double * const &basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_gradR function error.\n" );
@@ -214,7 +214,7 @@ void FEAElement_Tet10::get_gradR( const int &quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Tet10::get_R_gradR( const int &quaindex, double * const &basis,
+void FEAElement_Tet10::get_R_gradR( int quaindex, double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_z ) const
 {
@@ -229,7 +229,7 @@ void FEAElement_Tet10::get_R_gradR( const int &quaindex, double * const &basis,
   }
 }
 
-void FEAElement_Tet10::get_3D_R_dR_d2R( const int &quaindex,
+void FEAElement_Tet10::get_3D_R_dR_d2R( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -253,7 +253,7 @@ void FEAElement_Tet10::get_3D_R_dR_d2R( const int &quaindex,
   }
 }
 
-void FEAElement_Tet10::get_3D_R_gradR_LaplacianR( const int &quaindex,
+void FEAElement_Tet10::get_3D_R_gradR_LaplacianR( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -273,7 +273,7 @@ void FEAElement_Tet10::get_3D_R_gradR_LaplacianR( const int &quaindex,
   }
 }
 
-std::array<double,9> FEAElement_Tet10::get_Jacobian(const int &quaindex) const
+std::array<double,9> FEAElement_Tet10::get_Jacobian(int quaindex) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_Jacobian function error.\n" );
   return {{ dx_dr[9*quaindex], dx_dr[9*quaindex+1], dx_dr[9*quaindex+2],
@@ -281,7 +281,7 @@ std::array<double,9> FEAElement_Tet10::get_Jacobian(const int &quaindex) const
     dx_dr[9*quaindex+6], dx_dr[9*quaindex+7], dx_dr[9*quaindex+8] }};
 }
 
-std::array<double,9> FEAElement_Tet10::get_invJacobian(const int &quaindex) const
+std::array<double,9> FEAElement_Tet10::get_invJacobian(int quaindex) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_invJacobian function error.\n" );
   return {{ dr_dx[9*quaindex], dr_dx[9*quaindex+1], dr_dx[9*quaindex+2],
@@ -289,7 +289,7 @@ std::array<double,9> FEAElement_Tet10::get_invJacobian(const int &quaindex) cons
     dr_dx[9*quaindex+6], dr_dx[9*quaindex+7], dr_dx[9*quaindex+8] }};
 }
 
-void FEAElement_Tet10::buildBasis( const int &face_id, const IQuadPts * const &quad_s,
+void FEAElement_Tet10::buildBasis( int face_id, const IQuadPts * const &quad_s,
     const double * const &ctrl_x,
     const double * const &ctrl_y,
     const double * const &ctrl_z )

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Tet4.hpp"
 
-FEAElement_Tet4::FEAElement_Tet4( const int &in_nqua ) : numQuapts( in_nqua ),
+FEAElement_Tet4::FEAElement_Tet4( int in_nqua ) : numQuapts( in_nqua ),
   triangle_face( SYS_T::make_unique<FEAElement_Triangle3_3D_der0>(numQuapts) )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -79,7 +79,7 @@ void FEAElement_Tet4::buildBasis( const IQuadPts * const &quad,
   dR_dz[3] = Jac[17];
 }
 
-void FEAElement_Tet4::get_R( const int &quaindex, double * const &basis ) const
+void FEAElement_Tet4::get_R( int quaindex, double * const &basis ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -89,14 +89,14 @@ void FEAElement_Tet4::get_R( const int &quaindex, double * const &basis ) const
   basis[3] = R[offset+3];
 }
 
-std::vector<double> FEAElement_Tet4::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Tet4::get_R( int quaindex ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   return { R[offset], R[offset+1], R[offset+2], R[offset+3] };
 }
 
-void FEAElement_Tet4::get_gradR( const int &quaindex, double * const &basis_x,
+void FEAElement_Tet4::get_gradR( int quaindex, double * const &basis_x,
     double * const &basis_y, double * const &basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_gradR function error.\n" );
@@ -108,7 +108,7 @@ void FEAElement_Tet4::get_gradR( const int &quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Tet4::get_R_gradR( const int &quaindex, double * const &basis,
+void FEAElement_Tet4::get_R_gradR( int quaindex, double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_z ) const
 {
@@ -123,7 +123,7 @@ void FEAElement_Tet4::get_R_gradR( const int &quaindex, double * const &basis,
   }
 }
 
-void FEAElement_Tet4::get_3D_R_dR_d2R( const int &quaindex,
+void FEAElement_Tet4::get_3D_R_dR_d2R( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -147,7 +147,7 @@ void FEAElement_Tet4::get_3D_R_dR_d2R( const int &quaindex,
   }
 }
 
-void FEAElement_Tet4::get_3D_R_gradR_LaplacianR( const int &quaindex,
+void FEAElement_Tet4::get_3D_R_gradR_LaplacianR( int quaindex,
     double * const &basis, double * const &basis_x,
     double * const &basis_y, double * const &basis_z,
     double * const &basis_xx, double * const &basis_yy,
@@ -177,7 +177,7 @@ double FEAElement_Tet4::get_h( const double * const &ctrl_x,
       ctrl_z[0], ctrl_z[1], ctrl_z[2], ctrl_z[3] );  
 }
 
-void FEAElement_Tet4::buildBasis( const int &face_id, const IQuadPts * const &quad_s,
+void FEAElement_Tet4::buildBasis( int face_id, const IQuadPts * const &quad_s,
     const double * const &ctrl_x,
     const double * const &ctrl_y,
     const double * const &ctrl_z )
@@ -193,7 +193,7 @@ void FEAElement_Tet4::buildBasis( const int &face_id, const IQuadPts * const &qu
   triangle_face->buildBasis( quad_s, face_ctrl[0].data(), face_ctrl[1].data(), face_ctrl[2].data() );
 }
 
-std::array<std::vector<double>, 3> FEAElement_Tet4::get_face_ctrlPts( const int &face_id,
+std::array<std::vector<double>, 3> FEAElement_Tet4::get_face_ctrlPts( int face_id,
     const double * const &vol_ctrl_x,
     const double * const &vol_ctrl_y,
     const double * const &vol_ctrl_z ) const

--- a/src/Element/FEAElement_Triangle3.cpp
+++ b/src/Element/FEAElement_Triangle3.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Triangle3.hpp"
 
-FEAElement_Triangle3::FEAElement_Triangle3( const int &in_nqua )
+FEAElement_Triangle3::FEAElement_Triangle3( int in_nqua )
 : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -75,7 +75,7 @@ double FEAElement_Triangle3::get_h( const double * const &ctrl_x,
   return 2.0 * radius;
 }
 
-void FEAElement_Triangle3::get_R( const int &quaindex, 
+void FEAElement_Triangle3::get_R( int quaindex, 
     double * const &basis ) const
 {
   const int offset = quaindex * nLocBas;
@@ -84,14 +84,14 @@ void FEAElement_Triangle3::get_R( const int &quaindex,
   basis[2] = R[offset+2];
 }
 
-std::vector<double> FEAElement_Triangle3::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Triangle3::get_R( int quaindex ) const
 {
   const int offset = quaindex * nLocBas;
 
   return { R[offset], R[offset+1], R[offset+2] };
 }
 
-void FEAElement_Triangle3::get_gradR( const int &quaindex, 
+void FEAElement_Triangle3::get_gradR( int quaindex, 
     double * const &basis_x, double * const &basis_y ) const
 {
   for(int ii=0; ii<nLocBas; ++ii)
@@ -101,7 +101,7 @@ void FEAElement_Triangle3::get_gradR( const int &quaindex,
   } 
 }
 
-void FEAElement_Triangle3::get_R_gradR( const int &quaindex, 
+void FEAElement_Triangle3::get_R_gradR( int quaindex, 
     double * const &basis,
     double * const &basis_x, double * const &basis_y ) const
 {
@@ -114,7 +114,7 @@ void FEAElement_Triangle3::get_R_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Triangle3::get_2D_R_dR_d2R( const int &quaindex,
+void FEAElement_Triangle3::get_2D_R_dR_d2R( int quaindex,
     double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_xx, double * const &basis_yy,
@@ -133,12 +133,12 @@ void FEAElement_Triangle3::get_2D_R_dR_d2R( const int &quaindex,
   }
 }
 
-std::array<double,4> FEAElement_Triangle3::get_Jacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Triangle3::get_Jacobian_2D(int quaindex) const
 {
   return {{ Jac[0], Jac[1], Jac[2], Jac[3] }};
 }
 
-std::array<double,4> FEAElement_Triangle3::get_invJacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Triangle3::get_invJacobian_2D(int quaindex) const
 {
   return {{ Jac[4], Jac[5], Jac[6], Jac[7] }};
 }

--- a/src/Element/FEAElement_Triangle3_3D_der0.cpp
+++ b/src/Element/FEAElement_Triangle3_3D_der0.cpp
@@ -1,7 +1,7 @@
 #include "FEAElement_Triangle3_3D_der0.hpp"
 
 FEAElement_Triangle3_3D_der0::FEAElement_Triangle3_3D_der0( 
-    const int &in_nqua ) : numQuapts( in_nqua )
+    int in_nqua ) : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
 }
@@ -42,7 +42,7 @@ void FEAElement_Triangle3_3D_der0::buildBasis( const IQuadPts * const &quad,
   detJac = un.normalize();
 }
 
-void FEAElement_Triangle3_3D_der0::get_R( const int &quaindex, 
+void FEAElement_Triangle3_3D_der0::get_R( int quaindex, 
     double * const &basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle3_3D_der0::get_R function error.\n" );
@@ -52,14 +52,14 @@ void FEAElement_Triangle3_3D_der0::get_R( const int &quaindex,
   basis[2] = R[offset+2];
 }
 
-std::vector<double> FEAElement_Triangle3_3D_der0::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Triangle3_3D_der0::get_R( int quaindex ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle3_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   return { R[offset], R[offset+1], R[offset+2] };
 }
 
-Vector_3 FEAElement_Triangle3_3D_der0::get_2d_normal_out( const int &quaindex,
+Vector_3 FEAElement_Triangle3_3D_der0::get_2d_normal_out( int quaindex,
     double &area ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle3_3D_der0::get_2d_normal_out function error.\n" );
@@ -67,7 +67,7 @@ Vector_3 FEAElement_Triangle3_3D_der0::get_2d_normal_out( const int &quaindex,
   return un;
 }
 
-Vector_3 FEAElement_Triangle3_3D_der0::get_normal_out( const int &quaindex,
+Vector_3 FEAElement_Triangle3_3D_der0::get_normal_out( int quaindex,
     const Vector_3 &sur_pt, const Vector_3 &int_pt, double &area ) const
 {
   // Construct a vector from the interior point to the triangle first node

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Triangle6.hpp"
 
-FEAElement_Triangle6::FEAElement_Triangle6( const int &in_nqua )
+FEAElement_Triangle6::FEAElement_Triangle6( int in_nqua )
 : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -161,7 +161,7 @@ double FEAElement_Triangle6::get_h( const double * const &ctrl_x,
   return 2.0 * radius;
 }
 
-void FEAElement_Triangle6::get_R( const int &quaindex, 
+void FEAElement_Triangle6::get_R( int quaindex, 
     double * const &basis ) const
 {
   const int offset = quaindex * nLocBas;
@@ -170,13 +170,13 @@ void FEAElement_Triangle6::get_R( const int &quaindex,
   basis[4] = R[offset+4]; basis[5] = R[offset+5];
 }
 
-std::vector<double> FEAElement_Triangle6::get_R( const int &quaindex ) const
+std::vector<double> FEAElement_Triangle6::get_R( int quaindex ) const
 {
   const int offset = quaindex * nLocBas;
   return { R[offset], R[offset+1], R[offset+2], R[offset+3], R[offset+4], R[offset+5] };
 }
 
-void FEAElement_Triangle6::get_gradR( const int &quaindex, 
+void FEAElement_Triangle6::get_gradR( int quaindex, 
     double * const &basis_x, double * const &basis_y ) const
 {
   const int offset = quaindex * nLocBas;
@@ -187,7 +187,7 @@ void FEAElement_Triangle6::get_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Triangle6::get_R_gradR( const int &quaindex, 
+void FEAElement_Triangle6::get_R_gradR( int quaindex, 
     double * const &basis, double * const &basis_x, 
     double * const &basis_y ) const
 {
@@ -200,7 +200,7 @@ void FEAElement_Triangle6::get_R_gradR( const int &quaindex,
   }
 }
 
-void FEAElement_Triangle6::get_2D_R_dR_d2R( const int &quaindex,
+void FEAElement_Triangle6::get_2D_R_dR_d2R( int quaindex,
     double * const &basis,
     double * const &basis_x, double * const &basis_y,
     double * const &basis_xx, double * const &basis_yy,
@@ -219,13 +219,13 @@ void FEAElement_Triangle6::get_2D_R_dR_d2R( const int &quaindex,
   }
 }
 
-std::array<double,4> FEAElement_Triangle6::get_Jacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Triangle6::get_Jacobian_2D(int quaindex) const
 {
   return {{ Jac[4*quaindex], Jac[4*quaindex+1],
     Jac[4*quaindex+2], Jac[4*quaindex+3] }};
 }
 
-std::array<double,4> FEAElement_Triangle6::get_invJacobian_2D(const int &quaindex) const
+std::array<double,4> FEAElement_Triangle6::get_invJacobian_2D(int quaindex) const
 {
   const int offset = 4 * numQuapts + 4 * quaindex;
   return {{ Jac[offset], Jac[offset+1], Jac[offset+2], Jac[offset+3] }};

--- a/src/Element/FEAElement_Triangle6_3D_der0.cpp
+++ b/src/Element/FEAElement_Triangle6_3D_der0.cpp
@@ -1,6 +1,6 @@
 #include "FEAElement_Triangle6_3D_der0.hpp"
 
-FEAElement_Triangle6_3D_der0::FEAElement_Triangle6_3D_der0( const int &in_nqua )
+FEAElement_Triangle6_3D_der0::FEAElement_Triangle6_3D_der0( int in_nqua )
 : numQuapts( in_nqua )
 {
   R.resize(nLocBas * numQuapts, 0.0);
@@ -60,7 +60,7 @@ void FEAElement_Triangle6_3D_der0::buildBasis( const IQuadPts * const &quad,
 }
 
 void FEAElement_Triangle6_3D_der0::get_R( 
-    const int &quaindex, double * const &basis ) const
+    int quaindex, double * const &basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle6_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -73,14 +73,14 @@ void FEAElement_Triangle6_3D_der0::get_R(
 }
 
 std::vector<double> FEAElement_Triangle6_3D_der0::get_R( 
-    const int &quaindex ) const
+    int quaindex ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle6_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;
   return { R[offset], R[offset+1], R[offset+2], R[offset+3], R[offset+4], R[offset+5] };
 }
 
-Vector_3 FEAElement_Triangle6_3D_der0::get_2d_normal_out( const int &qua,
+Vector_3 FEAElement_Triangle6_3D_der0::get_2d_normal_out( int qua,
     double &area ) const
 {
   ASSERT(qua >= 0 && qua < numQuapts, "FEAElement_Triangle6_3D_der0::get_2d_normal_out function error.\n" );
@@ -88,7 +88,7 @@ Vector_3 FEAElement_Triangle6_3D_der0::get_2d_normal_out( const int &qua,
   return un[qua];
 }
 
-Vector_3 FEAElement_Triangle6_3D_der0::get_normal_out( const int &qua,
+Vector_3 FEAElement_Triangle6_3D_der0::get_normal_out( int qua,
     const Vector_3 &sur_pt, const Vector_3 &int_pt, double &len ) const
 {
   // Construct a vector starting from the interior point to the triangle


### PR DESCRIPTION
### Motivation

- Replace `const int &` parameters with plain `int` for primitive integer arguments to avoid unnecessary references and improve API consistency and performance.
- Apply the change uniformly to constructors and member functions of `FEAElement` and its concrete element classes to keep signatures consistent across headers and implementations.

### Description

- Updated base class `FEAElement` and all derived element headers and source files to change function signatures from `const int &` to `int` (including constructors, `get_R`, gradient/getter functions, Jacobian accessors, `buildBasis`, face helpers, and normal/geometry functions). 
- Updated `ElementFactory::createVolElement` and `createSurElement` to accept `int nqp` instead of `const int &nqp` and adjusted calls to element constructors accordingly.
- Applied matching changes in all affected implementation files so declarations and definitions remain consistent, with no functional logic changes to algorithms or data layouts.
- Affected files include (but are not limited to) `FEAElement.hpp`, `FEAElementFactory.hpp`, and the element headers/sources such as `FEAElement_Hex27.*`, `FEAElement_Hex8.*`, `FEAElement_Quad4.*`, `FEAElement_Quad9.*`, `FEAElement_Tet10.*`, `FEAElement_Tet4.*`, `FEAElement_Triangle3.*`, `FEAElement_Triangle6.*` and their `_3D_der0` variants.

### Testing

- Performed an out-of-source build with `cmake -S . -B build && cmake --build build` and the project compiled successfully.
- Ran the test suite with `ctest --test-dir build` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58a4db428832abb86943a72cc7624)