### PR TITLE
Use RAII for HDF5 writer lifecycle in ns examples

### DIFF
--- a/examples/ns/ns_herk_driver.cpp
+++ b/examples/ns/ns_herk_driver.cpp
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
+    auto cmdh5w = SYS_T::make_unique<HDF5_Writer>("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("fl_density", fluid_density);
     cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
@@ -160,7 +160,6 @@ int main(int argc, char *argv[])
     // cmdh5w->write_string("lpn_file", lpn_file);
     cmdh5w->write_string("inflow_file", inflow_file);
     cmdh5w->write_string("dot_inflow_file", dot_inflow_file);
-    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ns/ns_herk_driver_accurateA.cpp
+++ b/examples/ns/ns_herk_driver_accurateA.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
   // ===== Record important solver options =====
   if(rank == 0)
   {
-    HDF5_Writer * cmdh5w = new HDF5_Writer("solver_cmd.h5");
+    auto cmdh5w = SYS_T::make_unique<HDF5_Writer>("solver_cmd.h5");
 
     cmdh5w->write_doubleScalar("fl_density", fluid_density);
     cmdh5w->write_doubleScalar("fl_mu", fluid_mu);
@@ -161,7 +161,6 @@ int main(int argc, char *argv[])
     // cmdh5w->write_string("lpn_file", lpn_file);
     cmdh5w->write_string("inflow_file", inflow_file);
     cmdh5w->write_string("dot_inflow_file", dot_inflow_file);
-    delete cmdh5w;
   }
 
   MPI_Barrier(PETSC_COMM_WORLD);

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -125,7 +125,7 @@ int main( int argc, char * argv[] )
   }
 
   // Record the problem setting into a HDF5 file: preprocessor_cmd.h5
-  HDF5_Writer * cmdh5w = new HDF5_Writer("preprocessor_cmd.h5");
+  auto cmdh5w = SYS_T::make_unique<HDF5_Writer>("preprocessor_cmd.h5");
 
   cmdh5w->write_intScalar("num_inlet", num_inlet);
   cmdh5w->write_intScalar("num_outlet", num_outlet);
@@ -139,8 +139,6 @@ int main( int argc, char * argv[] )
   cmdh5w->write_string("sur_file_out_base", sur_file_out_base);
   cmdh5w->write_string("sur_file_wall", sur_file_wall);
   cmdh5w->write_string("part_file", part_file);
-
-  delete cmdh5w;
 
   // Read the volumetric mesh file from the vtu file: geo_file
   int nFunc, nElem;


### PR DESCRIPTION
### Motivation
- Replace manual `new`/`delete` management of `HDF5_Writer` with RAII to prevent leaks and simplify ownership.
- Align resource management in the `examples/ns` code with the project's existing `SYS_T::make_unique` usage.

### Description
- Replaced `HDF5_Writer * cmdh5w = new HDF5_Writer(...)` with `auto cmdh5w = SYS_T::make_unique<HDF5_Writer>(...)` in `examples/ns/ns_herk_driver.cpp`.
- Applied the same change in `examples/ns/ns_herk_driver_accurateA.cpp`.
- Replaced manual allocation in `examples/ns/preprocess.cpp` and removed the explicit `delete` calls now handled by the smart pointer.
- Committed the changes with a descriptive message and updated three files in total.

### Testing
- Ran `rg -n "HDF5_Writer \*|new HDF5_Writer|delete cmdh5w" examples/ns` to confirm the manual allocation/deallocation sites in the touched paths were removed, which succeeded.
- Verified repository status with `git status --short` and committed the change, which produced `3 files changed, 3 insertions(+), 7 deletions(-)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96795bc58832ab948992299b12ce6)