### PR TITLE
Refactor FEANode: simplify pointer parameter types in batch accessors

### DIFF
--- a/include/FEANode.hpp
+++ b/include/FEANode.hpp
@@ -64,8 +64,8 @@ class FEANode
     //         for index and ctrl_(x/y/z).
     // ------------------------------------------------------------------------
     virtual void get_ctrlPts_xyz( int num, const int * const &index, 
-        double * const &ctrl_x, double * const &ctrl_y, 
-        double * const &ctrl_z ) const;
+        double * ctrl_x, double * ctrl_y, 
+        double * ctrl_z ) const;
 
     virtual std::array<std::vector<double>, 3> get_ctrlPts_xyz( 
         const std::vector<int> &index ) const;
@@ -76,8 +76,8 @@ class FEANode
     //         for index and ctrl_(x/y/z/w).
     // ------------------------------------------------------------------------
     virtual void get_ctrlPts_xyzw( int num, const int * const &index, 
-        double * const &ctrl_x, double * const &ctrl_y, 
-        double * const &ctrl_z, double * const &ctrl_w ) const;
+        double * ctrl_x, double * ctrl_y, 
+        double * ctrl_z, double * ctrl_w ) const;
    
     // ------------------------------------------------------------------------
     // ! Get n control points' x-y-w in a batch
@@ -85,8 +85,8 @@ class FEANode
     //         for index and ctrl_(x/y/w).
     // ------------------------------------------------------------------------
     virtual void get_ctrlPts_xyw( int num, const int * const &index,
-        double * const &ctrl_x, double * const &ctrl_y,
-        double * const &ctrl_w ) const;
+        double * ctrl_x, double * ctrl_y,
+        double * ctrl_w ) const;
 
     // ------------------------------------------------------------------------
     // ! Get n contrl points' x-y in a batch
@@ -94,7 +94,7 @@ class FEANode
     //         for index and ctrl_(x/y).
     // ------------------------------------------------------------------------
     virtual void get_ctrlPts_xy( int num, const int * const &index,
-        double * const &ctrl_x, double * const &ctrl_y ) const;
+        double * ctrl_x, double * ctrl_y ) const;
 
     // ------------------------------------------------------------------------
     // ! Print the info for this class.

--- a/src/Analysis_Tool/FEANode.cpp
+++ b/src/Analysis_Tool/FEANode.cpp
@@ -46,7 +46,7 @@ void FEANode::print_info() const
 
 void FEANode::get_ctrlPts_xyz( 
     int num, const int * const &index,
-    double * const &ctrl_x, double * const &ctrl_y, double * const &ctrl_z ) const
+    double * ctrl_x, double * ctrl_y, double * ctrl_z ) const
 {
   for(int ii=0; ii<num; ++ii)
   {
@@ -76,8 +76,8 @@ std::array<std::vector<double>, 3> FEANode::get_ctrlPts_xyz(
 
 void FEANode::get_ctrlPts_xyzw( 
     int num, const int * const &index,
-    double * const &ctrl_x, double * const &ctrl_y, 
-    double * const &ctrl_z, double * const &ctrl_w ) const
+    double * ctrl_x, double * ctrl_y, 
+    double * ctrl_z, double * ctrl_w ) const
 {
   for(int ii=0; ii<num; ++ii)
   {
@@ -90,8 +90,8 @@ void FEANode::get_ctrlPts_xyzw(
 
 void FEANode::get_ctrlPts_xyw( 
     int num, const int * const &index,
-    double * const &ctrl_x, double * const &ctrl_y, 
-    double * const &ctrl_w ) const
+    double * ctrl_x, double * ctrl_y, 
+    double * ctrl_w ) const
 {
   for(int ii=0; ii<num; ++ii)
   {
@@ -103,7 +103,7 @@ void FEANode::get_ctrlPts_xyw(
 
 void FEANode::get_ctrlPts_xy( 
     int num, const int * const &index,
-    double * const &ctrl_x, double * const &ctrl_y ) const
+    double * ctrl_x, double * ctrl_y ) const
 {
   for(int ii=0; ii<num; ++ii)
   {


### PR DESCRIPTION
### Motivation
- Remove unnecessary reference-to-pointer parameter types (`double * const &`) from batch accessor APIs to simplify signatures and avoid potential confusion.
- Ensure consistent pointer formatting with a single space between `*` and the parameter name (e.g. `double * ctrl_x`) for readability and style consistency.

### Description
- Updated declarations in `include/FEANode.hpp` for `get_ctrlPts_xyz`, `get_ctrlPts_xyzw`, `get_ctrlPts_xyw`, and `get_ctrlPts_xy` to use `double *` for output-array parameters instead of `double * const &`.
- Synchronized the corresponding definitions in `src/Analysis_Tool/FEANode.cpp` to match the new declarations and preserved existing implementations.

### Testing
- Ran `rg "double \* const &ctrl_" -n include/FEANode.hpp src/Analysis_Tool/FEANode.cpp` to verify the old parameter form was removed, and the search returned no matches for the old pattern (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cc54c44c832a82aed9764bba8503)