### PR TITLE
Refactor FEAElement get_gradR/get_R_gradR parameter types to raw pointers

### DIFF
--- a/include/FEAElement.hpp
+++ b/include/FEAElement.hpp
@@ -101,23 +101,23 @@ class FEAElement
     // the pointer after use.
     // ------------------------------------------------------------------------    
     // 3D case
-    virtual void get_gradR( int quaindex, double *basis_x,
-        double *basis_y, double *basis_z ) const 
+    virtual void get_gradR( int quaindex, double * basis_x,
+        double * basis_y, double * basis_z ) const 
     {SYS_T::commPrint("Warning: get_gradR is not implemented. \n");} 
 
     // 2D case
-    virtual void get_gradR( int quaindex, double *basis_x,
-        double *basis_y ) const 
+    virtual void get_gradR( int quaindex, double * basis_x,
+        double * basis_y ) const 
     {SYS_T::commPrint("Warning: get_gradR is not implemented. \n");} 
 
     // 2D case:
-    virtual void get_R_gradR( int quaindex, double *basis, 
-        double *basis_x, double *basis_y ) const 
+    virtual void get_R_gradR( int quaindex, double * basis, 
+        double * basis_x, double * basis_y ) const 
     {SYS_T::commPrint("Warning: get_R_gradR is not implemented. \n");} 
 
     // 3D case:
-    virtual void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y, double *basis_z ) const 
+    virtual void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y, double * basis_z ) const 
     {SYS_T::commPrint("Warning: get_R_gradR is not implemented. \n");}
 
     // ------------------------------------------------------------------------    

--- a/include/FEAElement.hpp
+++ b/include/FEAElement.hpp
@@ -101,23 +101,23 @@ class FEAElement
     // the pointer after use.
     // ------------------------------------------------------------------------    
     // 3D case
-    virtual void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z ) const 
+    virtual void get_gradR( int quaindex, double *basis_x,
+        double *basis_y, double *basis_z ) const 
     {SYS_T::commPrint("Warning: get_gradR is not implemented. \n");} 
 
     // 2D case
-    virtual void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y ) const 
+    virtual void get_gradR( int quaindex, double *basis_x,
+        double *basis_y ) const 
     {SYS_T::commPrint("Warning: get_gradR is not implemented. \n");} 
 
     // 2D case:
-    virtual void get_R_gradR( int quaindex, double * const &basis, 
-        double * const &basis_x, double * const &basis_y ) const 
+    virtual void get_R_gradR( int quaindex, double *basis, 
+        double *basis_x, double *basis_y ) const 
     {SYS_T::commPrint("Warning: get_R_gradR is not implemented. \n");} 
 
     // 3D case:
-    virtual void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y, double * const &basis_z ) const 
+    virtual void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y, double *basis_z ) const 
     {SYS_T::commPrint("Warning: get_R_gradR is not implemented. \n");}
 
     // ------------------------------------------------------------------------    

--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -114,12 +114,12 @@ class FEAElement_Hex27 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y, double *basis_z ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y, double * basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y,
-        double *basis_z ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 

--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -114,12 +114,12 @@ class FEAElement_Hex27 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y, double *basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_z ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y,
+        double *basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -68,12 +68,12 @@ class FEAElement_Hex8 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y, double *basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_z ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y,
+        double *basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -68,12 +68,12 @@ class FEAElement_Hex8 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y, double *basis_z ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y, double * basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y,
-        double *basis_z ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -39,11 +39,11 @@ class FEAElement_Quad4 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -39,11 +39,11 @@ class FEAElement_Quad4 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -39,11 +39,11 @@ class FEAElement_Quad9 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -39,11 +39,11 @@ class FEAElement_Quad9 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -74,12 +74,12 @@ class FEAElement_Tet10 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y, double *basis_z ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y, double * basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y,
-        double *basis_z ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex,
         double * const &basis, double * const &basis_x,

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -74,12 +74,12 @@ class FEAElement_Tet10 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y, double *basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_z ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y,
+        double *basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex,
         double * const &basis, double * const &basis_x,

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -47,12 +47,12 @@ class FEAElement_Tet4 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y, double *basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_z ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y,
+        double *basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -47,12 +47,12 @@ class FEAElement_Tet4 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y, double *basis_z ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y, double * basis_z ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y,
-        double *basis_z ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
         double * const &basis, double * const &basis_x, 

--- a/include/FEAElement_Triangle3.hpp
+++ b/include/FEAElement_Triangle3.hpp
@@ -39,11 +39,11 @@ class FEAElement_Triangle3 final : public FEAElement
     
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex, 
         double * const &basis, 

--- a/include/FEAElement_Triangle3.hpp
+++ b/include/FEAElement_Triangle3.hpp
@@ -39,11 +39,11 @@ class FEAElement_Triangle3 final : public FEAElement
     
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex, 
         double * const &basis, 

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -40,11 +40,11 @@ class FEAElement_Triangle6 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double * const &basis_x,
-        double * const &basis_y ) const override;
+    void get_gradR( int quaindex, double *basis_x,
+        double *basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y ) const override;
+    void get_R_gradR( int quaindex, double *basis,
+        double *basis_x, double *basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -40,11 +40,11 @@ class FEAElement_Triangle6 final : public FEAElement
 
     std::vector<double> get_R( int quaindex ) const override;
 
-    void get_gradR( int quaindex, double *basis_x,
-        double *basis_y ) const override;
+    void get_gradR( int quaindex, double * basis_x,
+        double * basis_y ) const override;
 
-    void get_R_gradR( int quaindex, double *basis,
-        double *basis_x, double *basis_y ) const override;
+    void get_R_gradR( int quaindex, double * basis,
+        double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
         double * const &basis,

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -340,8 +340,8 @@ std::vector<double> FEAElement_Hex27::get_R( int quaindex ) const
   return vec;
 }
 
-void FEAElement_Hex27::get_gradR( int quaindex, double *basis_x,
-    double *basis_y, double *basis_z ) const
+void FEAElement_Hex27::get_gradR( int quaindex, double * basis_x,
+    double * basis_y, double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_gradR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -353,9 +353,9 @@ void FEAElement_Hex27::get_gradR( int quaindex, double *basis_x,
   }
 }
 
-void FEAElement_Hex27::get_R_gradR( int quaindex, double *basis,
-    double *basis_x, double *basis_y,
-    double *basis_z ) const
+void FEAElement_Hex27::get_R_gradR( int quaindex, double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -340,8 +340,8 @@ std::vector<double> FEAElement_Hex27::get_R( int quaindex ) const
   return vec;
 }
 
-void FEAElement_Hex27::get_gradR( int quaindex, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z ) const
+void FEAElement_Hex27::get_gradR( int quaindex, double *basis_x,
+    double *basis_y, double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_gradR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -353,9 +353,9 @@ void FEAElement_Hex27::get_gradR( int quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Hex27::get_R_gradR( int quaindex, double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_z ) const
+void FEAElement_Hex27::get_R_gradR( int quaindex, double *basis,
+    double *basis_x, double *basis_y,
+    double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -211,8 +211,8 @@ std::vector<double> FEAElement_Hex8::get_R( int quaindex ) const
          R[offset+4], R[offset+5], R[offset+6], R[offset+7] };
 }
 
-void FEAElement_Hex8::get_gradR( int quaindex, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z ) const
+void FEAElement_Hex8::get_gradR( int quaindex, double *basis_x,
+    double *basis_y, double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_gradR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -224,9 +224,9 @@ void FEAElement_Hex8::get_gradR( int quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Hex8::get_R_gradR( int quaindex, double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_z ) const
+void FEAElement_Hex8::get_R_gradR( int quaindex, double *basis,
+    double *basis_x, double *basis_y,
+    double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -211,8 +211,8 @@ std::vector<double> FEAElement_Hex8::get_R( int quaindex ) const
          R[offset+4], R[offset+5], R[offset+6], R[offset+7] };
 }
 
-void FEAElement_Hex8::get_gradR( int quaindex, double *basis_x,
-    double *basis_y, double *basis_z ) const
+void FEAElement_Hex8::get_gradR( int quaindex, double * basis_x,
+    double * basis_y, double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_gradR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -224,9 +224,9 @@ void FEAElement_Hex8::get_gradR( int quaindex, double *basis_x,
   }
 }
 
-void FEAElement_Hex8::get_R_gradR( int quaindex, double *basis,
-    double *basis_x, double *basis_y,
-    double *basis_z ) const
+void FEAElement_Hex8::get_R_gradR( int quaindex, double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -146,7 +146,7 @@ std::vector<double> FEAElement_Quad4::get_R( int quaindex ) const
 }
 
 void FEAElement_Quad4::get_gradR( int quaindex, 
-    double *basis_x, double *basis_y ) const
+    double * basis_x, double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)
@@ -157,8 +157,8 @@ void FEAElement_Quad4::get_gradR( int quaindex,
 }
 
 void FEAElement_Quad4::get_R_gradR( int quaindex, 
-    double *basis, double *basis_x, 
-    double *basis_y ) const
+    double * basis, double * basis_x, 
+    double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -146,7 +146,7 @@ std::vector<double> FEAElement_Quad4::get_R( int quaindex ) const
 }
 
 void FEAElement_Quad4::get_gradR( int quaindex, 
-    double * const &basis_x, double * const &basis_y ) const
+    double *basis_x, double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)
@@ -157,8 +157,8 @@ void FEAElement_Quad4::get_gradR( int quaindex,
 }
 
 void FEAElement_Quad4::get_R_gradR( int quaindex, 
-    double * const &basis, double * const &basis_x, 
-    double * const &basis_y ) const
+    double *basis, double *basis_x, 
+    double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -186,7 +186,7 @@ std::vector<double> FEAElement_Quad9::get_R( int quaindex ) const
 }
 
 void FEAElement_Quad9::get_gradR( int quaindex, 
-    double * const &basis_x, double * const &basis_y ) const
+    double *basis_x, double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)
@@ -197,8 +197,8 @@ void FEAElement_Quad9::get_gradR( int quaindex,
 }
 
 void FEAElement_Quad9::get_R_gradR( int quaindex, 
-    double * const &basis, double * const &basis_x, 
-    double * const &basis_y ) const
+    double *basis, double *basis_x, 
+    double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -186,7 +186,7 @@ std::vector<double> FEAElement_Quad9::get_R( int quaindex ) const
 }
 
 void FEAElement_Quad9::get_gradR( int quaindex, 
-    double *basis_x, double *basis_y ) const
+    double * basis_x, double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)
@@ -197,8 +197,8 @@ void FEAElement_Quad9::get_gradR( int quaindex,
 }
 
 void FEAElement_Quad9::get_R_gradR( int quaindex, 
-    double *basis, double *basis_x, 
-    double *basis_y ) const
+    double * basis, double * basis_x, 
+    double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -201,8 +201,8 @@ std::vector<double> FEAElement_Tet10::get_R( int quaindex ) const
     R[offset+4], R[offset+5], R[offset+6], R[offset+7], R[offset+8], R[offset+9] };
 }
 
-void FEAElement_Tet10::get_gradR( int quaindex, double *basis_x,
-    double *basis_y, double *basis_z ) const
+void FEAElement_Tet10::get_gradR( int quaindex, double * basis_x,
+    double * basis_y, double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_gradR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -214,9 +214,9 @@ void FEAElement_Tet10::get_gradR( int quaindex, double *basis_x,
   }
 }
 
-void FEAElement_Tet10::get_R_gradR( int quaindex, double *basis,
-    double *basis_x, double *basis_y,
-    double *basis_z ) const
+void FEAElement_Tet10::get_R_gradR( int quaindex, double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -201,8 +201,8 @@ std::vector<double> FEAElement_Tet10::get_R( int quaindex ) const
     R[offset+4], R[offset+5], R[offset+6], R[offset+7], R[offset+8], R[offset+9] };
 }
 
-void FEAElement_Tet10::get_gradR( int quaindex, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z ) const
+void FEAElement_Tet10::get_gradR( int quaindex, double *basis_x,
+    double *basis_y, double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_gradR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -214,9 +214,9 @@ void FEAElement_Tet10::get_gradR( int quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Tet10::get_R_gradR( int quaindex, double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_z ) const
+void FEAElement_Tet10::get_R_gradR( int quaindex, double *basis,
+    double *basis_x, double *basis_y,
+    double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -96,8 +96,8 @@ std::vector<double> FEAElement_Tet4::get_R( int quaindex ) const
   return { R[offset], R[offset+1], R[offset+2], R[offset+3] };
 }
 
-void FEAElement_Tet4::get_gradR( int quaindex, double *basis_x,
-    double *basis_y, double *basis_z ) const
+void FEAElement_Tet4::get_gradR( int quaindex, double * basis_x,
+    double * basis_y, double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_gradR function error.\n" );
   for( int ii=0; ii<nLocBas; ++ii )
@@ -108,9 +108,9 @@ void FEAElement_Tet4::get_gradR( int quaindex, double *basis_x,
   }
 }
 
-void FEAElement_Tet4::get_R_gradR( int quaindex, double *basis,
-    double *basis_x, double *basis_y,
-    double *basis_z ) const
+void FEAElement_Tet4::get_R_gradR( int quaindex, double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -96,8 +96,8 @@ std::vector<double> FEAElement_Tet4::get_R( int quaindex ) const
   return { R[offset], R[offset+1], R[offset+2], R[offset+3] };
 }
 
-void FEAElement_Tet4::get_gradR( int quaindex, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z ) const
+void FEAElement_Tet4::get_gradR( int quaindex, double *basis_x,
+    double *basis_y, double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_gradR function error.\n" );
   for( int ii=0; ii<nLocBas; ++ii )
@@ -108,9 +108,9 @@ void FEAElement_Tet4::get_gradR( int quaindex, double * const &basis_x,
   }
 }
 
-void FEAElement_Tet4::get_R_gradR( int quaindex, double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_z ) const
+void FEAElement_Tet4::get_R_gradR( int quaindex, double *basis,
+    double *basis_x, double *basis_y,
+    double *basis_z ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_R_gradR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Triangle3.cpp
+++ b/src/Element/FEAElement_Triangle3.cpp
@@ -92,7 +92,7 @@ std::vector<double> FEAElement_Triangle3::get_R( int quaindex ) const
 }
 
 void FEAElement_Triangle3::get_gradR( int quaindex, 
-    double *basis_x, double *basis_y ) const
+    double * basis_x, double * basis_y ) const
 {
   for(int ii=0; ii<nLocBas; ++ii)
   {
@@ -102,8 +102,8 @@ void FEAElement_Triangle3::get_gradR( int quaindex,
 }
 
 void FEAElement_Triangle3::get_R_gradR( int quaindex, 
-    double *basis,
-    double *basis_x, double *basis_y ) const
+    double * basis,
+    double * basis_x, double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii < nLocBas; ++ ii)

--- a/src/Element/FEAElement_Triangle3.cpp
+++ b/src/Element/FEAElement_Triangle3.cpp
@@ -92,7 +92,7 @@ std::vector<double> FEAElement_Triangle3::get_R( int quaindex ) const
 }
 
 void FEAElement_Triangle3::get_gradR( int quaindex, 
-    double * const &basis_x, double * const &basis_y ) const
+    double *basis_x, double *basis_y ) const
 {
   for(int ii=0; ii<nLocBas; ++ii)
   {
@@ -102,8 +102,8 @@ void FEAElement_Triangle3::get_gradR( int quaindex,
 }
 
 void FEAElement_Triangle3::get_R_gradR( int quaindex, 
-    double * const &basis,
-    double * const &basis_x, double * const &basis_y ) const
+    double *basis,
+    double *basis_x, double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii < nLocBas; ++ ii)

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -177,7 +177,7 @@ std::vector<double> FEAElement_Triangle6::get_R( int quaindex ) const
 }
 
 void FEAElement_Triangle6::get_gradR( int quaindex, 
-    double *basis_x, double *basis_y ) const
+    double * basis_x, double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)
@@ -188,8 +188,8 @@ void FEAElement_Triangle6::get_gradR( int quaindex,
 }
 
 void FEAElement_Triangle6::get_R_gradR( int quaindex, 
-    double *basis, double *basis_x, 
-    double *basis_y ) const
+    double * basis, double * basis_x, 
+    double * basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -177,7 +177,7 @@ std::vector<double> FEAElement_Triangle6::get_R( int quaindex ) const
 }
 
 void FEAElement_Triangle6::get_gradR( int quaindex, 
-    double * const &basis_x, double * const &basis_y ) const
+    double *basis_x, double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)
@@ -188,8 +188,8 @@ void FEAElement_Triangle6::get_gradR( int quaindex,
 }
 
 void FEAElement_Triangle6::get_R_gradR( int quaindex, 
-    double * const &basis, double * const &basis_x, 
-    double * const &basis_y ) const
+    double *basis, double *basis_x, 
+    double *basis_y ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii)


### PR DESCRIPTION
### Motivation
- Simplify the API and remove unnecessary reference-to-pointer parameter types by changing `double * const &` to raw `double *` for gradient-related methods. 
- Ensure consistent virtual signatures between the `FEAElement` base class and all element subclass overrides to avoid signature mismatch issues.

### Description
- Updated the `FEAElement` virtual method declarations `get_gradR` and `get_R_gradR` to accept `double *` parameters for both 2D and 3D overloads in `include/FEAElement.hpp`.
- Updated corresponding override declarations in element headers (`Tet4`, `Tet10`, `Hex8`, `Hex27`, `Triangle3`, `Triangle6`, `Quad4`, `Quad9`) to use `double *`.
- Updated all affected `.cpp` definitions in `src/Element/*` to match the new signatures without changing implementation logic.
- Limited change scope to function parameter types for `get_gradR` / `get_R_gradR` and their direct usages in element implementations.

### Testing
- Ran a signature scan with `rg "get_gradR\(|get_R_gradR\(" include/FEAElement*.hpp src/Element/FEAElement*.cpp -n` to confirm all updated declarations/definitions now use `double *`, which succeeded.
- Executed the automated replacement script used to apply the parameter-type updates across targeted files, which completed successfully.
- Performed targeted file inspections with `nl` to sample and verify updated declarations and definitions, which matched the intended changes.
- No behavioral or runtime tests were executed in this change, as the edits are limited to parameter types and implementations were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6154ae9cc832a84070f08682e4307)