### PR TITLE
Add override specifiers to ALocal_EBC_outflow methods

### DIFF
--- a/include/ALocal_EBC_outflow.hpp
+++ b/include/ALocal_EBC_outflow.hpp
@@ -21,9 +21,9 @@ class ALocal_EBC_outflow : public ALocal_EBC
     ALocal_EBC_outflow( const HDF5_Reader * const &h5r,
         const std::string &gname="/ebc" );
 
-    virtual ~ALocal_EBC_outflow() = default;
+    ~ALocal_EBC_outflow() override = default;
 
-    virtual void print_info() const;
+    void print_info() const override;
 
     // ------------------------------------------------------------------------
     // The following get functions will give meaningful data if the
@@ -31,13 +31,13 @@ class ALocal_EBC_outflow : public ALocal_EBC
     // surface
     // Note, the get functions do NOT check the range of the ii index
     // ------------------------------------------------------------------------
-    virtual int get_num_face_nodes(int ii) const {return num_face_nodes[ii];}
+    int get_num_face_nodes(int ii) const override {return num_face_nodes[ii];}
 
-    virtual std::vector<double> get_intNA(int ii) const {return intNA[ii];}
+    std::vector<double> get_intNA(int ii) const override {return intNA[ii];}
 
-    virtual std::vector<int> get_LID(int ii) const {return LID[ii];}
+    std::vector<int> get_LID(int ii) const override {return LID[ii];}
 
-    virtual Vector_3 get_outvec( int ii ) const {return outvec[ii];}
+    Vector_3 get_outvec( int ii ) const override {return outvec[ii];}
 
   protected:
     // Length num_ebc.


### PR DESCRIPTION
### Motivation
- Make overrides in the `ALocal_EBC_outflow` derived class explicit so the compiler can catch mismatches and improve code clarity.

### Description
- Updated `include/ALocal_EBC_outflow.hpp` to mark the destructor and all overridden accessors with `override` (replacing the previous `virtual` declarations where applicable). 
- Affected declarations: `~ALocal_EBC_outflow()`, `print_info()`, `get_num_face_nodes()`, `get_intNA()`, `get_LID()`, and `get_outvec()`.
- No other files were modified.

### Testing
- Verified the header contains the `override` specifiers using `rg -n "ALocal_EBC_outflow|override" include/ALocal_EBC_outflow.hpp`, which reported the updated declarations.
- Inspected the updated file with `nl` to confirm the changed lines and signatures were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d261bd84832a9249a44187ef0adf)