### PR TITLE
Make Field_Property accessors/destructor noexcept and simplify constructor parameters

### DIFF
--- a/include/Field_Property.hpp
+++ b/include/Field_Property.hpp
@@ -24,15 +24,15 @@ class Field_Property
   public:
     Field_Property() : id(0), dofNum(1), is_geo_field(true), name("unspecified") {};
 
-    Field_Property( const int &input_id, const int &input_dof, const bool &input_geo_flag, const std::string &input_name ) : id( input_id ), dofNum( input_dof ), is_geo_field( input_geo_flag ), name( input_name ) {};
+    Field_Property( int input_id, int input_dof, bool input_geo_flag, const std::string &input_name ) : id( input_id ), dofNum( input_dof ), is_geo_field( input_geo_flag ), name( input_name ) {};
 
-    virtual ~Field_Property() = default;
+    ~Field_Property() noexcept = default;
 
-    int get_id() const {return id;}
+    int get_id() const noexcept {return id;}
 
-    int get_dofNum() const {return dofNum;}
+    int get_dofNum() const noexcept {return dofNum;}
 
-    bool get_is_geo_field() const {return is_geo_field;}
+    bool get_is_geo_field() const noexcept {return is_geo_field;}
 
     std::string get_name() const {return name;}
 


### PR DESCRIPTION
### Motivation
- Improve exception-safety and minor performance by marking trivial accessors and the destructor `noexcept`, and simplify parameter passing for primitive types in the `Field_Property` constructor.

### Description
- Change constructor signature to take primitive parameters by value (`int`, `int`, `bool`) and keep the `std::string` as `const std::string&` to simplify calling code.
- Replace the `virtual` destructor with a non-virtual `~Field_Property() noexcept = default;` since the class is not intended for polymorphic use and to declare it `noexcept`.
- Mark lightweight getter methods (`get_id`, `get_dofNum`, `get_is_geo_field`) as `noexcept` to document and enable stronger optimizations.

### Testing
- Performed a full project build with `cmake -S . -B build && cmake --build build`, which completed successfully.
- Ran the test suite with `ctest --test-dir build`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c43614f4832ab9a86de724040ac8)