### PR TITLE
Refactor ElemBC virtual int parameters to pass-by-value and sync overrides

### DIFF
--- a/include/ElemBC.hpp
+++ b/include/ElemBC.hpp
@@ -50,19 +50,19 @@ class ElemBC
     
     // This returns the number of nodes on the surface with ebc_id, wherein
     // 0 <= ebc_id < get_num_ebc() 
-    virtual int get_num_node(const int &ebc_id) const
+    virtual int get_num_node(int ebc_id) const
     {SYS_T::commPrint("Warning: get_num_node is not implemented. \n"); return 0;}
     
     // This returns the number of cells on the surface with ebc_id, wherein
     // 0 <= ebc_id < get_num_ebc()
-    virtual int get_num_cell(const int &ebc_id) const
+    virtual int get_num_cell(int ebc_id) const
     {SYS_T::commPrint("Warning: get_num_cell is not implemented. \n"); return 0;}
 
     // This returns the number of local nodes in the boundary cell. For example,
     // linear triangles return 3;
     // bilinear quad returns 4;
     // quadratic triangles return 6.
-    virtual int get_cell_nLocBas(const int &ebc_id) const
+    virtual int get_cell_nLocBas(int ebc_id) const
     {SYS_T::commPrint("Warning: get_cell_nLocBas is not implemented. \n"); return 0;}
     
     // This returns the coordinates of the nodal points, wherein
@@ -72,8 +72,8 @@ class ElemBC
     // dir = 0 => x direction
     // dir = 1 => y direction
     // dir = 2 => z direction
-    virtual double get_pt_xyz(const int &ebc_id, const int &node, 
-        const int &dir) const
+    virtual double get_pt_xyz(int ebc_id, int node, 
+        int dir) const
     {SYS_T::commPrint("Warning: get_pt_xyz is not implemented. \n"); return 0.0;}
 
     // This returns the connectivity for the surface cell with the node list
@@ -81,37 +81,37 @@ class ElemBC
     // 0 <= ebc_id < get_num_ebc();
     // 0 <= cell   < get_num_cell();
     // 0 <= lnode  < get_cell_nLocBas().
-    virtual int get_ien(const int &ebc_id, const int &cell, const int &lnode) const
+    virtual int get_ien(int ebc_id, int cell, int lnode) const
     {SYS_T::commPrint("Warning: get_ien is not implemented. \n"); return 0;}
 
     // This returns the global node index (i.e., the node indices in the
     // volumetric mesh) for nodes.
     // 0 <= ebc_id < get_num_ebc();
     // 0 <= node   < get_num_node(ebc_id);
-    virtual int get_global_node(const int &ebc_id, const int &node_index) const
+    virtual int get_global_node(int ebc_id, int node_index) const
     {SYS_T::commPrint("Warning: get_global_node is not implemented. \n"); return 0;}
 
-    virtual void get_global_node(const int &ebc_id,std::vector<int> &out) const
+    virtual void get_global_node(int ebc_id,std::vector<int> &out) const
     {SYS_T::commPrint("Warning: get_global_node is not implemented. \n");}
 
-    virtual std::vector<int> get_global_node(const int &ebc_id) const
+    virtual std::vector<int> get_global_node(int ebc_id) const
     {SYS_T::commPrint("Warning: get_global_node is not implemented. \n"); return {};}
 
     // This returns the global volumetric element index for the surface cells.
-    virtual int get_global_cell(const int &ebc_id, const int &cell_index) const
+    virtual int get_global_cell(int ebc_id, int cell_index) const
     {SYS_T::commPrint("Warning: get_global_cell is not implemented. \n"); return 0;}
 
     // This returns the cell's interior point's xyz coordinates.
-    virtual double get_intpt_xyz(const int &ebc_id, const int &cell_index,
-        const int &dir) const
+    virtual double get_intpt_xyz(int ebc_id, int cell_index,
+        int dir) const
     {SYS_T::commPrint("Warning: get_intpt_xyz is not implemented. \n"); return 0.0;}
 
     // This function returns the outward normal vector for faces
-    virtual Vector_3 get_normal_vec( const int &ebc_id ) const
+    virtual Vector_3 get_normal_vec( int ebc_id ) const
     {SYS_T::commPrint("Warning: get_normal_vec is not implemented. \n"); return Vector_3();}
 
     // This function returns the integral of basis NA on the faces
-    virtual std::vector<double> get_intNA( const int &ebc_id ) const
+    virtual std::vector<double> get_intNA( int ebc_id ) const
     {SYS_T::commPrint("Warning: get_intNA is not implemented.\n"); return {};}
 
     // Access the data in ElemBC_3D_wall_turbulence, wall model type
@@ -119,7 +119,7 @@ class ElemBC
     {SYS_T::commPrint("Warning: get_wall_model_type is not implemented. \n"); return -1;}
 
     // Access the data in ElemBC_3D_wall_turbulence, face id of volume element
-    virtual int get_faceID( const int &cell_index ) const
+    virtual int get_faceID( int cell_index ) const
     {SYS_T::commPrint("Warning: get_faceID is not implemented. \n"); return {};}
  
     // print the information of the ebc object on screen.    

--- a/include/ElemBC_3D.hpp
+++ b/include/ElemBC_3D.hpp
@@ -22,28 +22,28 @@ class ElemBC_3D : public ElemBC
 
     virtual int get_num_ebc() const {return num_ebc;}
 
-    virtual int get_num_node(const int &ebc_id) const {return num_node[ebc_id];}
+    virtual int get_num_node(int ebc_id) const {return num_node[ebc_id];}
 
-    virtual int get_num_cell(const int &ebc_id) const {return num_cell[ebc_id];}
+    virtual int get_num_cell(int ebc_id) const {return num_cell[ebc_id];}
 
-    virtual int get_cell_nLocBas(const int &ebc_id) const {return cell_nLocBas[ebc_id];}
+    virtual int get_cell_nLocBas(int ebc_id) const {return cell_nLocBas[ebc_id];}
 
-    virtual double get_pt_xyz(const int &ebc_id, const int &node, const int &dir) const
+    virtual double get_pt_xyz(int ebc_id, int node, int dir) const
     {return pt_xyz[ebc_id][3*node+dir];}
 
-    virtual int get_ien(const int &ebc_id, const int &cell, const int &lnode) const
+    virtual int get_ien(int ebc_id, int cell, int lnode) const
     {return sur_ien[ebc_id][ cell_nLocBas[ebc_id] * cell + lnode ];}
 
-    virtual int get_global_node(const int &ebc_id, const int &node_index) const
+    virtual int get_global_node(int ebc_id, int node_index) const
     {return global_node[ebc_id][node_index];}
 
-    virtual void get_global_node(const int &ebc_id, std::vector<int> &out) const
+    virtual void get_global_node(int ebc_id, std::vector<int> &out) const
     {out = global_node[ebc_id];}
 
-    virtual std::vector<int> get_global_node(const int &ebc_id) const
+    virtual std::vector<int> get_global_node(int ebc_id) const
     {return global_node[ebc_id];}
 
-    virtual int get_global_cell(const int &ebc_id, const int &cell_index) const
+    virtual int get_global_cell(int ebc_id, int cell_index) const
     {return global_cell[ebc_id][cell_index];}
 
     virtual void print_info() const;
@@ -75,11 +75,11 @@ class ElemBC_3D : public ElemBC
     virtual void resetSurIEN_outwardnormal( const IIEN * const &VIEN );
 
     // Access the data in ElemBC_3D_outflow, outward normal vector
-    virtual Vector_3 get_normal_vec( const int &ebc_id ) const
+    virtual Vector_3 get_normal_vec( int ebc_id ) const
     {SYS_T::commPrint("Warning: get_normal_vec is not implemented. \n"); return Vector_3();}
 
     // Access the data in ElemBC_3D_outflow, basis surface integration
-    virtual std::vector<double> get_intNA( const int &ebc_id ) const
+    virtual std::vector<double> get_intNA( int ebc_id ) const
     {SYS_T::commPrint("Warning: get_intNA is not implemented.\n"); return {};}
 
     // Access the data in ElemBC_3D_wall_turbulence, wall model type
@@ -87,7 +87,7 @@ class ElemBC_3D : public ElemBC
     {SYS_T::commPrint("Warning: get_wall_model_type is not implemented. \n"); return -1;}
 
     // Access the data in ElemBC_3D_wall_turbulence, face id of volume element
-    virtual int get_faceID( const int &cell_index ) const
+    virtual int get_faceID( int cell_index ) const
     {SYS_T::commPrint("Warning: get_faceID is not implemented. \n"); return {};}
 
   protected:

--- a/include/ElemBC_3D_WallModel.hpp
+++ b/include/ElemBC_3D_WallModel.hpp
@@ -37,7 +37,7 @@ class ElemBC_3D_WallModel : public ElemBC_3D
 
     virtual int get_wall_model_type() const { return wall_model_type; };
 
-    virtual int get_faceID( const int &cell_index ) const { return face_id[cell_index]; }
+    virtual int get_faceID( int cell_index ) const { return face_id[cell_index]; }
 
   private:
     // Wall model type

--- a/include/ElemBC_3D_outflow.hpp
+++ b/include/ElemBC_3D_outflow.hpp
@@ -33,10 +33,10 @@ class ElemBC_3D_outflow : public ElemBC_3D
 
     virtual void print_info() const;
 
-    virtual Vector_3 get_normal_vec( const int &ebc_id ) const
+    virtual Vector_3 get_normal_vec( int ebc_id ) const
     { return outNormal[ebc_id]; }
 
-    virtual std::vector<double> get_intNA( const int &ebc_id ) const
+    virtual std::vector<double> get_intNA( int ebc_id ) const
     { return intNA[ebc_id]; }
 
   private:


### PR DESCRIPTION
### Motivation
- Reduce unnecessary pass-by-reference for scalar `int` parameters in the `ElemBC` virtual interface and ensure derived-class overrides keep matching signatures.
- Prevent subtle ABI/signature mismatches between base and derived classes after the interface change.

### Description
- Updated virtual method signatures in `include/ElemBC.hpp` to use `int` (pass-by-value) instead of `const int &` for scalar parameters such as `ebc_id`, `node`, `dir`, `cell`, `lnode`, `node_index`, and `cell_index`.
- Synchronized the overridden signatures in derived headers: `include/ElemBC_3D.hpp`, `include/ElemBC_3D_outflow.hpp`, and `include/ElemBC_3D_WallModel.hpp` so all overrides match the base class.
- Performed the replacements via a small script to update the affected headers consistently across the codebase.

### Testing
- Ran a targeted search for legacy `const int &` usage in the modified ElemBC headers with `rg` and confirmed the relevant virtual signatures no longer use `const int &` (search returned no matches).
- Inspected the updated header contents with `nl`/file prints to verify signatures in `ElemBC.hpp`, `ElemBC_3D.hpp`, `ElemBC_3D_outflow.hpp`, and `ElemBC_3D_WallModel.hpp` were updated as intended and are consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74a07e8ec832aa83196a563915fc7)