### PR TITLE
Adopt HDF5_Group RAII wrapper for group handles and add Reader/Writer overloads

### DIFF
--- a/examples/ale_ns_rotate/preprocess.cpp
+++ b/examples/ale_ns_rotate/preprocess.cpp
@@ -470,11 +470,9 @@ int main( int argc, char * argv[] )
     const std::string fName = SYS_T::gen_partfile_name( part_file, part->get_cpu_rank() );
     HDF5_Writer * h5w = new HDF5_Writer( fName, H5F_ACC_RDWR );
     const hid_t file_id = h5w->get_file_id();
-    hid_t g_id = H5Gcreate(file_id, "/rotation", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group g_id = HDF5_Group::create(file_id, "/rotation");
     h5w -> write_Vector_3( g_id, "point_rotated", point_rotated.to_std_array() );
     h5w -> write_Vector_3( g_id, "angular_direction", angular_direction.to_std_array() );
-
-    H5Gclose( g_id );
     delete h5w;
 
     // Partition sliding interface and write to h5 file
@@ -561,7 +559,7 @@ int main( int argc, char * argv[] )
     
     const hid_t file_id = h5w->get_file_id();
     
-    hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::open( file_id, GroupName.c_str() );
 
     h5w -> write_intVector( g_id, "max_num_local_fixed_cell", max_fixed_nlocalele );
 
@@ -574,7 +572,7 @@ int main( int argc, char * argv[] )
       std::string subgroup_name(groupbase);
       subgroup_name.append( std::to_string(ii) );
 
-      hid_t group_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT);
+      HDF5_Group group_id = HDF5_Group::open(g_id.id(), subgroup_name.c_str());
 
       h5w -> write_intVector( group_id, "fixed_node_part_tag", fixed_node_vol_part_tag[ii] );
 
@@ -583,11 +581,7 @@ int main( int argc, char * argv[] )
       h5w -> write_intVector( group_id, "rotated_node_part_tag", rotated_node_vol_part_tag[ii] );
 
       h5w -> write_intVector( group_id, "rotated_node_loc_pos", rotated_node_loc_pos[ii] );
-
-      H5Gclose( group_id );
     }
-
-    H5Gclose( g_id );
     delete h5w;
   }
 

--- a/include/HDF5_Reader.hpp
+++ b/include/HDF5_Reader.hpp
@@ -11,10 +11,11 @@
 //
 // A typical way of using this class is:
 //
-// auto h5r = SYS_T::make_unique<HDF5_Reader>(name_of_h5_file);
+// HDF5_Reader * h5r = new HDF5_Reader( name_of_h5_file );
 //
 // call read functions
-// (resource is released automatically when h5r goes out of scope)
+//
+// delete h5r;
 //
 // There are two modes for H5Fopen
 // H5F_ACC_RDONLY: the application will read only the file
@@ -30,7 +31,6 @@
 #include <array>
 #include "Sys_Tools.hpp"
 #include "Vec_Tools.hpp"
-#include "HDF5_Group.hpp"
 #include "hdf5.h"
 
 class HDF5_Reader
@@ -60,7 +60,7 @@ class HDF5_Reader
     // !check_data: return a bool value that determines if the data
     //              with the specified name exists in the file.
     // --------------------------------------------------------------
-    bool check_data( const char * const &name ) const
+    bool check_data( const char * name ) const
     {
       return H5Lexists(file_id, name, H5P_DEFAULT);
     }
@@ -68,82 +68,63 @@ class HDF5_Reader
     // --------------------------------------------------------------
     // ! get_file_id: return the internal hdf5 file id.
     // --------------------------------------------------------------
-    hid_t get_file_id() const
-    {
-      return file_id;
-    }
+    hid_t get_file_id() const { return file_id; }
     
     // --------------------------------------------------------------
     // !read_intScalar: return the integer scalar data by specifing 
     //                  its group_name with data_name.
     // --------------------------------------------------------------
-    int read_intScalar( const char * const &group_name,
-        const char * const &data_name ) const;
-    int read_intScalar( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    int read_intScalar( const char * group_name,
+        const char * data_name ) const;
 
     // --------------------------------------------------------------
     // !read_doubleScalar: return the double scalar data by specifing 
     //                  its group_name with data_name.
     // --------------------------------------------------------------
-    double read_doubleScalar( const char * const &group_name,
-        const char * const &data_name ) const;
-    double read_doubleScalar( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    double read_doubleScalar( const char * group_name,
+        const char * data_name ) const;
 
     // --------------------------------------------------------------
     // ! read_intVector: output the 1D integer array data into 
     //                   vector<int>.
     // --------------------------------------------------------------
-    std::vector<int> read_intVector( const char * const &group_name,
-        const char * const &data_name ) const;
-    std::vector<int> read_intVector( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    std::vector<int> read_intVector( const char * group_name,
+        const char * data_name ) const;
     
     // --------------------------------------------------------------
     // ! read_doubleVector: output the 1D integer array data into 
     //                      vector<double>.
     // --------------------------------------------------------------
-    std::vector<double> read_doubleVector( const char * const &group_name,
-        const char * const &data_name ) const;
-    std::vector<double> read_doubleVector( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    std::vector<double> read_doubleVector( const char * group_name,
+        const char * data_name ) const;
 
     // --------------------------------------------------------------
     // ! read_Vector_3 : output the std::array<double, 3>.
     // --------------------------------------------------------------
-    std::array<double, 3> read_Vector_3( const char * const &group_name,
-        const char * const &data_name ) const;
-    std::array<double, 3> read_Vector_3( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    std::array<double, 3> read_Vector_3( const char * group_name,
+        const char * data_name ) const;
 
     // --------------------------------------------------------------
     // ! read_Tensor2_3D : output the std::array<double, 9>.
     // --------------------------------------------------------------
-    std::array<double, 9> read_Tensor2_3D( const char * const &group_name,
-        const char * const &data_name ) const;
-    std::array<double, 9> read_Tensor2_3D( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    std::array<double, 9> read_Tensor2_3D( const char * group_name,
+        const char * data_name ) const;
 
     // --------------------------------------------------------------
     // ! read_intMatrix : output a 2D integer Matrix into vector<int>,
     //                    with size num_row x num_col. The matrix is
     //                    stroed by rows.
     // --------------------------------------------------------------
-    std::vector<int> read_intMatrix( const char * const &group_name,
-        const char * const &data_name, int &num_row, int &num_col ) const;
-    std::vector<int> read_intMatrix( const HDF5_Group &group,
-        const char * const &data_name, int &num_row, int &num_col ) const;
+    std::vector<int> read_intMatrix( const char * group_name,
+        const char * data_name, int &num_row, int &num_col ) const;
 
     // --------------------------------------------------------------
     // ! read_doubleMatrix : output a 2D double Matrix into 
     //                       vector<double>, with size num_row x num_col. 
     //                       The matrix is stroed by rows.
     // --------------------------------------------------------------
-    std::vector<double> read_doubleMatrix( const char * const &group_name,
-        const char * const &data_name, int &num_row, int &num_col ) const;
-    std::vector<double> read_doubleMatrix( const HDF5_Group &group,
-        const char * const &data_name, int &num_row, int &num_col ) const;
+    std::vector<double> read_doubleMatrix( const char * group_name,
+        const char * data_name, int &num_row, int &num_col ) const;
 
     // --------------------------------------------------------------
     // ! read_intArray
@@ -165,12 +146,9 @@ class HDF5_Reader
     //    Note: The user is responsible for deleting/freeing the memory 
     //          space for data_dims and data. 
     // --------------------------------------------------------------
-    void read_intArray(const char * const &group_name, 
-        const char * const &data_name,
+    void read_intArray(const char * group_name, 
+        const char * data_name,
         hid_t &data_rank, hsize_t * &data_dims, int * &data  ) const;
-    void read_intArray( const HDF5_Group &group,
-        const char * const &data_name,
-        hid_t &data_rank, hsize_t * &data_dims, int * &data ) const;
 
     // --------------------------------------------------------------
     // ! read_doubleArray
@@ -192,12 +170,9 @@ class HDF5_Reader
     //    Note: The user is responsible for deleting/freeing the memory 
     //          space for data_dims and data. 
     // --------------------------------------------------------------
-    void read_doubleArray(const char * const &group_name, 
-        const char * const &data_name,
+    void read_doubleArray(const char * group_name, 
+        const char * data_name,
         hid_t &data_rank, hsize_t * &data_dims, double * &data  ) const;
-    void read_doubleArray( const HDF5_Group &group,
-        const char * const &data_name,
-        hid_t &data_rank, hsize_t * &data_dims, double * &data ) const;
 
     // --------------------------------------------------------------
     // ! read_string
@@ -206,15 +181,13 @@ class HDF5_Reader
     //   \para group_name : the name of the group
     //   \para data_name  : the name of the dataset in the group
     // --------------------------------------------------------------
-    std::string read_string( const char * const &group_name,
-        const char * const &data_name ) const;
-    std::string read_string( const HDF5_Group &group,
-        const char * const &data_name ) const;
+    std::string read_string( const char * group_name,
+        const char * data_name ) const;
 
   private:
     const hid_t file_id;
 
-    void check_error(const herr_t &status, const char * const &funname ) const
+    void check_error(const herr_t &status, const char * funname ) const
     {
       if( status < 0 )
       {

--- a/include/HDF5_Reader.hpp
+++ b/include/HDF5_Reader.hpp
@@ -30,6 +30,7 @@
 #include <array>
 #include "Sys_Tools.hpp"
 #include "Vec_Tools.hpp"
+#include "HDF5_Group.hpp"
 #include "hdf5.h"
 
 class HDF5_Reader
@@ -78,12 +79,16 @@ class HDF5_Reader
     // --------------------------------------------------------------
     int read_intScalar( const char * const &group_name,
         const char * const &data_name ) const;
+    int read_intScalar( const HDF5_Group &group,
+        const char * const &data_name ) const;
 
     // --------------------------------------------------------------
     // !read_doubleScalar: return the double scalar data by specifing 
     //                  its group_name with data_name.
     // --------------------------------------------------------------
     double read_doubleScalar( const char * const &group_name,
+        const char * const &data_name ) const;
+    double read_doubleScalar( const HDF5_Group &group,
         const char * const &data_name ) const;
 
     // --------------------------------------------------------------
@@ -92,6 +97,8 @@ class HDF5_Reader
     // --------------------------------------------------------------
     std::vector<int> read_intVector( const char * const &group_name,
         const char * const &data_name ) const;
+    std::vector<int> read_intVector( const HDF5_Group &group,
+        const char * const &data_name ) const;
     
     // --------------------------------------------------------------
     // ! read_doubleVector: output the 1D integer array data into 
@@ -99,17 +106,23 @@ class HDF5_Reader
     // --------------------------------------------------------------
     std::vector<double> read_doubleVector( const char * const &group_name,
         const char * const &data_name ) const;
+    std::vector<double> read_doubleVector( const HDF5_Group &group,
+        const char * const &data_name ) const;
 
     // --------------------------------------------------------------
     // ! read_Vector_3 : output the std::array<double, 3>.
     // --------------------------------------------------------------
     std::array<double, 3> read_Vector_3( const char * const &group_name,
         const char * const &data_name ) const;
+    std::array<double, 3> read_Vector_3( const HDF5_Group &group,
+        const char * const &data_name ) const;
 
     // --------------------------------------------------------------
     // ! read_Tensor2_3D : output the std::array<double, 9>.
     // --------------------------------------------------------------
     std::array<double, 9> read_Tensor2_3D( const char * const &group_name,
+        const char * const &data_name ) const;
+    std::array<double, 9> read_Tensor2_3D( const HDF5_Group &group,
         const char * const &data_name ) const;
 
     // --------------------------------------------------------------
@@ -119,6 +132,8 @@ class HDF5_Reader
     // --------------------------------------------------------------
     std::vector<int> read_intMatrix( const char * const &group_name,
         const char * const &data_name, int &num_row, int &num_col ) const;
+    std::vector<int> read_intMatrix( const HDF5_Group &group,
+        const char * const &data_name, int &num_row, int &num_col ) const;
 
     // --------------------------------------------------------------
     // ! read_doubleMatrix : output a 2D double Matrix into 
@@ -126,6 +141,8 @@ class HDF5_Reader
     //                       The matrix is stroed by rows.
     // --------------------------------------------------------------
     std::vector<double> read_doubleMatrix( const char * const &group_name,
+        const char * const &data_name, int &num_row, int &num_col ) const;
+    std::vector<double> read_doubleMatrix( const HDF5_Group &group,
         const char * const &data_name, int &num_row, int &num_col ) const;
 
     // --------------------------------------------------------------
@@ -151,6 +168,9 @@ class HDF5_Reader
     void read_intArray(const char * const &group_name, 
         const char * const &data_name,
         hid_t &data_rank, hsize_t * &data_dims, int * &data  ) const;
+    void read_intArray( const HDF5_Group &group,
+        const char * const &data_name,
+        hid_t &data_rank, hsize_t * &data_dims, int * &data ) const;
 
     // --------------------------------------------------------------
     // ! read_doubleArray
@@ -175,6 +195,9 @@ class HDF5_Reader
     void read_doubleArray(const char * const &group_name, 
         const char * const &data_name,
         hid_t &data_rank, hsize_t * &data_dims, double * &data  ) const;
+    void read_doubleArray( const HDF5_Group &group,
+        const char * const &data_name,
+        hid_t &data_rank, hsize_t * &data_dims, double * &data ) const;
 
     // --------------------------------------------------------------
     // ! read_string
@@ -184,6 +207,8 @@ class HDF5_Reader
     //   \para data_name  : the name of the dataset in the group
     // --------------------------------------------------------------
     std::string read_string( const char * const &group_name,
+        const char * const &data_name ) const;
+    std::string read_string( const HDF5_Group &group,
         const char * const &data_name ) const;
 
   private:

--- a/include/HDF5_Writer.hpp
+++ b/include/HDF5_Writer.hpp
@@ -36,7 +36,6 @@
 #include <vector>
 #include <array>
 #include "Sys_Tools.hpp"
-#include "HDF5_Group.hpp"
 #include "hdf5.h"
 
 class HDF5_Writer
@@ -64,15 +63,10 @@ class HDF5_Writer
 
     // --- Write an int (H5T_NATIVE_INT) scalar as /group_id/data_name
     void write_intScalar( hid_t group_id, const char * data_name, int value ) const; 
-    void write_intScalar( const HDF5_Group &group, const char * data_name, int value ) const
-    { write_intScalar( group.id(), data_name, value ); }
 
     // --- Write a double (H5T_NATIVE_DOUBLE) scalar as /file_id/group_id
     void write_doubleScalar( hid_t group_id, const char * data_name, 
         double value ) const; 
-    void write_doubleScalar( const HDF5_Group &group, const char * data_name,
-        double value ) const
-    { write_doubleScalar( group.id(), data_name, value ); }
     
     // --- Write a double (H5T_NATIVE_DOUBLE) scalar as /file_id
     void write_doubleScalar( const char * data_name, double value ) const;
@@ -84,9 +78,6 @@ class HDF5_Writer
     //     /group_id/data_name
     void write_uintScalar( hid_t group_id, const char * data_name, 
         unsigned int value ) const;
-    void write_uintScalar( const HDF5_Group &group, const char * data_name,
-        unsigned int value ) const
-    { write_uintScalar( group.id(), data_name, value ); }
 
     // --------------------------------------------------------------
     // Array writer
@@ -96,9 +87,6 @@ class HDF5_Writer
     //     /group/data_name
     void write_intVector( hid_t group_id, const char * data_name,
         const int * value, int length ) const;
-    void write_intVector( const HDF5_Group &group, const char * data_name,
-        const int * value, int length ) const
-    { write_intVector( group.id(), data_name, value, length ); }
     
     // --- write an int array with given length and saved as /data_name
     void write_intVector( const char * data_name, const int * value,
@@ -112,9 +100,6 @@ class HDF5_Writer
     //     /group/data_name
     void write_int64Vector( hid_t group_id, const char * data_name, 
         const int64_t * value, int64_t length ) const;
-    void write_int64Vector( const HDF5_Group &group, const char * data_name,
-        const int64_t * value, int64_t length ) const
-    { write_int64Vector( group.id(), data_name, value, length ); }
     
     // --- write an int array with given length and saved as /data_name
     void write_int64Vector( const char * data_name, 
@@ -129,9 +114,6 @@ class HDF5_Writer
     void write_doubleVector( hid_t group_id, 
         const char * data_name,
         const double * value, int length ) const;
-    void write_doubleVector( const HDF5_Group &group, const char * data_name,
-        const double * value, int length ) const
-    { write_doubleVector( group.id(), data_name, value, length ); }
 
     // --- write a double array with given length at /data_name
     void write_doubleVector( const char * data_name,
@@ -143,9 +125,6 @@ class HDF5_Writer
     // --- write an int vector at /group_id/data_name
     void write_intVector( hid_t group_id,
         const char * data_name, const std::vector<int> &value ) const;
-    void write_intVector( const HDF5_Group &group, const char * data_name,
-        const std::vector<int> &value ) const
-    { write_intVector( group.id(), data_name, value ); }
 
     // --- write an int vector at /data_name
     void write_intVector( const char * data_name, 
@@ -154,16 +133,10 @@ class HDF5_Writer
     // --- write an unsigned int vector at /group_id/data_name
     void write_uintVector( hid_t group_id, const char * data_name, 
         const std::vector<unsigned int> &value ) const;
-    void write_uintVector( const HDF5_Group &group, const char * data_name,
-        const std::vector<unsigned int> &value ) const
-    { write_uintVector( group.id(), data_name, value ); }
 
     // --- write a double vector at /group_id/data_name
     void write_doubleVector( hid_t group_id, const char * data_name,
         const std::vector<double> &value ) const;
-    void write_doubleVector( const HDF5_Group &group, const char * data_name,
-        const std::vector<double> &value ) const
-    { write_doubleVector( group.id(), data_name, value ); }
 
     // --- write a double vector at /data_name
     void write_doubleVector( const char * data_name, 
@@ -174,9 +147,6 @@ class HDF5_Writer
     // --------------------------------------------------------------
     void write_Vector_3( hid_t group_id, const char * data_name,
         const std::array<double, 3> &value ) const;
-    void write_Vector_3( const HDF5_Group &group, const char * data_name,
-        const std::array<double, 3> &value ) const
-    { write_Vector_3( group.id(), data_name, value ); }
 
     void write_Vector_3( const char * data_name, 
         const std::array<double, 3> &value ) const;
@@ -186,9 +156,6 @@ class HDF5_Writer
     // --------------------------------------------------------------
     void write_Tensor2_3D( hid_t group_id, const char * data_name,
         const std::array<double, 9> &value ) const;
-    void write_Tensor2_3D( const HDF5_Group &group, const char * data_name,
-        const std::array<double, 9> &value ) const
-    { write_Tensor2_3D( group.id(), data_name, value ); }
 
     void write_Tensor2_3D( const char * data_name, 
         const std::array<double, 9> &value ) const;
@@ -199,16 +166,10 @@ class HDF5_Writer
     void write_intMatrix( hid_t group_id,
         const char * data_name, const std::vector<int> &value,
         int row_num, int col_num ) const;
-    void write_intMatrix( const HDF5_Group &group, const char * data_name,
-        const std::vector<int> &value, int row_num, int col_num ) const
-    { write_intMatrix( group.id(), data_name, value, row_num, col_num ); }
 
     void write_doubleMatrix( hid_t group_id, 
         const char * data_name, const std::vector<double> &value,
         int row_num, int col_num ) const;
-    void write_doubleMatrix( const HDF5_Group &group, const char * data_name,
-        const std::vector<double> &value, int row_num, int col_num ) const
-    { write_doubleMatrix( group.id(), data_name, value, row_num, col_num ); }
 
     // --------------------------------------------------------------
     // String
@@ -218,9 +179,6 @@ class HDF5_Writer
 
     void write_string( hid_t group_id, const char * data_name, 
         const std::string &string_input ) const;
-    void write_string( const HDF5_Group &group, const char * data_name,
-        const std::string &string_input ) const
-    { write_string( group.id(), data_name, string_input ); }
 
   private:
     hid_t file_id;

--- a/include/HDF5_Writer.hpp
+++ b/include/HDF5_Writer.hpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <array>
 #include "Sys_Tools.hpp"
+#include "HDF5_Group.hpp"
 #include "hdf5.h"
 
 class HDF5_Writer
@@ -63,10 +64,15 @@ class HDF5_Writer
 
     // --- Write an int (H5T_NATIVE_INT) scalar as /group_id/data_name
     void write_intScalar( hid_t group_id, const char * data_name, int value ) const; 
+    void write_intScalar( const HDF5_Group &group, const char * data_name, int value ) const
+    { write_intScalar( group.id(), data_name, value ); }
 
     // --- Write a double (H5T_NATIVE_DOUBLE) scalar as /file_id/group_id
     void write_doubleScalar( hid_t group_id, const char * data_name, 
         double value ) const; 
+    void write_doubleScalar( const HDF5_Group &group, const char * data_name,
+        double value ) const
+    { write_doubleScalar( group.id(), data_name, value ); }
     
     // --- Write a double (H5T_NATIVE_DOUBLE) scalar as /file_id
     void write_doubleScalar( const char * data_name, double value ) const;
@@ -78,6 +84,9 @@ class HDF5_Writer
     //     /group_id/data_name
     void write_uintScalar( hid_t group_id, const char * data_name, 
         unsigned int value ) const;
+    void write_uintScalar( const HDF5_Group &group, const char * data_name,
+        unsigned int value ) const
+    { write_uintScalar( group.id(), data_name, value ); }
 
     // --------------------------------------------------------------
     // Array writer
@@ -87,6 +96,9 @@ class HDF5_Writer
     //     /group/data_name
     void write_intVector( hid_t group_id, const char * data_name,
         const int * value, int length ) const;
+    void write_intVector( const HDF5_Group &group, const char * data_name,
+        const int * value, int length ) const
+    { write_intVector( group.id(), data_name, value, length ); }
     
     // --- write an int array with given length and saved as /data_name
     void write_intVector( const char * data_name, const int * value,
@@ -100,6 +112,9 @@ class HDF5_Writer
     //     /group/data_name
     void write_int64Vector( hid_t group_id, const char * data_name, 
         const int64_t * value, int64_t length ) const;
+    void write_int64Vector( const HDF5_Group &group, const char * data_name,
+        const int64_t * value, int64_t length ) const
+    { write_int64Vector( group.id(), data_name, value, length ); }
     
     // --- write an int array with given length and saved as /data_name
     void write_int64Vector( const char * data_name, 
@@ -114,6 +129,9 @@ class HDF5_Writer
     void write_doubleVector( hid_t group_id, 
         const char * data_name,
         const double * value, int length ) const;
+    void write_doubleVector( const HDF5_Group &group, const char * data_name,
+        const double * value, int length ) const
+    { write_doubleVector( group.id(), data_name, value, length ); }
 
     // --- write a double array with given length at /data_name
     void write_doubleVector( const char * data_name,
@@ -125,6 +143,9 @@ class HDF5_Writer
     // --- write an int vector at /group_id/data_name
     void write_intVector( hid_t group_id,
         const char * data_name, const std::vector<int> &value ) const;
+    void write_intVector( const HDF5_Group &group, const char * data_name,
+        const std::vector<int> &value ) const
+    { write_intVector( group.id(), data_name, value ); }
 
     // --- write an int vector at /data_name
     void write_intVector( const char * data_name, 
@@ -133,10 +154,16 @@ class HDF5_Writer
     // --- write an unsigned int vector at /group_id/data_name
     void write_uintVector( hid_t group_id, const char * data_name, 
         const std::vector<unsigned int> &value ) const;
+    void write_uintVector( const HDF5_Group &group, const char * data_name,
+        const std::vector<unsigned int> &value ) const
+    { write_uintVector( group.id(), data_name, value ); }
 
     // --- write a double vector at /group_id/data_name
     void write_doubleVector( hid_t group_id, const char * data_name,
         const std::vector<double> &value ) const;
+    void write_doubleVector( const HDF5_Group &group, const char * data_name,
+        const std::vector<double> &value ) const
+    { write_doubleVector( group.id(), data_name, value ); }
 
     // --- write a double vector at /data_name
     void write_doubleVector( const char * data_name, 
@@ -147,6 +174,9 @@ class HDF5_Writer
     // --------------------------------------------------------------
     void write_Vector_3( hid_t group_id, const char * data_name,
         const std::array<double, 3> &value ) const;
+    void write_Vector_3( const HDF5_Group &group, const char * data_name,
+        const std::array<double, 3> &value ) const
+    { write_Vector_3( group.id(), data_name, value ); }
 
     void write_Vector_3( const char * data_name, 
         const std::array<double, 3> &value ) const;
@@ -156,6 +186,9 @@ class HDF5_Writer
     // --------------------------------------------------------------
     void write_Tensor2_3D( hid_t group_id, const char * data_name,
         const std::array<double, 9> &value ) const;
+    void write_Tensor2_3D( const HDF5_Group &group, const char * data_name,
+        const std::array<double, 9> &value ) const
+    { write_Tensor2_3D( group.id(), data_name, value ); }
 
     void write_Tensor2_3D( const char * data_name, 
         const std::array<double, 9> &value ) const;
@@ -166,10 +199,16 @@ class HDF5_Writer
     void write_intMatrix( hid_t group_id,
         const char * data_name, const std::vector<int> &value,
         int row_num, int col_num ) const;
+    void write_intMatrix( const HDF5_Group &group, const char * data_name,
+        const std::vector<int> &value, int row_num, int col_num ) const
+    { write_intMatrix( group.id(), data_name, value, row_num, col_num ); }
 
     void write_doubleMatrix( hid_t group_id, 
         const char * data_name, const std::vector<double> &value,
         int row_num, int col_num ) const;
+    void write_doubleMatrix( const HDF5_Group &group, const char * data_name,
+        const std::vector<double> &value, int row_num, int col_num ) const
+    { write_doubleMatrix( group.id(), data_name, value, row_num, col_num ); }
 
     // --------------------------------------------------------------
     // String
@@ -179,6 +218,9 @@ class HDF5_Writer
 
     void write_string( hid_t group_id, const char * data_name, 
         const std::string &string_input ) const;
+    void write_string( const HDF5_Group &group, const char * data_name,
+        const std::string &string_input ) const
+    { write_string( group.id(), data_name, string_input ); }
 
   private:
     hid_t file_id;

--- a/src/Mesh/EBC_Partition.cpp
+++ b/src/Mesh/EBC_Partition.cpp
@@ -99,7 +99,7 @@ void EBC_Partition::write_hdf5( const std::string &FileName,
 
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   hid_t file_id = h5w->get_file_id();
-  hid_t g_id = H5Gcreate(file_id, GroupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); 
+  HDF5_Group g_id = HDF5_Group::create(file_id, GroupName.c_str()); 
 
   h5w -> write_intScalar( g_id, "num_ebc", num_ebc );
 
@@ -117,8 +117,7 @@ void EBC_Partition::write_hdf5( const std::string &FileName,
     {
       const std::string sub_gname = groupbase + std::to_string(ii);
 
-      hid_t group_id = H5Gcreate(g_id, sub_gname.c_str(), 
-          H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      HDF5_Group group_id = HDF5_Group::create(g_id.id(), sub_gname.c_str());
 
       h5w->write_doubleVector( group_id, "local_cell_node_xyz", local_cell_node_xyz[ii] );
 
@@ -129,12 +128,8 @@ void EBC_Partition::write_hdf5( const std::string &FileName,
       h5w->write_intVector( group_id, "local_cell_node_pos", local_cell_node_pos[ii] );
 
       h5w->write_intVector( group_id, "local_cell_vol_id", local_cell_vol_id[ii] );
-
-      H5Gclose( group_id );
     }
   }
-
-  H5Gclose( g_id );
 }
 
 void EBC_Partition::print_info() const

--- a/src/Mesh/EBC_Partition_WallModel.cpp
+++ b/src/Mesh/EBC_Partition_WallModel.cpp
@@ -32,7 +32,7 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/weak", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/weak");
 
   h5w -> write_intScalar( g_id, "wall_model_type", wall_model_type );
 
@@ -46,8 +46,6 @@ void EBC_Partition_WallModel::write_hdf5(const std::string &FileName) const
   }
   else
     ;   // stop writing if wall_model_type = 0
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/EBC_Partition_outflow.cpp
+++ b/src/Mesh/EBC_Partition_outflow.cpp
@@ -61,7 +61,7 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
 
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
-  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
+  HDF5_Group g_id = HDF5_Group::open( file_id, GroupName.c_str() );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {
@@ -69,17 +69,13 @@ void EBC_Partition_outflow::write_hdf5( const std::string &FileName,
     {
       std::string subgroup_name( "ebcid_" );
       subgroup_name.append( std::to_string(ii) );
-      hid_t subgroup_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT );
+      HDF5_Group subgroup_id = HDF5_Group::open(g_id.id(), subgroup_name.c_str() );
 
       h5w->write_doubleVector( subgroup_id, "intNA", face_int_NA[ii] );
       h5w->write_intVector( subgroup_id, "LID_all_face_nodes", LID_all_face_nodes[ii] );
       h5w->write_Vector_3( subgroup_id, "out_normal", outvec[ii].to_std_array() );
-
-      H5Gclose( subgroup_id );
     }
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/EBC_Partition_outflow_MF.cpp
+++ b/src/Mesh/EBC_Partition_outflow_MF.cpp
@@ -78,7 +78,7 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
 
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
-  hid_t g_id = H5Gopen( file_id, GroupName.c_str(), H5P_DEFAULT );
+  HDF5_Group g_id = HDF5_Group::open( file_id, GroupName.c_str() );
 
   for(int ii=0; ii<num_ebc; ++ii)
   {
@@ -86,17 +86,13 @@ void EBC_Partition_outflow_MF::write_hdf5( const std::string &FileName,
     {
       std::string subgroup_name( "ebcid_" );
       subgroup_name.append( std::to_string(ii) );
-      hid_t subgroup_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT );
+      HDF5_Group subgroup_id = HDF5_Group::open(g_id.id(), subgroup_name.c_str() );
 
       h5w->write_doubleVector( subgroup_id, "intNA", face_int_NA[ii] );
       h5w->write_intVector( subgroup_id, "LID_all_face_nodes", LID_all_face_nodes[ii] );
       h5w->write_Vector_3( subgroup_id, "out_normal", outvec[ii].to_std_array() );
-
-      H5Gclose( subgroup_id );
     }
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Gmsh_FileIO.cpp
+++ b/src/Mesh/Gmsh_FileIO.cpp
@@ -912,8 +912,7 @@ void Gmsh_FileIO::write_sur_h5( int index_2d,
     // Record info
     std::string name_1d_domain(slash);
     name_1d_domain.append( std::to_string( static_cast<int>(ii) ) );
-    hid_t g_id = H5Gcreate( file_id, name_1d_domain.c_str(), 
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::create( file_id, name_1d_domain.c_str());
 
     h5w->write_string(g_id, "name", phy_1d_name[ index_1d[ii] ] );
     h5w->write_intScalar(g_id, "phy_tag", index_1d[ii]);
@@ -926,8 +925,6 @@ void Gmsh_FileIO::write_sur_h5( int index_2d,
     h5w->write_intVector(g_id, "pt_idx", bcpt);
     h5w->write_intVector(g_id, "edge2elem", face2elem);
     h5w->write_doubleVector(g_id, "pt_coor", surpt);
-
-    H5Gclose(g_id);
   }
 }
 
@@ -1079,8 +1076,7 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     // Record info
     std::string name_2d_domain(slash);
     name_2d_domain.append( std::to_string( static_cast<int>(ii) ) );
-    hid_t g_id = H5Gcreate( file_id, name_2d_domain.c_str(),
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::create( file_id, name_2d_domain.c_str());
 
     h5w->write_string(g_id, "name", phy_2d_name[ index_2d[ii] ] );
     h5w->write_intScalar(g_id, "phy_tag", index_2d[ii]);
@@ -1093,8 +1089,6 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     h5w->write_intVector(g_id, "pt_idx", bcpt);
     h5w->write_intVector(g_id, "face2elem", face2elem);
     h5w->write_doubleVector(g_id, "pt_coor", surpt);
-
-    H5Gclose(g_id);
   } // End-loop-over-2d-face
 }
 
@@ -1249,8 +1243,7 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     // Record info
     std::string name_2d_domain(slash);
     name_2d_domain.append( std::to_string( static_cast<int>(ii) ) );
-    hid_t g_id = H5Gcreate( file_id, name_2d_domain.c_str(),
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+    HDF5_Group g_id = HDF5_Group::create( file_id, name_2d_domain.c_str());
 
     h5w->write_string(g_id, "name", phy_2d_name[ index_2d[ii] ] );
     h5w->write_intScalar(g_id, "phy_tag", index_2d[ii]);
@@ -1263,8 +1256,6 @@ void Gmsh_FileIO::write_vol_h5( int index_3d,
     h5w->write_intVector(g_id, "pt_idx", bcpt);
     h5w->write_intVector(g_id, "face2elem", face2elem);
     h5w->write_doubleVector(g_id, "pt_coor", surpt);
-
-    H5Gclose(g_id);
   } // End-loop-over-2d-face
 }
 

--- a/src/Mesh/Interface_Partition.cpp
+++ b/src/Mesh/Interface_Partition.cpp
@@ -173,7 +173,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>( fName, H5F_ACC_RDWR );
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/sliding", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/sliding");
 
   h5w -> write_intScalar( g_id, "num_interface", num_pair );
 
@@ -190,7 +190,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
     std::string subgroup_name(groupbase);
     subgroup_name.append( std::to_string(ii) );
 
-    hid_t group_id = H5Gcreate(g_id, subgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group group_id = HDF5_Group::create(g_id.id(), subgroup_name.c_str());
 
     h5w -> write_intScalar( group_id, "num_fixed_node", VEC_T::get_size(fixed_global_node[ii]) );
 
@@ -235,19 +235,13 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
       std::string subsubgroup_name(subgroupbase);
       subsubgroup_name.append( std::to_string(jj) );
 
-      hid_t subgroup_id = H5Gcreate(group_id, subsubgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      HDF5_Group subgroup_id = HDF5_Group::create(group_id.id(), subsubgroup_name.c_str());
 
       h5w -> write_intVector( subgroup_id, "tagged_fixed_cell", tagged_fixed_ele[ii][jj] );
 
       h5w -> write_intVector( subgroup_id, "tagged_rotated_cell", tagged_rotated_ele[ii][jj] );
-
-      H5Gclose( subgroup_id );
     }
-
-    H5Gclose( group_id );
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition.cpp
+++ b/src/Mesh/NBC_Partition.cpp
@@ -86,7 +86,7 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
   auto h5writer = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5writer->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, GroupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, GroupName.c_str());
 
   h5writer->write_intVector( g_id, "LID", LID );
 
@@ -107,8 +107,6 @@ void NBC_Partition::write_hdf5( const std::string &FileName,
   h5writer->write_intVector(g_id, "Num_LD",  Num_LD);
   h5writer->write_intVector(g_id, "Num_LPS", Num_LPS);
   h5writer->write_intVector(g_id, "Num_LPM", Num_LPM);
-
-  H5Gclose(g_id);
 }
 
 void NBC_Partition::print_info() const

--- a/src/Mesh/NBC_Partition_MF.cpp
+++ b/src/Mesh/NBC_Partition_MF.cpp
@@ -152,9 +152,9 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
   auto h5writer = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5writer->get_file_id();
 
-  hid_t g_nbc_id = H5Gopen(file_id, GroupName.c_str(), H5P_DEFAULT);
+  HDF5_Group g_nbc_id = HDF5_Group::open(file_id, GroupName.c_str());
 
-  hid_t g_id = H5Gcreate(g_nbc_id, "MF", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(g_nbc_id.id(), "MF");
 
   h5writer->write_intVector( g_id, "LID", LID_MF );
 
@@ -176,7 +176,6 @@ void NBC_Partition_MF::write_hdf5( const std::string &FileName,
   h5writer->write_intVector(g_id, "Num_LPS", Num_LPS);
   h5writer->write_intVector(g_id, "Num_LPM", Num_LPM);
 
-  H5Gclose(g_id); H5Gclose(g_nbc_id);
-}
+  }
 
 // EOF

--- a/src/Mesh/NBC_Partition_inflow.cpp
+++ b/src/Mesh/NBC_Partition_inflow.cpp
@@ -119,7 +119,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/inflow", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/inflow");
 
   h5w -> write_intScalar( g_id, "num_nbc", num_nbc );
 
@@ -128,8 +128,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
     std::string subgroup_name( "nbcid_" );
     subgroup_name.append( std::to_string(ii) );
 
-    hid_t group_id = H5Gcreate(g_id, subgroup_name.c_str(),
-        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group group_id = HDF5_Group::create(g_id.id(), subgroup_name.c_str());
 
     h5w->write_intScalar( group_id, "Num_LD", Num_LD[ii] );
     
@@ -162,11 +161,7 @@ void NBC_Partition_inflow::write_hdf5( const std::string &FileName ) const
     h5w->write_intVector( group_id, "local_node_pos", local_node_pos[ii] );
 
     h5w->write_intVector( group_id, "local_global_cell", local_global_cell[ii] );
-
-    H5Gclose( group_id );
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_inflow_MF.cpp
+++ b/src/Mesh/NBC_Partition_inflow_MF.cpp
@@ -36,19 +36,17 @@ void NBC_Partition_inflow_MF::write_hdf5( const std::string &FileName ) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gopen(file_id, "/inflow", H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::open(file_id, "/inflow");
 
   for(int ii=0; ii<num_nbc; ++ii)
   {
     std::string subgroup_name( "nbcid_" );
     subgroup_name.append( std::to_string(ii) );
 
-    hid_t group_id = H5Gopen(g_id, subgroup_name.c_str(), H5P_DEFAULT);
+    HDF5_Group group_id = HDF5_Group::open(g_id.id(), subgroup_name.c_str());
 
     h5w->write_intVector( group_id, "LDN_MF", LDN_MF[ii] );
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/NBC_Partition_rotated.cpp
+++ b/src/Mesh/NBC_Partition_rotated.cpp
@@ -98,7 +98,7 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
   auto h5w = SYS_T::make_unique<HDF5_Writer>(fName, H5F_ACC_RDWR);
   const hid_t file_id = h5w->get_file_id();
 
-  hid_t g_id = H5Gcreate(file_id, "/rotated_nbc", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group g_id = HDF5_Group::create(file_id, "/rotated_nbc");
 
   h5w->write_intScalar( g_id, "Num_LD", Num_LD );
   
@@ -130,8 +130,6 @@ void NBC_Partition_rotated::write_hdf5( const std::string &FileName ) const
 
     h5w->write_intVector( g_id, "local_global_cell", local_global_cell );   
   }
-
-  H5Gclose( g_id );
 }
 
 // EOF

--- a/src/Mesh/Part_FEM.cpp
+++ b/src/Mesh/Part_FEM.cpp
@@ -333,16 +333,13 @@ void Part_FEM::write( const std::string &inputFileName ) const
   const hid_t file_id = h5w->get_file_id();
 
   // group 1: local element
-  hid_t group_id_1 = H5Gcreate(file_id, "/Local_Elem", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_1 = HDF5_Group::create(file_id, "/Local_Elem");
 
   h5w->write_intScalar( group_id_1, "nlocalele", nlocalele );
   h5w->write_intVector( group_id_1, "elem_loc", elem_loc );
   h5w->write_intVector( group_id_1, "elem_rotated_tag", elem_rotated_tag );
-
-  H5Gclose( group_id_1 );
-
   // group 2: local node
-  hid_t group_id_2 = H5Gcreate( file_id, "/Local_Node", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
+  HDF5_Group group_id_2 = HDF5_Group::create( file_id, "/Local_Node");
 
   h5w->write_intScalar( group_id_2, "nlocalnode", nlocalnode );
   h5w->write_intScalar( group_id_2, "nghostnode", nghostnode );
@@ -355,11 +352,8 @@ void Part_FEM::write( const std::string &inputFileName ) const
   h5w->write_intVector( group_id_2, "local_to_global", local_to_global );
   if(nghostnode > 0)
     h5w->write_intVector( group_id_2, "node_ghost", node_ghost );
-
-  H5Gclose( group_id_2 );
-
   // group 3: global mesh info
-  hid_t group_id_3 = H5Gcreate(file_id, "/Global_Mesh_Info", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_3 = HDF5_Group::create(file_id, "/Global_Mesh_Info");
 
   h5w->write_intScalar( group_id_3, "nElem", nElem );
   h5w->write_intScalar( group_id_3, "nFunc", nFunc );
@@ -373,19 +367,13 @@ void Part_FEM::write( const std::string &inputFileName ) const
   h5w->write_intScalar( group_id_3, "field_id", field_id );
   h5w->write_intScalar( group_id_3, "is_geo_field", (is_geo_field ? 1 : 0) );
   h5w->write_string( group_id_3, "field_name", field_name );
-
-  H5Gclose( group_id_3 );
-
   // group 4: part info
-  hid_t group_id_4 = H5Gcreate( file_id, "/Part_Info", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); 
+  HDF5_Group group_id_4 = HDF5_Group::create( file_id, "/Part_Info"); 
 
   h5w->write_intScalar( group_id_4, "cpu_rank", cpu_rank );
   h5w->write_intScalar( group_id_4, "cpu_size", cpu_size );
-
-  H5Gclose( group_id_4 );
-
   // group 5: LIEN
-  hid_t group_id_5 = H5Gcreate(file_id, "/LIEN", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_5 = HDF5_Group::create(file_id, "/LIEN");
 
   std::vector<int> row_LIEN(nlocalele * nLocBas, -1);
 
@@ -396,19 +384,14 @@ void Part_FEM::write( const std::string &inputFileName ) const
   }
 
   h5w -> write_intMatrix( group_id_5, "LIEN", row_LIEN, nlocalele, nLocBas);
-
-  H5Gclose( group_id_5 );
-
   // group 6: control points
   if( is_geo_field == true )
   {
-    hid_t group_id_6 = H5Gcreate(file_id, "/ctrlPts_loc", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    HDF5_Group group_id_6 = HDF5_Group::create(file_id, "/ctrlPts_loc");
 
     h5w -> write_doubleVector( group_id_6, "ctrlPts_x_loc", ctrlPts_x_loc );
     h5w -> write_doubleVector( group_id_6, "ctrlPts_y_loc", ctrlPts_y_loc );
     h5w -> write_doubleVector( group_id_6, "ctrlPts_z_loc", ctrlPts_z_loc );
-
-    H5Gclose( group_id_6 );
   }
 }
 

--- a/src/Mesh/Part_FEM_FSI.cpp
+++ b/src/Mesh/Part_FEM_FSI.cpp
@@ -50,14 +50,11 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
   const hid_t file_id = h5w->get_file_id();
 
   // open group 1: local element
-  hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);
+  HDF5_Group group_id_1 = HDF5_Group::open(file_id, "/Local_Elem");
 
   h5w->write_intVector( group_id_1, "elem_phy_tag", elem_phy_tag );
-
-  H5Gclose( group_id_1 );
-
   // group 2: local node
-  hid_t group_id_2 = H5Gopen( file_id, "/Local_Node", H5P_DEFAULT );
+  HDF5_Group group_id_2 = HDF5_Group::open( file_id, "/Local_Node");
 
   h5w->write_intScalar( group_id_2, "nlocalnode_fluid", nlocalnode_fluid );
   h5w->write_intScalar( group_id_2, "nlocalnode_solid", nlocalnode_solid );
@@ -67,15 +64,10 @@ void Part_FEM_FSI::write( const std::string &inputFileName ) const
 
   if( nlocalnode_solid > 0 )
     h5w->write_intVector( group_id_2, "node_loc_solid", node_loc_solid );
-
-  H5Gclose( group_id_2 );
-
   // group 7: DOF mapper
-  hid_t group_id_7 = H5Gcreate(file_id, "/DOF_mapper", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  HDF5_Group group_id_7 = HDF5_Group::create(file_id, "/DOF_mapper");
 
   h5w -> write_intScalar( group_id_7, "start_idx", start_idx );
-
-  H5Gclose( group_id_7 );
 }
 
 // EOF

--- a/src/Mesh/Part_FEM_Rotated.cpp
+++ b/src/Mesh/Part_FEM_Rotated.cpp
@@ -48,14 +48,11 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
   const hid_t file_id = h5w->get_file_id();
 
   // open group 1: local element
-  hid_t group_id_1 = H5Gopen(file_id, "/Local_Elem", H5P_DEFAULT);
+  HDF5_Group group_id_1 = HDF5_Group::open(file_id, "/Local_Elem");
 
   h5w->write_intVector( group_id_1, "elem_phy_tag", elem_tag );
-
-  H5Gclose( group_id_1 );
-
   // group 2: local node
-  hid_t group_id_2 = H5Gopen( file_id, "/Local_Node", H5P_DEFAULT );
+  HDF5_Group group_id_2 = HDF5_Group::open( file_id, "/Local_Node");
 
   h5w->write_intScalar( group_id_2, "nlocalnode_fixed", nlocalnode_fixed );
   h5w->write_intScalar( group_id_2, "nlocalnode_rotated", nlocalnode_rotated );
@@ -65,8 +62,6 @@ void Part_FEM_Rotated::write( const std::string &inputFileName ) const
 
   if( nlocalnode_rotated > 0 )
     h5w->write_intVector( group_id_2, "node_loc_rotated", node_loc_rotated );
-
-  H5Gclose( group_id_2 );
 }
 
 // EOF

--- a/src/System/HDF5_Reader.cpp
+++ b/src/System/HDF5_Reader.cpp
@@ -1,18 +1,12 @@
 #include "HDF5_Reader.hpp"
 
-void HDF5_Reader::read_intArray(const char * const &group_name,
-    const char * const &data_name,
+void HDF5_Reader::read_intArray(const char * group_name,
+    const char * data_name,
     hid_t &data_rank, hsize_t * &data_dims, int * &data  ) const
 {
-  const HDF5_Group group_id = HDF5_Group::open( file_id, group_name );
-  read_intArray( group_id, data_name, data_rank, data_dims, data );
-}
-
-void HDF5_Reader::read_intArray( const HDF5_Group &group,
-    const char * const &data_name,
-    hid_t &data_rank, hsize_t * &data_dims, int * &data ) const
-{
-  hid_t data_id = H5Dopen(group.id(), data_name, H5P_DEFAULT);
+  // open group file and data file
+  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
+  hid_t data_id = H5Dopen(group_id, data_name, H5P_DEFAULT);
 
   // retrive dataspace of the dataset
   hid_t data_space = H5Dget_space( data_id );
@@ -48,21 +42,16 @@ void HDF5_Reader::read_intArray( const HDF5_Group &group,
   H5Sclose( mem_space );
   H5Sclose( data_space );
   H5Dclose( data_id );
+  H5Gclose( group_id );
 }
 
-void HDF5_Reader::read_doubleArray(const char * const &group_name,
-    const char * const &data_name,
+void HDF5_Reader::read_doubleArray(const char * group_name,
+    const char * data_name,
     hid_t &data_rank, hsize_t * &data_dims, double * &data  ) const
 {
-  const HDF5_Group group_id = HDF5_Group::open( file_id, group_name );
-  read_doubleArray( group_id, data_name, data_rank, data_dims, data );
-}
-
-void HDF5_Reader::read_doubleArray( const HDF5_Group &group,
-    const char * const &data_name,
-    hid_t &data_rank, hsize_t * &data_dims, double * &data ) const
-{
-  hid_t data_id  = H5Dopen(group.id(), data_name, H5P_DEFAULT);
+  // open group file and data file
+  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
+  hid_t data_id  = H5Dopen(group_id, data_name, H5P_DEFAULT);
 
   // retrive dataspace of the dataset
   hid_t data_space = H5Dget_space( data_id );
@@ -95,28 +84,22 @@ void HDF5_Reader::read_doubleArray( const HDF5_Group &group,
   H5Sclose( mem_space );
   H5Sclose( data_space );
   H5Dclose( data_id );
+  H5Gclose( group_id );
 }
 
-int HDF5_Reader::read_intScalar( const char * const &group_name,
-    const char * const &data_name ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_intScalar( group, data_name );
-}
-
-int HDF5_Reader::read_intScalar( const HDF5_Group &group,
-    const char * const &data_name ) const
+int HDF5_Reader::read_intScalar( const char * group_name,
+    const char * data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   int * intdata;
 
-  read_intArray( group, data_name, drank, ddims, intdata );
+  read_intArray( group_name, data_name, drank, ddims, intdata );
 
   if( drank != 1 || ddims[0] != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_intScalar read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_intScalar read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a scalar! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -127,26 +110,19 @@ int HDF5_Reader::read_intScalar( const HDF5_Group &group,
   return outdata;
 }
 
-double HDF5_Reader::read_doubleScalar( const char * const &group_name,
-    const char * const &data_name ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_doubleScalar( group, data_name );
-}
-
-double HDF5_Reader::read_doubleScalar( const HDF5_Group &group,
-    const char * const &data_name ) const
+double HDF5_Reader::read_doubleScalar( const char * group_name,
+    const char * data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group, data_name, drank, ddims, ddata );
+  read_doubleArray( group_name, data_name, drank, ddims, ddata );
 
   if( drank != 1 || ddims[0] != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_doubleScalar read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_doubleScalar read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a scalar! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -157,26 +133,19 @@ double HDF5_Reader::read_doubleScalar( const HDF5_Group &group,
   return outdata;
 }
 
-std::vector<int> HDF5_Reader::read_intVector( const char * const &group_name,
-    const char * const &data_name ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_intVector( group, data_name );
-}
-
-std::vector<int> HDF5_Reader::read_intVector( const HDF5_Group &group,
-    const char * const &data_name ) const
+std::vector<int> HDF5_Reader::read_intVector( const char * group_name,
+    const char * data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   int * intdata;
 
-  read_intArray( group, data_name, drank, ddims, intdata );
+  read_intArray( group_name, data_name, drank, ddims, intdata );
 
   if( drank != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_intVector read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_intVector read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a 1D vector! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -188,26 +157,19 @@ std::vector<int> HDF5_Reader::read_intVector( const HDF5_Group &group,
   return out;
 }
 
-std::vector<double> HDF5_Reader::read_doubleVector( const char * const &group_name,
-    const char * const &data_name ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_doubleVector( group, data_name );
-}
-
-std::vector<double> HDF5_Reader::read_doubleVector( const HDF5_Group &group,
-    const char * const &data_name ) const
+std::vector<double> HDF5_Reader::read_doubleVector( const char * group_name,
+    const char * data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group, data_name, drank, ddims, ddata );
+  read_doubleArray( group_name, data_name, drank, ddims, ddata );
 
   if( drank != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_doubleVector read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_doubleVector read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a 1D vector! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -218,26 +180,19 @@ std::vector<double> HDF5_Reader::read_doubleVector( const HDF5_Group &group,
   return out;
 }
 
-std::array<double, 3> HDF5_Reader::read_Vector_3( const char * const &group_name,
-    const char * const &data_name ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_Vector_3( group, data_name );
-}
-
-std::array<double, 3> HDF5_Reader::read_Vector_3( const HDF5_Group &group,
-    const char * const &data_name ) const
+std::array<double, 3> HDF5_Reader::read_Vector_3( const char * group_name,
+    const char * data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group, data_name, drank, ddims, ddata );
+  read_doubleArray( group_name, data_name, drank, ddims, ddata );
 
   if( drank != 1 || ddims[0] != 3 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_Vector_3 read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_Vector_3 read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a 3-component vector! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -248,26 +203,19 @@ std::array<double, 3> HDF5_Reader::read_Vector_3( const HDF5_Group &group,
   return out;
 }
 
-std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const char * const &group_name,
-    const char * const &data_name ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_Tensor2_3D( group, data_name );
-}
-
-std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const HDF5_Group &group,
-    const char * const &data_name ) const
+std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const char * group_name,
+    const char * data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group, data_name, drank, ddims, ddata );
+  read_doubleArray( group_name, data_name, drank, ddims, ddata );
 
   if( drank != 1 || ddims[0] != 9 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_Tensor2_3D read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_Tensor2_3D read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a 3x3 matrix! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -278,26 +226,19 @@ std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const HDF5_Group &group,
   return out;
 }
 
-std::vector<int> HDF5_Reader::read_intMatrix( const char * const &group_name,
-    const char * const &data_name, int &num_row, int &num_col ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_intMatrix( group, data_name, num_row, num_col );
-}
-
-std::vector<int> HDF5_Reader::read_intMatrix( const HDF5_Group &group,
-    const char * const &data_name, int &num_row, int &num_col ) const
+std::vector<int> HDF5_Reader::read_intMatrix( const char * group_name,
+    const char * data_name, int &num_row, int &num_col ) const
 {
   hid_t drank;
   hsize_t * ddims;
   int * intdata;
 
-  read_intArray( group, data_name, drank, ddims, intdata );
+  read_intArray( group_name, data_name, drank, ddims, intdata );
 
   if( drank != 2 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_intMatrix read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_intMatrix read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a 2D matrix! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -312,26 +253,19 @@ std::vector<int> HDF5_Reader::read_intMatrix( const HDF5_Group &group,
   return out;
 }
 
-std::vector<double> HDF5_Reader::read_doubleMatrix( const char * const &group_name,
-    const char * const &data_name, int &num_row, int &num_col ) const
-{
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_doubleMatrix( group, data_name, num_row, num_col );
-}
-
-std::vector<double> HDF5_Reader::read_doubleMatrix( const HDF5_Group &group,
-    const char * const &data_name, int &num_row, int &num_col ) const
+std::vector<double> HDF5_Reader::read_doubleMatrix( const char * group_name,
+    const char * data_name, int &num_row, int &num_col ) const
 {
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group, data_name, drank, ddims, ddata );
+  read_doubleArray( group_name, data_name, drank, ddims, ddata );
 
   if( drank != 2 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_doubleMatrix read data at "<<"<group>";
+    oss<<"Error: HDF5_Reader::read_doubleMatrix read data at "<<group_name;
     oss<<" with name "<<data_name<<" is not a 2D matrix! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -346,17 +280,12 @@ std::vector<double> HDF5_Reader::read_doubleMatrix( const HDF5_Group &group,
   return out;
 }
 
-std::string HDF5_Reader::read_string( const char * const &group_name,
-    const char * const &data_name ) const
+std::string HDF5_Reader::read_string( const char * group_name,
+    const char * data_name ) const
 {
-  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
-  return read_string( group, data_name );
-}
-
-std::string HDF5_Reader::read_string( const HDF5_Group &group,
-    const char * const &data_name ) const
-{
-  hid_t data_id  = H5Dopen(group.id(), data_name, H5P_DEFAULT);
+  // open group file and data file
+  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
+  hid_t data_id  = H5Dopen(group_id, data_name, H5P_DEFAULT);
 
   hid_t filetype = H5Dget_type( data_id );
   size_t sdim = H5Tget_size( filetype );
@@ -388,6 +317,7 @@ std::string HDF5_Reader::read_string( const HDF5_Group &group,
   H5Tclose( filetype );
   H5Sclose( data_space );
   H5Dclose( data_id );
+  H5Gclose( group_id );
 
   return string_out;
 }

--- a/src/System/HDF5_Reader.cpp
+++ b/src/System/HDF5_Reader.cpp
@@ -4,9 +4,15 @@ void HDF5_Reader::read_intArray(const char * const &group_name,
     const char * const &data_name,
     hid_t &data_rank, hsize_t * &data_dims, int * &data  ) const
 {
-  // open group file and data file
-  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
-  hid_t data_id = H5Dopen(group_id, data_name, H5P_DEFAULT);
+  const HDF5_Group group_id = HDF5_Group::open( file_id, group_name );
+  read_intArray( group_id, data_name, data_rank, data_dims, data );
+}
+
+void HDF5_Reader::read_intArray( const HDF5_Group &group,
+    const char * const &data_name,
+    hid_t &data_rank, hsize_t * &data_dims, int * &data ) const
+{
+  hid_t data_id = H5Dopen(group.id(), data_name, H5P_DEFAULT);
 
   // retrive dataspace of the dataset
   hid_t data_space = H5Dget_space( data_id );
@@ -42,16 +48,21 @@ void HDF5_Reader::read_intArray(const char * const &group_name,
   H5Sclose( mem_space );
   H5Sclose( data_space );
   H5Dclose( data_id );
-  H5Gclose( group_id );
 }
 
 void HDF5_Reader::read_doubleArray(const char * const &group_name,
     const char * const &data_name,
     hid_t &data_rank, hsize_t * &data_dims, double * &data  ) const
 {
-  // open group file and data file
-  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
-  hid_t data_id  = H5Dopen(group_id, data_name, H5P_DEFAULT);
+  const HDF5_Group group_id = HDF5_Group::open( file_id, group_name );
+  read_doubleArray( group_id, data_name, data_rank, data_dims, data );
+}
+
+void HDF5_Reader::read_doubleArray( const HDF5_Group &group,
+    const char * const &data_name,
+    hid_t &data_rank, hsize_t * &data_dims, double * &data ) const
+{
+  hid_t data_id  = H5Dopen(group.id(), data_name, H5P_DEFAULT);
 
   // retrive dataspace of the dataset
   hid_t data_space = H5Dget_space( data_id );
@@ -84,22 +95,28 @@ void HDF5_Reader::read_doubleArray(const char * const &group_name,
   H5Sclose( mem_space );
   H5Sclose( data_space );
   H5Dclose( data_id );
-  H5Gclose( group_id );
 }
 
 int HDF5_Reader::read_intScalar( const char * const &group_name,
+    const char * const &data_name ) const
+{
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_intScalar( group, data_name );
+}
+
+int HDF5_Reader::read_intScalar( const HDF5_Group &group,
     const char * const &data_name ) const
 {
   hid_t drank;
   hsize_t * ddims;
   int * intdata;
 
-  read_intArray( group_name, data_name, drank, ddims, intdata );
+  read_intArray( group, data_name, drank, ddims, intdata );
 
   if( drank != 1 || ddims[0] != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_intScalar read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_intScalar read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a scalar! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -113,16 +130,23 @@ int HDF5_Reader::read_intScalar( const char * const &group_name,
 double HDF5_Reader::read_doubleScalar( const char * const &group_name,
     const char * const &data_name ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_doubleScalar( group, data_name );
+}
+
+double HDF5_Reader::read_doubleScalar( const HDF5_Group &group,
+    const char * const &data_name ) const
+{
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group_name, data_name, drank, ddims, ddata );
+  read_doubleArray( group, data_name, drank, ddims, ddata );
 
   if( drank != 1 || ddims[0] != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_doubleScalar read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_doubleScalar read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a scalar! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -136,16 +160,23 @@ double HDF5_Reader::read_doubleScalar( const char * const &group_name,
 std::vector<int> HDF5_Reader::read_intVector( const char * const &group_name,
     const char * const &data_name ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_intVector( group, data_name );
+}
+
+std::vector<int> HDF5_Reader::read_intVector( const HDF5_Group &group,
+    const char * const &data_name ) const
+{
   hid_t drank;
   hsize_t * ddims;
   int * intdata;
 
-  read_intArray( group_name, data_name, drank, ddims, intdata );
+  read_intArray( group, data_name, drank, ddims, intdata );
 
   if( drank != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_intVector read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_intVector read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a 1D vector! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -160,16 +191,23 @@ std::vector<int> HDF5_Reader::read_intVector( const char * const &group_name,
 std::vector<double> HDF5_Reader::read_doubleVector( const char * const &group_name,
     const char * const &data_name ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_doubleVector( group, data_name );
+}
+
+std::vector<double> HDF5_Reader::read_doubleVector( const HDF5_Group &group,
+    const char * const &data_name ) const
+{
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group_name, data_name, drank, ddims, ddata );
+  read_doubleArray( group, data_name, drank, ddims, ddata );
 
   if( drank != 1 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_doubleVector read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_doubleVector read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a 1D vector! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -183,16 +221,23 @@ std::vector<double> HDF5_Reader::read_doubleVector( const char * const &group_na
 std::array<double, 3> HDF5_Reader::read_Vector_3( const char * const &group_name,
     const char * const &data_name ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_Vector_3( group, data_name );
+}
+
+std::array<double, 3> HDF5_Reader::read_Vector_3( const HDF5_Group &group,
+    const char * const &data_name ) const
+{
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group_name, data_name, drank, ddims, ddata );
+  read_doubleArray( group, data_name, drank, ddims, ddata );
 
   if( drank != 1 || ddims[0] != 3 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_Vector_3 read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_Vector_3 read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a 3-component vector! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -206,16 +251,23 @@ std::array<double, 3> HDF5_Reader::read_Vector_3( const char * const &group_name
 std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const char * const &group_name,
     const char * const &data_name ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_Tensor2_3D( group, data_name );
+}
+
+std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const HDF5_Group &group,
+    const char * const &data_name ) const
+{
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group_name, data_name, drank, ddims, ddata );
+  read_doubleArray( group, data_name, drank, ddims, ddata );
 
   if( drank != 1 || ddims[0] != 9 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_Tensor2_3D read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_Tensor2_3D read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a 3x3 matrix! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -229,16 +281,23 @@ std::array<double, 9> HDF5_Reader::read_Tensor2_3D( const char * const &group_na
 std::vector<int> HDF5_Reader::read_intMatrix( const char * const &group_name,
     const char * const &data_name, int &num_row, int &num_col ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_intMatrix( group, data_name, num_row, num_col );
+}
+
+std::vector<int> HDF5_Reader::read_intMatrix( const HDF5_Group &group,
+    const char * const &data_name, int &num_row, int &num_col ) const
+{
   hid_t drank;
   hsize_t * ddims;
   int * intdata;
 
-  read_intArray( group_name, data_name, drank, ddims, intdata );
+  read_intArray( group, data_name, drank, ddims, intdata );
 
   if( drank != 2 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_intMatrix read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_intMatrix read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a 2D matrix! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -256,16 +315,23 @@ std::vector<int> HDF5_Reader::read_intMatrix( const char * const &group_name,
 std::vector<double> HDF5_Reader::read_doubleMatrix( const char * const &group_name,
     const char * const &data_name, int &num_row, int &num_col ) const
 {
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_doubleMatrix( group, data_name, num_row, num_col );
+}
+
+std::vector<double> HDF5_Reader::read_doubleMatrix( const HDF5_Group &group,
+    const char * const &data_name, int &num_row, int &num_col ) const
+{
   hid_t drank;
   hsize_t * ddims;
   double * ddata;
 
-  read_doubleArray( group_name, data_name, drank, ddims, ddata );
+  read_doubleArray( group, data_name, drank, ddims, ddata );
 
   if( drank != 2 )
   {
     std::ostringstream oss;
-    oss<<"Error: HDF5_Reader::read_doubleMatrix read data at "<<group_name;
+    oss<<"Error: HDF5_Reader::read_doubleMatrix read data at "<<"<group>";
     oss<<" with name "<<data_name<<" is not a 2D matrix! \n";
     SYS_T::print_fatal( oss.str().c_str() );
   }
@@ -283,9 +349,14 @@ std::vector<double> HDF5_Reader::read_doubleMatrix( const char * const &group_na
 std::string HDF5_Reader::read_string( const char * const &group_name,
     const char * const &data_name ) const
 {
-  // open group file and data file
-  hid_t group_id = H5Gopen(file_id, group_name, H5P_DEFAULT);
-  hid_t data_id  = H5Dopen(group_id, data_name, H5P_DEFAULT);
+  const HDF5_Group group = HDF5_Group::open( file_id, group_name );
+  return read_string( group, data_name );
+}
+
+std::string HDF5_Reader::read_string( const HDF5_Group &group,
+    const char * const &data_name ) const
+{
+  hid_t data_id  = H5Dopen(group.id(), data_name, H5P_DEFAULT);
 
   hid_t filetype = H5Dget_type( data_id );
   size_t sdim = H5Tget_size( filetype );
@@ -317,7 +388,6 @@ std::string HDF5_Reader::read_string( const char * const &group_name,
   H5Tclose( filetype );
   H5Sclose( data_space );
   H5Dclose( data_id );
-  H5Gclose( group_id );
 
   return string_out;
 }


### PR DESCRIPTION
### Motivation
- Eliminate scattered manual `H5Gcreate`/`H5Gopen`/`H5Gclose` usage and the associated leak/double-close risk by adopting an RAII wrapper for HDF5 group handles.
- Allow existing HDF5 read/write APIs to accept the RAII handle with minimal call-site changes so users can switch to safe group management incrementally.

### Description
- Introduced and used the `HDF5_Group` RAII wrapper and added `#include "HDF5_Group.hpp"` where needed to accept RAII group handles.
- Added `HDF5_Writer` overloads that take `const HDF5_Group &` and forward to the existing `hid_t`-based implementations to preserve current functionality without call-site churn (`include/HDF5_Writer.hpp`).
- Added `HDF5_Reader` overloads that accept `const HDF5_Group &` and refactored `src/System/HDF5_Reader.cpp` so the string/group-name based methods open an `HDF5_Group` and delegate to the new overloads, removing manual `H5Gclose` calls.
- Replaced direct `H5Gcreate`/`H5Gopen`/`H5Gclose` call-sites across mesh and preprocess code to use `HDF5_Group::create/open` and pass `HDF5_Group` to writer/reader calls (many `src/Mesh/*.cpp` and `examples/ale_ns_rotate/preprocess.cpp` were updated); manual `H5Gclose` calls were removed.

### Testing
- Ran repository searches to verify transformation of direct HDF5 group APIs (`rg "H5G(create|open|close)"` and `rg "HDF5_Group::(open|create)"`) and validated no top-level lingering `H5Gclose` calls in touched files, which succeeded.
- Performed a quick argument-count sanity check script (`python` check) over `HDF5_Group::open/create` usages to ensure call signatures are consistent, which passed.
- Attempted to build with `cmake -S . -B build && cmake --build build -j2`, but the build could not be run in this environment because the repository root lacks a top-level `CMakeLists.txt` (diagnostic, not a code failure).
- Changes were committed locally (branch commit message: "Adopt HDF5_Group RAII wrapper across HDF5 group usage") and no compile-time regressions were validated here due to the missing top-level build configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c3e90f00832a8db1a8adb3eb983a)