### PR TITLE
Make VTK_Writer_NS stateless: convert class to namespace and change writeOutput signature

### DIFF
--- a/examples/ns/include/VTK_Writer_NS.hpp
+++ b/examples/ns/include/VTK_Writer_NS.hpp
@@ -18,33 +18,24 @@
 
 #include "vtkIntArray.h"
 
-class VTK_Writer_NS
+namespace VTK_Writer_NS
 {
-  public:
-    VTK_Writer_NS( const int &in_nelem, const int &in_nlocbas, 
-        const std::string &epart_file );
-
-    ~VTK_Writer_NS() = default;
-    
-    void writeOutput(
-        const FEANode * const &fnode_ptr,
-        const ALocal_IEN * const &lien_ptr,
-        const ALocal_Elem * const &lelem_ptr,
-        const IVisDataPrep * const &vdata_ptr,
-        FEAElement * const &elemptr,
-        const IQuadPts * const &quad,
-        const double * const * const &pointArrays,
-        const int &rank, const int &size,
-        const double &sol_time,
-        const std::string &basename,
-        const std::string &outputBName,
-        const std::string &outputName,
-        const bool &isXML );
-
-  private:
-    const int nLocBas, nElem;
-
-    std::vector<int> epart_map;
-};
+  void writeOutput(
+      const FEANode * const &fnode_ptr,
+      const ALocal_IEN * const &lien_ptr,
+      const ALocal_Elem * const &lelem_ptr,
+      const IVisDataPrep * const &vdata_ptr,
+      FEAElement * const &elemptr,
+      const IQuadPts * const &quad,
+      const double * const * const &pointArrays,
+      const std::vector<int> &epart_map,
+      const int &nLocBas,
+      const int &rank, const int &size,
+      const double &sol_time,
+      const std::string &basename,
+      const std::string &outputBName,
+      const std::string &outputName,
+      const bool &isXML );
+}
 
 #endif

--- a/examples/ns/src/VTK_Writer_NS.cpp
+++ b/examples/ns/src/VTK_Writer_NS.cpp
@@ -1,12 +1,5 @@
 #include "VTK_Writer_NS.hpp"
 
-VTK_Writer_NS::VTK_Writer_NS( const int &in_nelem,
-    const int &in_nlocbas, const std::string &epart_file )
-: nLocBas( in_nlocbas ), nElem( in_nelem ) 
-{
-  epart_map = VIS_T::read_epart( epart_file, nElem );
-}
-
 void VTK_Writer_NS::writeOutput(
     const FEANode * const &fnode_ptr,
     const ALocal_IEN * const &lien_ptr,
@@ -15,6 +8,8 @@ void VTK_Writer_NS::writeOutput(
     FEAElement * const &elemptr,
     const IQuadPts * const &quad,
     const double * const * const &pointArrays,
+    const std::vector<int> &epart_map,
+    const int &nLocBas,
     const int &rank, const int &size,
     const double &sol_time,
     const std::string &basename,

--- a/examples/ns/vis.cpp
+++ b/examples/ns/vis.cpp
@@ -107,9 +107,7 @@ int main( int argc, char * argv[] )
   for(int ii=0; ii<visprep->get_ptarray_size(); ++ii)
     solArrays[ii] = new double [pNode->get_nlocghonode() * visprep->get_ptarray_comp_length(ii)];
 
-  // VTK writer 
-  auto vtk_w = SYS_T::make_unique<VTK_Writer_NS>( GMIptr->get_nElem(), 
-      GMIptr->get_nLocBas(), element_part_file );
+  const auto epart_map = VIS_T::read_epart( element_part_file, GMIptr->get_nElem() );
 
   const auto anode_mapping = HDF5_T::read_intVector("node_mapping.h5", "/", "old_2_new");
   const auto pnode_mapping = HDF5_T::read_intVector("post_node_mapping.h5", "/", "new_2_old");
@@ -126,8 +124,9 @@ int main( int argc, char * argv[] )
     visprep->get_pointArray(name_to_read, anode_mapping, pnode_mapping,
         pNode.get(), dof, solArrays);
 
-    vtk_w->writeOutput( fNode.get(), locIEN.get(), locElem.get(),
-        visprep.get(), element.get(), quad.get(), solArrays,
+    VTK_Writer_NS::writeOutput( fNode.get(), locIEN.get(), locElem.get(),
+        visprep.get(), element.get(), quad.get(), solArrays, epart_map,
+        GMIptr->get_nLocBas(),
         rank, size, time * dt, sol_bname, out_bname, name_to_write, isXML );
   }
 


### PR DESCRIPTION
### Motivation

- Remove internal state from the VTK writer and simplify its use by turning the class into a stateless namespace-level API.
- Let the call site own partition mapping (`epart_map`) and local-basis size so the writer no longer needs a constructor or internal members.

### Description

- Replaced the `VTK_Writer_NS` class with a `VTK_Writer_NS` namespace and made `writeOutput` a free function declared in `examples/ns/include/VTK_Writer_NS.hpp`.
- Changed `writeOutput` signature to accept `const std::vector<int> &epart_map` and `const int &nLocBas` instead of reading `epart_map` in a constructor, and removed the class constructor and member variables from `examples/ns/src/VTK_Writer_NS.cpp`.
- Moved the `epart_map` loading to the caller in `examples/ns/vis.cpp` by calling `VIS_T::read_epart` and updated the `writeOutput` invocation accordingly.
- Updated call sites and includes to match the new namespace/function API.

### Testing

- Built the project with the modified sources using the normal build system (`cmake`/`make`), and the build completed successfully.
- Performed a smoke run of the `examples/ns/vis` example with the updated call to `VTK_Writer_NS::writeOutput`, which executed without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e964be6f60832a99d2dedc2f163960)