### PR TITLE
Refactor FEAElement::get_h to take coordinate pointers by value

### DIFF
--- a/include/FEAElement.hpp
+++ b/include/FEAElement.hpp
@@ -47,12 +47,12 @@ class FEAElement
     // ------------------------------------------------------------------------
     // Calculate the element size
     // ------------------------------------------------------------------------
-    virtual double get_h( const double * const &ctrl_x, const double * const &ctrl_y,
-        const double * const &ctrl_z ) const
+    virtual double get_h( const double * ctrl_x, const double * ctrl_y,
+        const double * ctrl_z ) const
     {SYS_T::commPrint("Warning: get_h is not implemented. \n"); return 0.0;}
 
-    virtual double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y ) const
+    virtual double get_h( const double * ctrl_x,
+        const double * ctrl_y ) const
     {SYS_T::commPrint("Warning: get_h is not implemented. \n"); return 0.0;}
 
     virtual double get_h( const std::array<std::vector<double>,3> pts ) const

--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -105,9 +105,9 @@ class FEAElement_Hex27 final : public FEAElement
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
     
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override;
     
     // Get functions give access to function evaluations at the quadrature point 
     // corresponding to quaindex

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -59,9 +59,9 @@ class FEAElement_Hex8 final : public FEAElement
         const double * const &ctrl_y,
         const double * const &ctrl_z ) override;
     
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override;
     
     // Get functions give access to function evaluations at the quadrature point 
     // corresponding to quaindex

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -32,8 +32,8 @@ class FEAElement_Quad4 final : public FEAElement
         const double * const &ctrl_x,
         const double * const &ctrl_y ) override;
 
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y ) const override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -32,8 +32,8 @@ class FEAElement_Quad9 final : public FEAElement
         const double * const &ctrl_x,
         const double * const &ctrl_y ) override;
 
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y ) const override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -65,9 +65,9 @@ class FEAElement_Tet10 final : public FEAElement
     // Return the element size.
     // Here we adopt the algorithm for Tet4 and use the four vertex
     // nodes to calculate the element size
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override;
 
     // get_xxx functions give access to function evaluations at the
     // quadrature point corresponding to quaindex

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -39,9 +39,9 @@ class FEAElement_Tet4 final : public FEAElement
     // Return the element size.
     // For the linear tet element, we calculate the DIAMETER of the
     // circumscribing sphere
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override;
 
     // Get functions give access to function evaluations at the quadrature point 
     // corresponding to quaindex

--- a/include/FEAElement_Triangle3.hpp
+++ b/include/FEAElement_Triangle3.hpp
@@ -32,8 +32,8 @@ class FEAElement_Triangle3 final : public FEAElement
         const double * const &ctrl_x,
         const double * const &ctrl_y ) override;
 
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y ) const override;
 
     void get_R( int quaindex, double * const &basis ) const override;
     

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -33,8 +33,8 @@ class FEAElement_Triangle6 final : public FEAElement
         const double * const &ctrl_x,
         const double * const &ctrl_y ) override;
 
-    double get_h( const double * const &ctrl_x,
-        const double * const &ctrl_y ) const override;
+    double get_h( const double * ctrl_x,
+        const double * ctrl_y ) const override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -303,9 +303,9 @@ void FEAElement_Hex27::buildBasis( const IQuadPts * const &quad,
   }
 }
 
-double FEAElement_Hex27::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z ) const
+double FEAElement_Hex27::get_h( const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z ) const
 {
   const double diag[4] { std::pow((ctrl_x[0] - ctrl_x[6]), 2.0)
       + std::pow((ctrl_y[0] - ctrl_y[6]), 2.0) + std::pow((ctrl_z[0] - ctrl_z[6]), 2.0),

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -174,9 +174,9 @@ void FEAElement_Hex8::buildBasis( const IQuadPts * const &quad,
   }
 }
 
-double FEAElement_Hex8::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z ) const
+double FEAElement_Hex8::get_h( const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z ) const
 {
   const double diag[4] { std::pow((ctrl_x[0] - ctrl_x[6]), 2.0)
       + std::pow((ctrl_y[0] - ctrl_y[6]), 2.0) + std::pow((ctrl_z[0] - ctrl_z[6]), 2.0),

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -118,8 +118,8 @@ void FEAElement_Quad4::buildBasis( const IQuadPts * const &quad,
   }
 }
 
-double FEAElement_Quad4::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y ) const
+double FEAElement_Quad4::get_h( const double * ctrl_x,
+    const double * ctrl_y ) const
 {
    const double diag[2] { std::pow((ctrl_x[0] - ctrl_x[2]), 2.0) 
       + std::pow((ctrl_y[0] - ctrl_y[2]), 2.0),

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -158,8 +158,8 @@ void FEAElement_Quad9::buildBasis( const IQuadPts * const &quad,
   }
 }
 
-double FEAElement_Quad9::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y ) const
+double FEAElement_Quad9::get_h( const double * ctrl_x,
+    const double * ctrl_y ) const
 {
   const double diag[2] { std::pow((ctrl_x[0] - ctrl_x[2]), 2.0) 
       + std::pow((ctrl_y[0] - ctrl_y[2]), 2.0),

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -176,9 +176,9 @@ void FEAElement_Tet10::buildBasis( const IQuadPts * const &quad,
   }
 }
 
-double FEAElement_Tet10::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z ) const
+double FEAElement_Tet10::get_h( const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z ) const
 {
   return 2.0 * FE_T::get_tet_sphere_radius(
       ctrl_x[0], ctrl_x[1], ctrl_x[2], ctrl_x[3],

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -167,9 +167,9 @@ void FEAElement_Tet4::get_3D_R_gradR_LaplacianR( int quaindex,
   }
 }
 
-double FEAElement_Tet4::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z ) const
+double FEAElement_Tet4::get_h( const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z ) const
 {
   return 2.0 * FE_T::get_tet_sphere_radius(
       ctrl_x[0], ctrl_x[1], ctrl_x[2], ctrl_x[3],

--- a/src/Element/FEAElement_Triangle3.cpp
+++ b/src/Element/FEAElement_Triangle3.cpp
@@ -52,8 +52,8 @@ void FEAElement_Triangle3::buildBasis( const IQuadPts * const &quad,
   dR_dy[2] = Jac[7];
 }
 
-double FEAElement_Triangle3::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y ) const
+double FEAElement_Triangle3::get_h( const double * ctrl_x,
+    const double * ctrl_y ) const
 {
   const double a = 2.0 * ( ctrl_x[1] - ctrl_x[0] );
   const double b = 2.0 * ( ctrl_y[1] - ctrl_y[0] );

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -137,8 +137,8 @@ void FEAElement_Triangle6::buildBasis( const IQuadPts * const &quad,
   }
 }
 
-double FEAElement_Triangle6::get_h( const double * const &ctrl_x,
-    const double * const &ctrl_y ) const
+double FEAElement_Triangle6::get_h( const double * ctrl_x,
+    const double * ctrl_y ) const
 {
   const double a = 2.0 * ( ctrl_x[1] - ctrl_x[0] );
   const double b = 2.0 * ( ctrl_y[1] - ctrl_y[0] );


### PR DESCRIPTION
### Motivation
- Reduce unnecessary reference-to-pointer indirection by passing coordinate arrays as pointer values to `get_h`, simplifying the API and calling semantics.

### Description
- Changed the `FEAElement` virtual `get_h` overloads from `const double * const &` to `const double *` for 2D and 3D variants in `include/FEAElement.hpp`.
- Updated all overriding declarations and definitions to match the new signature for element implementations: `Quad4`, `Quad9`, `Triangle3`, `Triangle6`, `Tet4`, `Tet10`, `Hex8`, and `Hex27` across their headers and source files.
- No changes to algorithms or runtime behavior; only function parameter types were adjusted for pointer passing semantics.

### Testing
- Performed a repository-wide search with `rg` to ensure there are no remaining `get_h` signatures using `const double * const &` and confirmed no matches were found.
- Ran the automated replacement script that updated the affected header and source files (17 files updated) and validated the modifications applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e591dcd114832aa9c3f38a5924d805)