### PR TITLE
Refactor FEAElement APIs from pointer-references to raw pointers

### DIFF
--- a/include/FEAElement.hpp
+++ b/include/FEAElement.hpp
@@ -124,28 +124,28 @@ class FEAElement
     // R, gradR, and Laplacian R
     // ------------------------------------------------------------------------    
     virtual void get_3D_R_gradR_LaplacianR( int quaindex,
-        double * const &basis, double * const &basis_x, double * const &basis_y,
-        double * const &basis_z, double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz ) const 
+        double * basis, double * basis_x, double * basis_y,
+        double * basis_z, double * basis_xx, double * basis_yy, 
+        double * basis_zz ) const 
     {SYS_T::commPrint("Warning: get_3DLaplacianR is not implemented. \n");}
 
     virtual void get_2D_R_gradR_LaplacianR( int quaindex,
-        double * const &basis, double * const &basis_x, double * const &basis_y,
-        double * const &basis_xx, double * const &basis_yy ) const 
+        double * basis, double * basis_x, double * basis_y,
+        double * basis_xx, double * basis_yy ) const 
     {SYS_T::commPrint("Warning: get_2DLaplacianR is not implemented. \n");}
 
     // ------------------------------------------------------------------------    
     // R, gradR, and grad gradR
     // ------------------------------------------------------------------------    
-    virtual void get_2D_R_dR_d2R( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y, double * const &basis_xx, 
-        double * const &basis_yy, double * const &basis_xy ) const
+    virtual void get_2D_R_dR_d2R( int quaindex, double * basis,
+        double * basis_x, double * basis_y, double * basis_xx, 
+        double * basis_yy, double * basis_xy ) const
     {SYS_T::commPrint("Warning: get_2D_R_dR_d2R is not implemented. \n");}
 
-    virtual void get_3D_R_dR_d2R( int quaindex, double * const &basis,
-        double * const &basis_x, double * const &basis_y, double * const &basis_z,
-        double * const &basis_xx, double * const &basis_yy, double * const &basis_zz,
-        double * const &basis_xy, double * const &basis_xz, double * const &basis_yz ) 
+    virtual void get_3D_R_dR_d2R( int quaindex, double * basis,
+        double * basis_x, double * basis_y, double * basis_z,
+        double * basis_xx, double * basis_yy, double * basis_zz,
+        double * basis_xy, double * basis_xz, double * basis_yz ) 
       const {SYS_T::commPrint("Warning: get_3D_R_dR_d2R is not implemented. \n");}
 
     // ------------------------------------------------------------------------    
@@ -246,9 +246,9 @@ class FEAElement
     // dx_dr in parent domain
     // ------------------------------------------------------------------------
     virtual Vector_3 get_dx_dr( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const 
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const 
     {
       SYS_T::commPrint("Warning: get_dx_dr is not implemented. \n");
       return Vector_3();
@@ -258,9 +258,9 @@ class FEAElement
     // dx_ds in parent domain
     // ------------------------------------------------------------------------
     virtual Vector_3 get_dx_ds( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const 
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const 
     {
       SYS_T::commPrint("Warning: get_dx_ds is not implemented. \n");
       return Vector_3();
@@ -270,9 +270,9 @@ class FEAElement
     // d2x_drr in parent domain
     // ------------------------------------------------------------------------
     virtual Vector_3 get_d2x_drr( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const 
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const 
     {
       SYS_T::commPrint("Warning: get_d2x_drr is not implemented. \n");
       return Vector_3();
@@ -282,9 +282,9 @@ class FEAElement
     // d2x_dss in parent domain
     // ------------------------------------------------------------------------
     virtual Vector_3 get_d2x_dss( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const 
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const 
     {
       SYS_T::commPrint("Warning: get_d2x_dss is not implemented. \n");
       return Vector_3();
@@ -294,18 +294,18 @@ class FEAElement
     // d2x_drs in parent domain
     // ------------------------------------------------------------------------
     virtual Vector_3 get_d2x_drs( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const 
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const 
     {
       SYS_T::commPrint("Warning: get_d2x_drs is not implemented. \n");
       return Vector_3();
     }
 
     virtual std::array<std::vector<double>, 3> get_face_ctrlPts( int face_id,
-        const double * const &volctrl_x,
-        const double * const &volctrl_y,
-        const double * const &volctrl_z ) const
+        const double * volctrl_x,
+        const double * volctrl_y,
+        const double * volctrl_z ) const
     {
       SYS_T::commPrint("Warning: get_face_ctrlPts is not implemented. \n");
     

--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -122,17 +122,17 @@ class FEAElement_Hex27 final : public FEAElement
         double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
-        double * const &basis, double * const &basis_x, 
-        double * const &basis_y, double * const &basis_z,
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz, double * const &basis_xy, 
-        double * const &basis_xz, double * const &basis_yz ) const override;
+        double * basis, double * basis_x, 
+        double * basis_y, double * basis_z,
+        double * basis_xx, double * basis_yy, 
+        double * basis_zz, double * basis_xy, 
+        double * basis_xz, double * basis_yz ) const override;
 
     void get_3D_R_gradR_LaplacianR( int quaindex,
-        double * const &basis, double * const &basis_x, 
-        double * const &basis_y, double * const &basis_z, 
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz ) const override;
+        double * basis, double * basis_x, 
+        double * basis_y, double * basis_z, 
+        double * basis_xx, double * basis_yy, 
+        double * basis_zz ) const override;
     
     // Get the Jacobian matrix dx/dr
     std::array<double,9> get_Jacobian( int quaindex ) const override;

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -76,17 +76,17 @@ class FEAElement_Hex8 final : public FEAElement
         double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
-        double * const &basis, double * const &basis_x, 
-        double * const &basis_y, double * const &basis_z,
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz, double * const &basis_xy, 
-        double * const &basis_xz, double * const &basis_yz ) const override;
+        double * basis, double * basis_x, 
+        double * basis_y, double * basis_z,
+        double * basis_xx, double * basis_yy, 
+        double * basis_zz, double * basis_xy, 
+        double * basis_xz, double * basis_yz ) const override;
 
     void get_3D_R_gradR_LaplacianR( int quaindex,
-        double * const &basis, double * const &basis_x, 
-        double * const &basis_y, double * const &basis_z, 
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz ) const override;
+        double * basis, double * basis_x, 
+        double * basis_y, double * basis_z, 
+        double * basis_xx, double * basis_yy, 
+        double * basis_zz ) const override;
 
     // Get the Jacobian matrix dx/dr
     std::array<double,9> get_Jacobian( int quaindex ) const override;

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -46,10 +46,10 @@ class FEAElement_Quad4 final : public FEAElement
         double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
-        double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_xx, double * const &basis_yy,
-        double * const &basis_xy ) const override;
+        double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_xx, double * basis_yy,
+        double * basis_xy ) const override;
 
     std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -46,10 +46,10 @@ class FEAElement_Quad9 final : public FEAElement
         double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
-        double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_xx, double * const &basis_yy,
-        double * const &basis_xy ) const override;
+        double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_xx, double * basis_yy,
+        double * basis_xy ) const override;
 
     std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -82,17 +82,17 @@ class FEAElement_Tet10 final : public FEAElement
         double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex,
-        double * const &basis, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z,
-        double * const &basis_xx, double * const &basis_yy,
-        double * const &basis_zz, double * const &basis_xy,
-        double * const &basis_xz, double * const &basis_yz ) const override;
+        double * basis, double * basis_x,
+        double * basis_y, double * basis_z,
+        double * basis_xx, double * basis_yy,
+        double * basis_zz, double * basis_xy,
+        double * basis_xz, double * basis_yz ) const override;
 
     void get_3D_R_gradR_LaplacianR( int quaindex,
-        double * const &basis, double * const &basis_x,
-        double * const &basis_y, double * const &basis_z,
-        double * const &basis_xx, double * const &basis_yy,
-        double * const &basis_zz ) const override;
+        double * basis, double * basis_x,
+        double * basis_y, double * basis_z,
+        double * basis_xx, double * basis_yy,
+        double * basis_zz ) const override;
 
     std::array<double,9> get_Jacobian( int quaindex ) const override;
 

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -55,17 +55,17 @@ class FEAElement_Tet4 final : public FEAElement
         double * basis_z ) const override;
 
     void get_3D_R_dR_d2R( int quaindex, 
-        double * const &basis, double * const &basis_x, 
-        double * const &basis_y, double * const &basis_z,
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz, double * const &basis_xy, 
-        double * const &basis_xz, double * const &basis_yz ) const override;
+        double * basis, double * basis_x, 
+        double * basis_y, double * basis_z,
+        double * basis_xx, double * basis_yy, 
+        double * basis_zz, double * basis_xy, 
+        double * basis_xz, double * basis_yz ) const override;
 
     void get_3D_R_gradR_LaplacianR( int quaindex,
-        double * const &basis, double * const &basis_x, 
-        double * const &basis_y, double * const &basis_z, 
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_zz ) const override;
+        double * basis, double * basis_x, 
+        double * basis_y, double * basis_z, 
+        double * basis_xx, double * basis_yy, 
+        double * basis_zz ) const override;
 
     // Get the Jacobian matrix dx/dr
     std::array<double,9> get_Jacobian( int quaindex ) const override
@@ -104,9 +104,9 @@ class FEAElement_Tet4 final : public FEAElement
     {return triangle_face->get_2d_normal_out( quaindex, area );}
 
     std::array<std::vector<double>, 3> get_face_ctrlPts( int face_id,
-        const double * const &volctrl_x,
-        const double * const &volctrl_y,
-        const double * const &volctrl_z ) const override;
+        const double * volctrl_x,
+        const double * volctrl_y,
+        const double * volctrl_z ) const override;
 
   private:
     static constexpr int nLocBas = 4;

--- a/include/FEAElement_Triangle3.hpp
+++ b/include/FEAElement_Triangle3.hpp
@@ -46,10 +46,10 @@ class FEAElement_Triangle3 final : public FEAElement
         double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex, 
-        double * const &basis, 
-        double * const &basis_x, double * const &basis_y, 
-        double * const &basis_xx, double * const &basis_yy, 
-        double * const &basis_xy ) const override;
+        double * basis, 
+        double * basis_x, double * basis_y, 
+        double * basis_xx, double * basis_yy, 
+        double * basis_xy ) const override;
 
     std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 

--- a/include/FEAElement_Triangle3_3D_der0.hpp
+++ b/include/FEAElement_Triangle3_3D_der0.hpp
@@ -63,9 +63,9 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
     // These functions are needed in the FE_T::search_closest_point function,
     // which is called inside the sliding interface formulation.
     Vector_3 get_dx_dr( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override
     {
       return Vector_3( - ctrl_x[0] + ctrl_x[1],
                        - ctrl_y[0] + ctrl_y[1],
@@ -73,9 +73,9 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
     }
     
     Vector_3 get_dx_ds( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override
     {
       return Vector_3( - ctrl_x[0] + ctrl_x[2],
                        - ctrl_y[0] + ctrl_y[2],
@@ -83,21 +83,21 @@ class FEAElement_Triangle3_3D_der0 final : public FEAElement
     }
 
     Vector_3 get_d2x_drr( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override
     {return Vector_3(0.0, 0.0, 0.0);}
 
     Vector_3 get_d2x_dss( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override
     {return Vector_3(0.0, 0.0, 0.0);}
 
     Vector_3 get_d2x_drs( int quaindex,
-        const double * const &ctrl_x,
-        const double * const &ctrl_y,
-        const double * const &ctrl_z ) const override
+        const double * ctrl_x,
+        const double * ctrl_y,
+        const double * ctrl_z ) const override
     {return Vector_3(0.0, 0.0, 0.0);}
 
   private:

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -47,10 +47,10 @@ class FEAElement_Triangle6 final : public FEAElement
         double * basis_x, double * basis_y ) const override;
 
     void get_2D_R_dR_d2R( int quaindex,
-        double * const &basis,
-        double * const &basis_x, double * const &basis_y,
-        double * const &basis_xx, double * const &basis_yy,
-        double * const &basis_xy ) const override;
+        double * basis,
+        double * basis_x, double * basis_y,
+        double * basis_xx, double * basis_yy,
+        double * basis_xy ) const override;
 
     std::array<double,4> get_Jacobian_2D(int quaindex) const override;
 

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -369,11 +369,11 @@ void FEAElement_Hex27::get_R_gradR( int quaindex, double * basis,
 }
 
 void FEAElement_Hex27::get_3D_R_dR_d2R( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz, double * const &basis_xy,
-    double * const &basis_xz, double * const &basis_yz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz, double * basis_xy,
+    double * basis_xz, double * basis_yz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_3D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -393,10 +393,10 @@ void FEAElement_Hex27::get_3D_R_dR_d2R( int quaindex,
 }
 
 void FEAElement_Hex27::get_3D_R_gradR_LaplacianR( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex27::get_3D_R_gradR_LaplacianR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -240,11 +240,11 @@ void FEAElement_Hex8::get_R_gradR( int quaindex, double * basis,
 }
 
 void FEAElement_Hex8::get_3D_R_dR_d2R( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz, double * const &basis_xy,
-    double * const &basis_xz, double * const &basis_yz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz, double * basis_xy,
+    double * basis_xz, double * basis_yz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_3D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -264,10 +264,10 @@ void FEAElement_Hex8::get_3D_R_dR_d2R( int quaindex,
 }
 
 void FEAElement_Hex8::get_3D_R_gradR_LaplacianR( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Hex8::get_3D_R_gradR_LaplacianR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -132,7 +132,7 @@ double FEAElement_Quad4::get_h( const double * ctrl_x,
 }
 
 void FEAElement_Quad4::get_R( int quaindex, 
-    double * const &basis ) const
+    double * basis ) const
 {
   const int offset = quaindex * nLocBas;
   basis[0] = R[offset];   basis[1] = R[offset+1];
@@ -170,10 +170,10 @@ void FEAElement_Quad4::get_R_gradR( int quaindex,
 }
 
 void FEAElement_Quad4::get_2D_R_dR_d2R( int quaindex,
-    double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_xy ) const
+    double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_xx, double * basis_yy,
+    double * basis_xy ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Quad4::get_2D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Quad4_3D_der0.cpp
+++ b/src/Element/FEAElement_Quad4_3D_der0.cpp
@@ -53,7 +53,7 @@ void FEAElement_Quad4_3D_der0::buildBasis( const IQuadPts * quad,
 }
 
 void FEAElement_Quad4_3D_der0::get_R( 
-    int quaindex, double * const &basis ) const
+    int quaindex, double * basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Quad4_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -172,7 +172,7 @@ double FEAElement_Quad9::get_h( const double * ctrl_x,
 }
 
 void FEAElement_Quad9::get_R( int quaindex, 
-    double * const &basis ) const
+    double * basis ) const
 {
   const int offset = quaindex * nLocBas;
   for(int ii=0; ii<nLocBas; ++ii) basis[ii] = R[offset+ii];
@@ -210,10 +210,10 @@ void FEAElement_Quad9::get_R_gradR( int quaindex,
 }
 
 void FEAElement_Quad9::get_2D_R_dR_d2R( int quaindex,
-    double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_xy ) const
+    double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_xx, double * basis_yy,
+    double * basis_xy ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Quad9::get_2D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Quad9_3D_der0.cpp
+++ b/src/Element/FEAElement_Quad9_3D_der0.cpp
@@ -73,7 +73,7 @@ void FEAElement_Quad9_3D_der0::buildBasis( const IQuadPts * quad,
 }
 
 void FEAElement_Quad9_3D_der0::get_R( 
-    int quaindex, double * const &basis ) const
+    int quaindex, double * basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Quad9_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -230,11 +230,11 @@ void FEAElement_Tet10::get_R_gradR( int quaindex, double * basis,
 }
 
 void FEAElement_Tet10::get_3D_R_dR_d2R( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz, double * const &basis_xy,
-    double * const &basis_xz, double * const &basis_yz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz, double * basis_xy,
+    double * basis_xz, double * basis_yz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_3D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -254,10 +254,10 @@ void FEAElement_Tet10::get_3D_R_dR_d2R( int quaindex,
 }
 
 void FEAElement_Tet10::get_3D_R_gradR_LaplacianR( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet10::get_3D_R_gradR_LaplacianR function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -124,11 +124,11 @@ void FEAElement_Tet4::get_R_gradR( int quaindex, double * basis,
 }
 
 void FEAElement_Tet4::get_3D_R_dR_d2R( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz, double * const &basis_xy,
-    double * const &basis_xz, double * const &basis_yz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz, double * basis_xy,
+    double * basis_xz, double * basis_yz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_3D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -148,10 +148,10 @@ void FEAElement_Tet4::get_3D_R_dR_d2R( int quaindex,
 }
 
 void FEAElement_Tet4::get_3D_R_gradR_LaplacianR( int quaindex,
-    double * const &basis, double * const &basis_x,
-    double * const &basis_y, double * const &basis_z,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_zz ) const
+    double * basis, double * basis_x,
+    double * basis_y, double * basis_z,
+    double * basis_xx, double * basis_yy,
+    double * basis_zz ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Tet4::get_3D_R_gradR_LaplacianR function error.\n" );
   const int offset = quaindex * nLocBas;
@@ -194,9 +194,9 @@ void FEAElement_Tet4::buildBasis( int face_id, const IQuadPts * quad_s,
 }
 
 std::array<std::vector<double>, 3> FEAElement_Tet4::get_face_ctrlPts( int face_id,
-    const double * const &vol_ctrl_x,
-    const double * const &vol_ctrl_y,
-    const double * const &vol_ctrl_z ) const
+    const double * vol_ctrl_x,
+    const double * vol_ctrl_y,
+    const double * vol_ctrl_z ) const
 {
   std::array<std::vector<double>, 3> out;
 

--- a/src/Element/FEAElement_Triangle3.cpp
+++ b/src/Element/FEAElement_Triangle3.cpp
@@ -76,7 +76,7 @@ double FEAElement_Triangle3::get_h( const double * ctrl_x,
 }
 
 void FEAElement_Triangle3::get_R( int quaindex, 
-    double * const &basis ) const
+    double * basis ) const
 {
   const int offset = quaindex * nLocBas;
   basis[0] = R[offset];
@@ -115,10 +115,10 @@ void FEAElement_Triangle3::get_R_gradR( int quaindex,
 }
 
 void FEAElement_Triangle3::get_2D_R_dR_d2R( int quaindex,
-    double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_xy ) const
+    double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_xx, double * basis_yy,
+    double * basis_xy ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Triangle3::get_2D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Triangle3_3D_der0.cpp
+++ b/src/Element/FEAElement_Triangle3_3D_der0.cpp
@@ -43,7 +43,7 @@ void FEAElement_Triangle3_3D_der0::buildBasis( const IQuadPts * quad,
 }
 
 void FEAElement_Triangle3_3D_der0::get_R( int quaindex, 
-    double * const &basis ) const
+    double * basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle3_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -162,7 +162,7 @@ double FEAElement_Triangle6::get_h( const double * ctrl_x,
 }
 
 void FEAElement_Triangle6::get_R( int quaindex, 
-    double * const &basis ) const
+    double * basis ) const
 {
   const int offset = quaindex * nLocBas;
   basis[0] = R[offset];   basis[1] = R[offset+1];
@@ -201,10 +201,10 @@ void FEAElement_Triangle6::get_R_gradR( int quaindex,
 }
 
 void FEAElement_Triangle6::get_2D_R_dR_d2R( int quaindex,
-    double * const &basis,
-    double * const &basis_x, double * const &basis_y,
-    double * const &basis_xx, double * const &basis_yy,
-    double * const &basis_xy ) const
+    double * basis,
+    double * basis_x, double * basis_y,
+    double * basis_xx, double * basis_yy,
+    double * basis_xy ) const
 {
   ASSERT( quaindex >= 0 && quaindex < numQuapts, "FEAElement_Triangle6::get_2D_R_dR_d2R function error.\n" );
   const int offset = quaindex * nLocBas;

--- a/src/Element/FEAElement_Triangle6_3D_der0.cpp
+++ b/src/Element/FEAElement_Triangle6_3D_der0.cpp
@@ -60,7 +60,7 @@ void FEAElement_Triangle6_3D_der0::buildBasis( const IQuadPts * quad,
 }
 
 void FEAElement_Triangle6_3D_der0::get_R( 
-    int quaindex, double * const &basis ) const
+    int quaindex, double * basis ) const
 {
   ASSERT(quaindex>=0 && quaindex < numQuapts, "FEAElement_Triangle6_3D_der0::get_R function error.\n" );
   const int offset = quaindex * nLocBas;


### PR DESCRIPTION
### Motivation
- Simplify function signatures by replacing reference-to-pointer parameters with plain pointer parameters to improve readability and consistency of the FEA element API.
- Ensure derived classes and their implementations match the updated base-class interface to avoid signature mismatches.

### Description
- Replaced occurrences of `double * const &` and `const double * const &` with `double *` and `const double *` in `include/FEAElement.hpp` and applied the same style spacing (`* variable`).
- Applied matching signature updates to all derived-class headers under `include/FEAElement_*.hpp` so `override` declarations stay consistent with the base type.
- Updated corresponding function definitions in `src/Element/FEAElement*.cpp` to keep declarations and implementations consistent.
- Adjusted all usages found in element implementations (e.g., Quad4, Quad9, Hex8/27, Tet4/10, Triangle3/6 and their _3D_der0 variants) to the new parameter style.

### Testing
- Performed code-wide pattern searches to locate and replace `double * const &` / `const double * const &` and confirmed there are no remaining occurrences in the targeted headers and source files.
- Verified that declarations in headers and corresponding definitions in `src/Element` are consistent after the change.
- Inspected modified files to ensure pointer spacing follows the requested style and that builds are not impacted by signature mismatches (no remaining pattern hits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61987d694832a885313287835667d)