### PR TITLE
Simplify pointer parameter signatures for FEAElement::buildBasis and related APIs

### DIFF
--- a/include/FEAElement.hpp
+++ b/include/FEAElement.hpp
@@ -64,21 +64,21 @@ class FEAElement
     // Build Basis function quadrature info
     // ------------------------------------------------------------------------
     // Build 3D basis -- FEM
-    virtual void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x, const double * const &ctrl_y,
-        const double * const &ctrl_z )
+    virtual void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x, const double * ctrl_y,
+        const double * ctrl_z )
     {SYS_T::commPrint("Warning: buildBasis() is not implemented. \n");}
 
-    virtual void buildBasis( const IQuadPts * const &quad_rule,
+    virtual void buildBasis( const IQuadPts * quad_rule,
         const std::array<std::vector<double>,3> &pts )
     {buildBasis(quad_rule, &pts[0][0], &pts[1][0], &pts[2][0]);}
 
     // Build 2D basis -- FEM
-    virtual void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x, const double * const &ctrl_y )
+    virtual void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x, const double * ctrl_y )
     {SYS_T::commPrint("Warning: buildBasis() is not implemented. \n");}
 
-    virtual void buildBasis( const IQuadPts * const &quad_rule,
+    virtual void buildBasis( const IQuadPts * quad_rule,
         const std::array<std::vector<double>,2> &pts )
     {buildBasis(quad_rule, &pts[0][0], &pts[1][0]);}
 
@@ -237,10 +237,10 @@ class FEAElement
     // Build the volume element with a face id and the quad_rule on surface element.
     // ------------------------------------------------------------------------
     virtual void buildBasis( int face_id,
-        const IQuadPts * const &quad_rule_s,
-        const double * const &ctrl_x, 
-        const double * const &ctrl_y,
-        const double * const &ctrl_z )
+        const IQuadPts * quad_rule_s,
+        const double * ctrl_x, 
+        const double * ctrl_y,
+        const double * ctrl_z )
     {SYS_T::commPrint("Warning: buildBasis is not implemented. \n");}
 
     // ------------------------------------------------------------------------

--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -100,10 +100,10 @@ class FEAElement_Hex27 final : public FEAElement
 
     // Given the quadrature points and nodal coordinates, evaluate the basis 
     // functions and their derivatives up to second order
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
     
     double get_h( const double * ctrl_x, const double * ctrl_y,
         const double * ctrl_z ) const override;
@@ -150,10 +150,10 @@ class FEAElement_Hex27 final : public FEAElement
     //   Hex-Face-3 : Node 1 2 6 5 9 18 13 17 21
     //   Hex-Face-4 : Node 3 7 6 2 19 14 18 10 23
     //   Hex-Face-5 : Node 0 4 7 3 16 15 19 11 20
-    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( int face_id, const IQuadPts * quad_rule_s,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     // Get the outwardnormal on faces
     Vector_3 get_2d_normal_out( int quaindex, double &area ) const override

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -54,10 +54,10 @@ class FEAElement_Hex8 final : public FEAElement
 
     // Given the quadrature points and nodal coordinates, evaluate the basis 
     // functions and their derivatives up to second order
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
     
     double get_h( const double * ctrl_x, const double * ctrl_y,
         const double * ctrl_z ) const override;
@@ -104,10 +104,10 @@ class FEAElement_Hex8 final : public FEAElement
     //   Hex-Face-3 : Node 1 2 6 5
     //   Hex-Face-4 : Node 3 7 6 2
     //   Hex-Face-5 : Node 0 4 7 3
-    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( int face_id, const IQuadPts * quad_rule_s,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     // Get the outwardnormal on faces
     Vector_3 get_2d_normal_out( int quaindex, double &area ) const override

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -28,9 +28,9 @@ class FEAElement_Quad4 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y ) override;
 
     double get_h( const double * ctrl_x,
         const double * ctrl_y ) const override;

--- a/include/FEAElement_Quad4_3D_der0.hpp
+++ b/include/FEAElement_Quad4_3D_der0.hpp
@@ -49,10 +49,10 @@ class FEAElement_Quad4_3D_der0 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -28,9 +28,9 @@ class FEAElement_Quad9 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y ) override;
 
     double get_h( const double * ctrl_x,
         const double * ctrl_y ) const override;

--- a/include/FEAElement_Quad9_3D_der0.hpp
+++ b/include/FEAElement_Quad9_3D_der0.hpp
@@ -49,10 +49,10 @@ class FEAElement_Quad9_3D_der0 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -57,10 +57,10 @@ class FEAElement_Tet10 final : public FEAElement
 
     // Given the quadrature points and nodal coordinates, evaluate
     // the basis functions and their derivatives up to second order
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     // Return the element size.
     // Here we adopt the algorithm for Tet4 and use the four vertex
@@ -105,10 +105,10 @@ class FEAElement_Tet10 final : public FEAElement
     //   Tet-Face-1 : Node 0 3 2 7 9 6
     //   Tet-Face-2 : Node 0 1 3 4 8 7
     //   Tet-Face-3 : Node 0 2 1 6 5 4
-    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( int face_id, const IQuadPts * quad_rule_s,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     // Get the outwardnormal on faces
     Vector_3 get_2d_normal_out( int quaindex, double &area ) const override

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -31,10 +31,10 @@ class FEAElement_Tet4 final : public FEAElement
 
     // Given the quadrature points and nodal coordinates, evaluate the basis 
     // functions and their derivatives up to second order
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     // Return the element size.
     // For the linear tet element, we calculate the DIAMETER of the
@@ -90,10 +90,10 @@ class FEAElement_Tet4 final : public FEAElement
     //   Tet-Face-1 : Node 0 3 2
     //   Tet-Face-2 : Node 0 1 3
     //   Tet-Face-3 : Node 0 2 1
-    void buildBasis( int face_id, const IQuadPts * const &quad_rule_s,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( int face_id, const IQuadPts * quad_rule_s,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     // Get the outwardnormal on faces
     // This function requires the buildBasis with face_id provided, so that the

--- a/include/FEAElement_Triangle3.hpp
+++ b/include/FEAElement_Triangle3.hpp
@@ -28,9 +28,9 @@ class FEAElement_Triangle3 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y ) override;
 
     double get_h( const double * ctrl_x,
         const double * ctrl_y ) const override;

--- a/include/FEAElement_Triangle3_3D_der0.hpp
+++ b/include/FEAElement_Triangle3_3D_der0.hpp
@@ -38,10 +38,10 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -29,9 +29,9 @@ class FEAElement_Triangle6 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y ) override;
 
     double get_h( const double * ctrl_x,
         const double * ctrl_y ) const override;

--- a/include/FEAElement_Triangle6_3D_der0.hpp
+++ b/include/FEAElement_Triangle6_3D_der0.hpp
@@ -49,10 +49,10 @@ class FEAElement_Triangle6_3D_der0 final : public FEAElement
 
     void print_info() const override;
 
-    void buildBasis( const IQuadPts * const &quad_rule,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) override;
+    void buildBasis( const IQuadPts * quad_rule,
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) override;
 
     void get_R( int quaindex, double * const &basis ) const override;
 

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -28,10 +28,10 @@ void FEAElement_Hex27::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Hex27::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Hex27::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT( quad -> get_dim() == 3, "FEAElement_Hex27::buildBasis function error.\n" );
 
@@ -428,10 +428,10 @@ std::array<double,9> FEAElement_Hex27::get_invJacobian(int quaindex) const
     dr_dx[9*quaindex+6], dr_dx[9*quaindex+7], dr_dx[9*quaindex+8] }};
 }
 
-void FEAElement_Hex27::buildBasis( int face_id, const IQuadPts * const &quad_s,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Hex27::buildBasis( int face_id, const IQuadPts * quad_s,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   // Build the volume element
   const auto quad_v = FE_T::QuadPts_on_face( this->get_Type(), face_id, quad_s );

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -28,10 +28,10 @@ void FEAElement_Hex8::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Hex8::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Hex8::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT( quad -> get_dim() == 3, "FEAElement_Hex8::buildBasis function error.\n" );
 
@@ -299,10 +299,10 @@ std::array<double,9> FEAElement_Hex8::get_invJacobian(int quaindex) const
     dr_dx[9*quaindex+6], dr_dx[9*quaindex+7], dr_dx[9*quaindex+8] }};
 }
 
-void FEAElement_Hex8::buildBasis( int face_id, const IQuadPts * const &quad_s, 
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Hex8::buildBasis( int face_id, const IQuadPts * quad_s, 
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   // Build the volume element
   const auto quad_v = FE_T::QuadPts_on_face( this->get_Type(), face_id, quad_s );

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -22,9 +22,9 @@ void FEAElement_Quad4::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Quad4::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y )
+void FEAElement_Quad4::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y )
 {
   ASSERT(quad->get_dim() == 2, "FEAElement_Quad4::buildBasis function error.\n" );
 

--- a/src/Element/FEAElement_Quad4_3D_der0.cpp
+++ b/src/Element/FEAElement_Quad4_3D_der0.cpp
@@ -15,10 +15,10 @@ void FEAElement_Quad4_3D_der0::print_info() const
   SYS_T::commPrint("Note: This element is designed for natural BC integrals.\n");
 }
 
-void FEAElement_Quad4_3D_der0::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Quad4_3D_der0::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT(quad->get_dim() == 2, "FEAElement_Quad4_3D_der0::buildBasis function error.\n" );
 

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -21,9 +21,9 @@ void FEAElement_Quad9::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Quad9::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y )
+void FEAElement_Quad9::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y )
 {
   ASSERT(quad->get_dim() == 2, "FEAElement_Quad9::buildBasis function error.\n" );
 

--- a/src/Element/FEAElement_Quad9_3D_der0.cpp
+++ b/src/Element/FEAElement_Quad9_3D_der0.cpp
@@ -15,10 +15,10 @@ void FEAElement_Quad9_3D_der0::print_info() const
   SYS_T::commPrint("Note: This element is designed for natural BC integrals.\n");
 }
 
-void FEAElement_Quad9_3D_der0::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Quad9_3D_der0::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT(quad->get_dim() == 2, "FEAElement_Quad9_3D_der0::buildBasis function error.\n" );
 

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -29,10 +29,10 @@ void FEAElement_Tet10::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Tet10::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Tet10::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT( quad -> get_dim() == 4, "FEAElement_Tet10::buildBasis function error.\n" );
 
@@ -289,10 +289,10 @@ std::array<double,9> FEAElement_Tet10::get_invJacobian(int quaindex) const
     dr_dx[9*quaindex+6], dr_dx[9*quaindex+7], dr_dx[9*quaindex+8] }};
 }
 
-void FEAElement_Tet10::buildBasis( int face_id, const IQuadPts * const &quad_s,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Tet10::buildBasis( int face_id, const IQuadPts * quad_s,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   // Build the volume element
   const auto quad_v = FE_T::QuadPts_on_face( this->get_Type(), face_id, quad_s );

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -13,10 +13,10 @@ void FEAElement_Tet4::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Tet4::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Tet4::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT( quad -> get_dim() == 4, "FEAElement_Tet4::buildBasis function error.\n" );
 
@@ -177,10 +177,10 @@ double FEAElement_Tet4::get_h( const double * ctrl_x,
       ctrl_z[0], ctrl_z[1], ctrl_z[2], ctrl_z[3] );  
 }
 
-void FEAElement_Tet4::buildBasis( int face_id, const IQuadPts * const &quad_s,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Tet4::buildBasis( int face_id, const IQuadPts * quad_s,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   // Build the volume element
   const auto quad_v = FE_T::QuadPts_on_face( this->get_Type(), face_id, quad_s );

--- a/src/Element/FEAElement_Triangle3.cpp
+++ b/src/Element/FEAElement_Triangle3.cpp
@@ -13,8 +13,8 @@ void FEAElement_Triangle3::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated. \n");
 }
 
-void FEAElement_Triangle3::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x, const double * const &ctrl_y )
+void FEAElement_Triangle3::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x, const double * ctrl_y )
 {
   ASSERT(quad -> get_dim() == 3, "FEAElement_Triangle3::buildBasis function error.\n" );
 

--- a/src/Element/FEAElement_Triangle3_3D_der0.cpp
+++ b/src/Element/FEAElement_Triangle3_3D_der0.cpp
@@ -13,10 +13,10 @@ void FEAElement_Triangle3_3D_der0::print_info() const
   SYS_T::commPrint("Note: This element is designed for natural BC integrals.\n");
 }
 
-void FEAElement_Triangle3_3D_der0::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Triangle3_3D_der0::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   for( int qua = 0; qua < numQuapts; ++qua )
   {

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -22,9 +22,9 @@ void FEAElement_Triangle6::print_info() const
   SYS_T::commPrint("Note: Jacobian and inverse Jacobian are evaluated.\n");
 }
 
-void FEAElement_Triangle6::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y )
+void FEAElement_Triangle6::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y )
 {
   ASSERT(quad->get_dim() == 3, "FEAElement_Triangle6::buildBasis function error.\n" );
 

--- a/src/Element/FEAElement_Triangle6_3D_der0.cpp
+++ b/src/Element/FEAElement_Triangle6_3D_der0.cpp
@@ -15,10 +15,10 @@ void FEAElement_Triangle6_3D_der0::print_info() const
   SYS_T::commPrint("Note: This element is designed for natural BC integrals.\n");
 }
 
-void FEAElement_Triangle6_3D_der0::buildBasis( const IQuadPts * const &quad,
-    const double * const &ctrl_x,
-    const double * const &ctrl_y,
-    const double * const &ctrl_z )
+void FEAElement_Triangle6_3D_der0::buildBasis( const IQuadPts * quad,
+    const double * ctrl_x,
+    const double * ctrl_y,
+    const double * ctrl_z )
 {
   ASSERT(quad->get_dim() == 3, "FEAElement_Triangle6_3D_der0::buildBasis function error.\n" );
 


### PR DESCRIPTION
### Motivation
- Remove unnecessary reference-to-pointer parameter types (e.g. `const IQuadPts * const &`) to simplify function interfaces and improve readability.
- Make pointer parameter usage consistent across the `FEAElement` hierarchy to avoid confusing `&` bindings and potential compiler warnings.

### Description
- Replaced function parameter types of the form `const IQuadPts * const &quad_rule` with `const IQuadPts * quad_rule` across the `FEAElement` base class and derived element headers.
- Replaced `const double * const &ctrl_x` / `ctrl_y` / `ctrl_z` with `const double * ctrl_x` / `ctrl_y` / `ctrl_z` in both declarations and definitions for all affected element types (including `Hex27`, `Hex8`, `Quad4`, `Quad9`, `Tet10`, `Tet4`, `Triangle3`, `Triangle6` and their `_3D_der0` variants), and likewise for the face `buildBasis` overloads.
- Updated corresponding `.cpp` implementations to match the new signatures so that declarations and definitions remain consistent.
- No computational logic was changed; the edits are limited to function parameter types and matching signatures.

### Testing
- Built the project with `cmake -S . -B build && cmake --build build -j` and the compilation completed successfully.
- Ran the automated test suite with `ctest --test-dir build` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a36861e4832a87c27072a123b25f)