### PR TITLE
Add override specifiers to EBC_Partition derived virtual methods

### DIFF
--- a/include/EBC_Partition_WallModel.hpp
+++ b/include/EBC_Partition_WallModel.hpp
@@ -19,10 +19,10 @@ class EBC_Partition_WallModel : public EBC_Partition
         const Map_Node_Index * const &mnidex,
         const ElemBC * const &ebc );
 
-    virtual ~EBC_Partition_WallModel() = default;
+    ~EBC_Partition_WallModel() override = default;
 
     // write the data to hdf5 file in folder /weak
-    virtual void write_hdf5( const std::string &FileName ) const;
+    void write_hdf5( const std::string &FileName ) const override;
 
   protected:
     const int wall_model_type;

--- a/include/EBC_Partition_outflow.hpp
+++ b/include/EBC_Partition_outflow.hpp
@@ -26,11 +26,11 @@ class EBC_Partition_outflow : public EBC_Partition
         const ElemBC * const &ebc,
         const std::vector<INodalBC *> &nbc_list );
 
-    virtual ~EBC_Partition_outflow() = default;
+    ~EBC_Partition_outflow() override = default;
 
     // write the data to hdf5 file in group /ebc/ebcid_xxx, 
     // xxx is the ebc_id
-    virtual void write_hdf5( const std::string &FileName ) const
+    void write_hdf5( const std::string &FileName ) const override
     { write_hdf5(FileName, "/ebc"); }
 
   protected:
@@ -54,8 +54,8 @@ class EBC_Partition_outflow : public EBC_Partition
     // write the data to hdf5 file in group /group-name/ebcid_xxx, 
     // xxx is the ebc_id
     // We do not give users the access to this function out of the class
-    virtual void write_hdf5( const std::string &FileName, 
-        const std::string &GroupName ) const;
+    void write_hdf5( const std::string &FileName, 
+        const std::string &GroupName ) const override;
 
 };
 

--- a/include/EBC_Partition_outflow_MF.hpp
+++ b/include/EBC_Partition_outflow_MF.hpp
@@ -25,11 +25,11 @@ class EBC_Partition_outflow_MF : public EBC_Partition
         const std::vector<INodalBC *> &nbc_list,
         const std::vector< std::vector<int> > &grid2id );
 
-    virtual ~EBC_Partition_outflow_MF() = default;
+    ~EBC_Partition_outflow_MF() override = default;
 
     // write the data to hdf5 file in group /ebc/ebcid_xxx, 
     // xxx is the ebc_id
-    virtual void write_hdf5( const std::string &FileName ) const
+    void write_hdf5( const std::string &FileName ) const override
     { write_hdf5(FileName, "/ebc"); }
 
   protected:
@@ -53,8 +53,8 @@ class EBC_Partition_outflow_MF : public EBC_Partition
     // write the data to hdf5 file in group /group-name/ebcid_xxx, 
     // xxx is the ebc_id
     // We do not give users the access to this function out of the class
-    virtual void write_hdf5( const std::string &FileName,
-        const std::string &GroupName ) const;
+    void write_hdf5( const std::string &FileName,
+        const std::string &GroupName ) const override;
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- Ensure virtual functions overridden in subclasses of `EBC_Partition` are annotated with `override` to enable compiler checks and improve code clarity.

### Description
- Add `override` to destructors and `write_hdf5` declarations in `EBC_Partition_outflow`, `EBC_Partition_outflow_MF`, and `EBC_Partition_WallModel` headers (`include/EBC_Partition_outflow.hpp`, `include/EBC_Partition_outflow_MF.hpp`, `include/EBC_Partition_WallModel.hpp`) without changing runtime behavior.

### Testing
- Verified the edits and repository state by running `git -C /workspace/PERIGEE status --short`, `rg` to confirm updated declarations, and committed the changes with `git -C /workspace/PERIGEE commit`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d839e1dc832a989a87e5b7e26ce2)