### PR TITLE
refactor(ns): use '+' and `const` for vis_wss filename construction

### DIFF
--- a/examples/ns/vis_wss_hex27.cpp
+++ b/examples/ns/vis_wss_hex27.cpp
@@ -82,8 +82,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the command line argument on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -212,13 +211,12 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     std::ostringstream time_index;
     time_index.str("");
     time_index << 900000000 + time;
-    name_to_read.append(time_index.str());
-    name_to_write.append(time_index.str());
+    const std::string time_label = time_index.str();
+    const std::string name_to_read = sol_bname + time_label;
+    const std::string name_to_write = out_bname + time_label;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ns/vis_wss_hex27.cpp
+++ b/examples/ns/vis_wss_hex27.cpp
@@ -214,9 +214,9 @@ int main( int argc, char * argv[] )
     std::ostringstream time_index;
     time_index.str("");
     time_index << 900000000 + time;
-    const std::string time_label = time_index.str();
-    const std::string name_to_read = sol_bname + time_label;
-    const std::string name_to_write = out_bname + time_label;
+    const std::string time_suffix = time_index.str();
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ns/vis_wss_hex8.cpp
+++ b/examples/ns/vis_wss_hex8.cpp
@@ -82,8 +82,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the command line argument on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -212,13 +211,12 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     std::ostringstream time_index;
     time_index.str("");
     time_index << 900000000 + time;
-    name_to_read.append(time_index.str());
-    name_to_write.append(time_index.str());
+    const std::string time_label = time_index.str();
+    const std::string name_to_read = sol_bname + time_label;
+    const std::string name_to_write = out_bname + time_label;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ns/vis_wss_hex8.cpp
+++ b/examples/ns/vis_wss_hex8.cpp
@@ -214,9 +214,9 @@ int main( int argc, char * argv[] )
     std::ostringstream time_index;
     time_index.str("");
     time_index << 900000000 + time;
-    const std::string time_label = time_index.str();
-    const std::string name_to_read = sol_bname + time_label;
-    const std::string name_to_write = out_bname + time_label;
+    const std::string time_suffix = time_index.str();
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ns/vis_wss_tet10.cpp
+++ b/examples/ns/vis_wss_tet10.cpp
@@ -82,8 +82,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the command line argument on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -207,13 +206,12 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     std::ostringstream time_index;
     time_index.str("");
     time_index << 900000000 + time;
-    name_to_read.append(time_index.str());
-    name_to_write.append(time_index.str());
+    const std::string time_label = time_index.str();
+    const std::string name_to_read = sol_bname + time_label;
+    const std::string name_to_write = out_bname + time_label;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ns/vis_wss_tet10.cpp
+++ b/examples/ns/vis_wss_tet10.cpp
@@ -209,9 +209,9 @@ int main( int argc, char * argv[] )
     std::ostringstream time_index;
     time_index.str("");
     time_index << 900000000 + time;
-    const std::string time_label = time_index.str();
-    const std::string name_to_read = sol_bname + time_label;
-    const std::string name_to_write = out_bname + time_label;
+    const std::string time_suffix = time_index.str();
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ns/vis_wss_tet4.cpp
+++ b/examples/ns/vis_wss_tet4.cpp
@@ -73,8 +73,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);  
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the key data on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -207,12 +206,11 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     time_index.str("");
     time_index << 900000000 + time;
-    name_to_read.append(time_index.str());
-    name_to_write.append(time_index.str());
+    const std::string time_label = time_index.str();
+    const std::string name_to_read = sol_bname + time_label;
+    const std::string name_to_write = out_bname + time_label;
 
     std::cout<<"Time "<<time<<": Read "<<name_to_read<<" and Write "<<name_to_write<<std::endl;
 

--- a/examples/ns/vis_wss_tet4.cpp
+++ b/examples/ns/vis_wss_tet4.cpp
@@ -208,9 +208,9 @@ int main( int argc, char * argv[] )
     // Generate the file name
     time_index.str("");
     time_index << 900000000 + time;
-    const std::string time_label = time_index.str();
-    const std::string name_to_read = sol_bname + time_label;
-    const std::string name_to_write = out_bname + time_label;
+    const std::string time_suffix = time_index.str();
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     std::cout<<"Time "<<time<<": Read "<<name_to_read<<" and Write "<<name_to_write<<std::endl;
 


### PR DESCRIPTION
### Motivation
- Modernize filename construction in the NS WSS visualization examples by replacing `append(...)` calls with `+` string concatenation to make intent clearer and expressions more concise.
- Mark immutable filename-related variables as `const` where appropriate to communicate immutability and avoid accidental modification.

### Description
- Replaced `out_bname` building from `out_bname = sol_bname; out_bname.append("WSS_");` to `const std::string out_bname = sol_bname + "WSS_";` in `examples/ns/vis_wss_tet4.cpp`, `vis_wss_tet10.cpp`, `vis_wss_hex8.cpp`, and `vis_wss_hex27.cpp`.
- In each time loop replaced the prior `append` usage with `time_index` → `time_label` and constructed `name_to_read`/`name_to_write` as `const std::string name_to_read = sol_bname + time_label;` and `const std::string name_to_write = out_bname + time_label;`.
- Added `const` qualifiers to the new filename variables (`out_bname`, `time_label`, `name_to_read`, `name_to_write`) to enforce immutability and keep changes local to the examples.

### Testing
- Ran `rg -n "append\\(" examples/ns/vis_wss_*.cpp` to confirm there are no remaining `append` calls in the modified files, which returned no hits.
- Reviewed the source diffs with `git diff -- examples/ns/vis_wss_tet4.cpp examples/ns/vis_wss_tet10.cpp examples/ns/vis_wss_hex8.cpp examples/ns/vis_wss_hex27.cpp` to verify the intended replacements were applied successfully.
- Inspected file snippets (`nl`/`sed` outputs) for each modified file to ensure the new `const` concatenation and `time_label` usage are present and correctly scoped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61642c3d4832a8c2b751d88c739d6)