### PR TITLE
Replace raw new/delete with unique_ptr in examples/ns/preprocess.cpp

### DIFF
--- a/examples/ns/prepost.cpp
+++ b/examples/ns/prepost.cpp
@@ -12,6 +12,7 @@
 #include "Global_Part_Serial.hpp"
 #include "Part_FEM.hpp"
 #include "yaml-cpp/yaml.h"
+#include <memory>
 
 int main( int argc, char * argv[] )
 {
@@ -25,15 +26,13 @@ int main( int argc, char * argv[] )
 
   // Read preprocessor command-line arguements recorded in the .h5 file
 
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( "preprocessor_cmd.h5" );
+  auto cmd_h5r = SYS_T::make_unique<HDF5_Reader>( "preprocessor_cmd.h5" );
 
   std::string geo_file = cmd_h5r -> read_string("/", "geo_file");
   const std::string elemType_str = cmd_h5r -> read_string("/","elemType");
   const int dofNum = cmd_h5r -> read_intScalar("/","dofNum");
   int in_ncommon = cmd_h5r -> read_intScalar("/","in_ncommon");
   const FEType elemType = FE_T::to_FEType(elemType_str);
-
-  delete cmd_h5r;
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("ns_prepost.yml");
@@ -68,41 +67,39 @@ int main( int argc, char * argv[] )
 
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
   
-  IIEN * IEN = new IEN_FEM(nElem, vecIEN);
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
   VEC_T::clean( vecIEN ); // clean the vector
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
   
   SYS_T::print_fatal_if( IEN->get_nLocBas() != nLocBas, "Error: the nLocBas from the Mesh %d and the IEN %d classes do not match. \n", nLocBas, IEN->get_nLocBas());
 
-  IGlobal_Part * global_part = nullptr;
+  std::unique_ptr<IGlobal_Part> global_part = nullptr;
   if(cpu_size > 1)
-    global_part = new Global_Part_METIS( cpu_size, in_ncommon,
-        isDualGraph, nElem, nFunc, nLocBas, IEN, "post_epart", "post_npart" );
+    global_part = SYS_T::make_unique<Global_Part_METIS>( cpu_size, in_ncommon,
+        isDualGraph, nElem, nFunc, nLocBas, IEN.get(), "post_epart", "post_npart" );
   else if(cpu_size == 1)
-    global_part = new Global_Part_Serial( nElem, nFunc, "post_epart", "post_npart" );
+    global_part = SYS_T::make_unique<Global_Part_Serial>( nElem, nFunc, "post_epart", "post_npart" );
   else SYS_T::print_fatal("ERROR: wrong cpu_size: %d \n", cpu_size);
 
-  Map_Node_Index * mnindex = new Map_Node_Index(global_part, cpu_size, nFunc);
+  auto mnindex = SYS_T::make_unique<Map_Node_Index>(global_part.get(), cpu_size, nFunc);
   mnindex->write_hdf5("post_node_mapping");
 
   cout<<"=== Start Partition ... \n";
   int proc_size = cpu_size;
-  SYS_T::Timer * mytimer = new SYS_T::Timer();
+  auto mytimer = SYS_T::make_unique<SYS_T::Timer>();
   for(int proc_rank = 0; proc_rank < proc_size; ++proc_rank)
   {
     mytimer->Reset(); mytimer->Start();
-    IPart * part = new Part_FEM( nElem, nFunc, nLocBas, global_part, mnindex, IEN,
+    auto part = SYS_T::make_unique<Part_FEM>( nElem, nFunc, nLocBas, global_part.get(), mnindex.get(), IEN.get(),
         ctrlPts, proc_rank, proc_size, elemType, {0, dofNum, true, "NS"} );
     part->write(part_file.c_str());
     mytimer->Stop();
     cout<<"-- proc "<<proc_rank<<" Time taken: "<<mytimer->get_sec()<<" sec. \n";
-    delete part;
   }
 
   // Clean memory
   cout<<"=== Clean memory. \n";
-  delete mnindex; delete global_part; delete IEN; delete mytimer;
   return EXIT_SUCCESS;
 }
 

--- a/examples/ns/prepost.cpp
+++ b/examples/ns/prepost.cpp
@@ -12,7 +12,6 @@
 #include "Global_Part_Serial.hpp"
 #include "Part_FEM.hpp"
 #include "yaml-cpp/yaml.h"
-#include <memory>
 
 int main( int argc, char * argv[] )
 {
@@ -33,6 +32,8 @@ int main( int argc, char * argv[] )
   const int dofNum = cmd_h5r -> read_intScalar("/","dofNum");
   int in_ncommon = cmd_h5r -> read_intScalar("/","in_ncommon");
   const FEType elemType = FE_T::to_FEType(elemType_str);
+
+  cmd_h5r.reset();
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("ns_prepost.yml");

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -20,7 +20,6 @@
 #include "EBC_Partition_outflow.hpp"
 #include "EBC_Partition_WallModel.hpp"
 #include "yaml-cpp/yaml.h"
-#include <memory>
 
 int main( int argc, char * argv[] )
 {

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -20,6 +20,7 @@
 #include "EBC_Partition_outflow.hpp"
 #include "EBC_Partition_WallModel.hpp"
 #include "yaml-cpp/yaml.h"
+#include <memory>
 
 int main( int argc, char * argv[] )
 {
@@ -149,7 +150,7 @@ int main( int argc, char * argv[] )
   
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
   
-  IIEN * IEN = new IEN_FEM(nElem, vecIEN);
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
   VEC_T::clean( vecIEN ); // clean the vector
   
   const int nLocBas = FE_T::to_nLocBas(elemType);
@@ -157,16 +158,16 @@ int main( int argc, char * argv[] )
   SYS_T::print_fatal_if( IEN->get_nLocBas() != nLocBas, "Error: the nLocBas from the Mesh %d and the IEN %d classes do not match. \n", nLocBas, IEN->get_nLocBas() );
 
   // Call METIS to partition the mesh 
-  IGlobal_Part * global_part = nullptr;
+  std::unique_ptr<IGlobal_Part> global_part = nullptr;
   if(cpu_size > 1)
-    global_part = new Global_Part_METIS( cpu_size, in_ncommon,
-        isDualGraph, nElem, nFunc, nLocBas, IEN, "epart", "npart" );
+    global_part = SYS_T::make_unique<Global_Part_METIS>( cpu_size, in_ncommon,
+        isDualGraph, nElem, nFunc, nLocBas, IEN.get(), "epart", "npart" );
   else if(cpu_size == 1)
-    global_part = new Global_Part_Serial( nElem, nFunc, "epart", "npart" );
+    global_part = SYS_T::make_unique<Global_Part_Serial>( nElem, nFunc, "epart", "npart" );
   else SYS_T::print_fatal("ERROR: wrong cpu_size: %d \n", cpu_size);
 
   // Generate the new nodal numbering
-  Map_Node_Index * mnindex = new Map_Node_Index(global_part, cpu_size, nFunc);
+  auto mnindex = SYS_T::make_unique<Map_Node_Index>(global_part.get(), cpu_size, nFunc);
   mnindex->write_hdf5("node_mapping");
 
   // Setup Nodal i.e. Dirichlet type Boundary Conditions
@@ -195,21 +196,21 @@ int main( int argc, char * argv[] )
   if(elemType == FEType::Tet4 || elemType == FEType::Tet10)
   {
     for(unsigned int ii=0; ii<sur_file_in.size(); ++ii)
-      inlet_outvec[ii] = TET_T::get_out_normal( sur_file_in[ii], ctrlPts, IEN );    
+      inlet_outvec[ii] = TET_T::get_out_normal( sur_file_in[ii], ctrlPts, IEN.get() );    
   }
   else if(elemType == FEType::Hex8 || elemType == FEType::Hex27)
   {
     for(unsigned int ii=0; ii<sur_file_in.size(); ++ii)
-      inlet_outvec[ii] = HEX_T::get_out_normal( sur_file_in[ii], ctrlPts, IEN );  
+      inlet_outvec[ii] = HEX_T::get_out_normal( sur_file_in[ii], ctrlPts, IEN.get() );  
   }
   else
     SYS_T::print_fatal("Error: unknown element type occurs when obtaining the outward normal vector for the inflow boundary condition. \n");
 
-  INodalBC * InFBC = new NodalBC_3D_inflow( sur_file_in, sur_file_wall,
+  auto InFBC = SYS_T::make_unique<NodalBC_3D_inflow>( sur_file_in, sur_file_wall,
       nFunc, inlet_outvec, elemType );
   
   // reset IEN for outward normal calculations
-  InFBC -> resetSurIEN_outwardnormal( IEN );
+  InFBC -> resetSurIEN_outwardnormal( IEN.get() );
 
   // Setup Elemental Boundary Conditions
   // Obtain the outward normal vector
@@ -218,22 +219,22 @@ int main( int argc, char * argv[] )
   if(elemType == FEType::Tet4 || elemType == FEType::Tet10)
   {
     for(unsigned int ii=0; ii<sur_file_out.size(); ++ii)
-      outlet_outvec[ii] = TET_T::get_out_normal( sur_file_out[ii], ctrlPts, IEN );  
+      outlet_outvec[ii] = TET_T::get_out_normal( sur_file_out[ii], ctrlPts, IEN.get() );  
   }
   else if(elemType == FEType::Hex8 || elemType == FEType::Hex27)
   {
     for(unsigned int ii=0; ii<sur_file_out.size(); ++ii)
-      outlet_outvec[ii] = HEX_T::get_out_normal( sur_file_out[ii], ctrlPts, IEN );
+      outlet_outvec[ii] = HEX_T::get_out_normal( sur_file_out[ii], ctrlPts, IEN.get() );
   }
   else
     SYS_T::print_fatal("Error: unknown element type occurs when obtaining the outward normal vector for the elemental boundary conditions. \n");
 
-  ElemBC * ebc = new ElemBC_3D_outflow( sur_file_out, outlet_outvec, elemType );
+  auto ebc = SYS_T::make_unique<ElemBC_3D_outflow>( sur_file_out, outlet_outvec, elemType );
 
-  ebc -> resetSurIEN_outwardnormal( IEN ); // reset IEN for outward normal calculations
+  ebc -> resetSurIEN_outwardnormal( IEN.get() ); // reset IEN for outward normal calculations
 
   // Setup weakly enforced Dirichlet BC on wall if wall_model_type > 0
-  ElemBC * wbc = new ElemBC_3D_WallModel( weak_list, wall_model_type, IEN, elemType );
+  auto wbc = SYS_T::make_unique<ElemBC_3D_WallModel>( weak_list, wall_model_type, IEN.get(), elemType );
  
   // Start partition the mesh for each cpu_rank 
 
@@ -249,7 +250,7 @@ int main( int argc, char * argv[] )
     mytimer->Reset();
     mytimer->Start();
     auto part = SYS_T::make_unique<Part_FEM>( 
-        nElem, nFunc, nLocBas, global_part, mnindex, IEN,
+        nElem, nFunc, nLocBas, global_part.get(), mnindex.get(), IEN.get(),
         ctrlPts, proc_rank, cpu_size, elemType, 
         Field_Property(0, dofNum, true, "NS") );
     mytimer->Stop();
@@ -261,22 +262,22 @@ int main( int argc, char * argv[] )
     part -> print_part_loadbalance_edgecut();
     
     // Partition Nodal BC and write to h5 file
-    auto nbcpart = SYS_T::make_unique<NBC_Partition>(part.get(), mnindex, NBC_list);
+    auto nbcpart = SYS_T::make_unique<NBC_Partition>(part.get(), mnindex.get(), NBC_list);
     
     nbcpart -> write_hdf5( part_file );
 
     // Partition Nodal Inflow BC and write to h5 file
-    auto infpart = SYS_T::make_unique<NBC_Partition_inflow>(part.get(), mnindex, InFBC);
+    auto infpart = SYS_T::make_unique<NBC_Partition_inflow>(part.get(), mnindex.get(), InFBC.get());
     
     infpart->write_hdf5( part_file );
     
     // Partition Elemental BC and write to h5 file
-    auto ebcpart = SYS_T::make_unique<EBC_Partition_outflow>(part.get(), mnindex, ebc, NBC_list);
+    auto ebcpart = SYS_T::make_unique<EBC_Partition_outflow>(part.get(), mnindex.get(), ebc.get(), NBC_list);
 
     ebcpart -> write_hdf5( part_file );
 
     // Partition Weak BC and write to h5 file
-    auto wbcpart = SYS_T::make_unique<EBC_Partition_WallModel>(part.get(), mnindex, wbc);
+    auto wbcpart = SYS_T::make_unique<EBC_Partition_WallModel>(part.get(), mnindex.get(), wbc.get());
 
     wbcpart -> write_hdf5( part_file );
 
@@ -306,9 +307,6 @@ int main( int argc, char * argv[] )
 
   // Finalize the code and exit
   for(auto &it_nbc : NBC_list) delete it_nbc;
-
-  delete InFBC; delete ebc; delete wbc;
-  delete mnindex; delete global_part; delete IEN;
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Motivation
- Modernize memory management in the Navier–Stokes preprocessor by replacing raw heap allocations and manual `delete` calls with RAII-style smart pointers to prevent leaks and simplify ownership.

### Description
- Added `#include <memory>` and replaced raw `new` allocations with `SYS_T::make_unique` to create `unique_ptr` instances for `IEN_FEM`, `Global_Part_*`, `Map_Node_Index`, BC objects, and partition helper objects.
- Updated function calls and constructors to pass raw pointers from smart pointers using `.get()` where APIs expect raw pointers, and switched several local pointer declarations to `auto` or `std::unique_ptr` for clarity.
- Removed explicit `delete` calls at the end of `main` since object lifetimes are now managed by `unique_ptr`.

### Testing
- Verified that the modified source compiles as part of the examples build and the edited file `examples/ns/preprocess.cpp` compiles without errors.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c822f4e0832aa742bba09a96a2f0)