### PR TITLE
Centralize body force: add LoadData::body_force and replace get_f usages

### DIFF
--- a/examples/ns/include/LoadData.hpp
+++ b/examples/ns/include/LoadData.hpp
@@ -1,0 +1,19 @@
+#ifndef NS_LOADDATA_HPP
+#define NS_LOADDATA_HPP
+
+#include "Vector_3.hpp"
+
+namespace LoadData
+{
+  // --------------------------------------------------------------------------
+  // body_force
+  //   Body force density per unit mass, i.e. acceleration-like term b(x,t).
+  //   It is multiplied by rho0 during assembly where needed.
+  // --------------------------------------------------------------------------
+  inline Vector_3 body_force( const Vector_3 &pt, const double &tt )
+  {
+    return Vector_3(0.0, 0.0, 0.0);
+  }
+}
+
+#endif

--- a/examples/ns/include/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.hpp
+++ b/examples/ns/include/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.hpp
@@ -183,12 +183,6 @@ class PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha : public IPLocAssem_2x2Block
       void get_DC( double &dc_tau, const double * const &dxi_dx,
           const double &u, const double &v, const double &w ) const;
 
-      void get_f(const double &x, const double &y, const double &z,
-          const double &t, double &fx, double &fy, double &fz ) const
-      {
-        fx = 0.0; fy = 0.0; fz = 0.0;
-      }
-
       void get_H1(const double &x, const double &y, const double &z,
           const double &t, const double &nx, const double &ny,
           const double &nz, double &gx, double &gy, double &gz ) const

--- a/examples/ns/include/PLocAssem_Block_VMS_NS_HERK.hpp
+++ b/examples/ns/include/PLocAssem_Block_VMS_NS_HERK.hpp
@@ -253,11 +253,6 @@ class PLocAssem_Block_VMS_NS_HERK
     double get_DC( const std::array<double, 9> &dxi_dx,
         const double &u, const double &v, const double &w ) const;
 
-    Vector_3 get_f(const Vector_3 &pt, const double &tt) const
-    {
-      return Vector_3( 0.0, 0.0, 0.0 );
-    }
-
     Vector_3 get_H1(const Vector_3 &pt, const double &tt, 
         const Vector_3 &n_out ) const
     {

--- a/examples/ns/include/PLocAssem_VMS_NS_GenAlpha.hpp
+++ b/examples/ns/include/PLocAssem_VMS_NS_GenAlpha.hpp
@@ -166,11 +166,6 @@ class PLocAssem_VMS_NS_GenAlpha : public IPLocAssem
     double get_DC( const std::array<double, 9> &dxi_dx,
         const double &u, const double &v, const double &w ) const;
 
-    Vector_3 get_f(const Vector_3 &pt, const double &tt) const
-    {
-      return Vector_3( 0.0, 0.0, 0.0 );
-    }
-
     Vector_3 get_H1(const Vector_3 &pt, const double &tt, 
         const Vector_3 &n_out ) const
     {

--- a/examples/ns/src/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.cpp
+++ b/examples/ns/src/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.cpp
@@ -1,4 +1,5 @@
 #include "PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.hpp"
+#include "LoadData.hpp"
 
 PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha(
     const TimeMethod_GenAlpha * const &tm_gAlpha,
@@ -253,7 +254,8 @@ void PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::Assem_Residual(
     const double gwts = element->get_detJac(qua) * quad->get_qw(qua);
 
     // Get the body force
-    get_f(coor_x, coor_y, coor_z, curr, fx, fy, fz);
+    const Vector_3 f_body = LoadData::body_force( Vector_3(coor_x, coor_y, coor_z), curr );
+    fx = f_body.x(); fy = f_body.y(); fz = f_body.z();
 
     const double u_lap = u_xx + u_yy + u_zz;
     const double v_lap = v_xx + v_yy + v_zz;
@@ -425,7 +427,8 @@ void PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::Assem_Tangent_Residual(
 
     const double gwts = element->get_detJac(qua) * quad->get_qw(qua); 
 
-    get_f(coor_x, coor_y, coor_z, curr, fx, fy, fz);
+    const Vector_3 f_body = LoadData::body_force( Vector_3(coor_x, coor_y, coor_z), curr );
+    fx = f_body.x(); fy = f_body.y(); fz = f_body.z();
 
     const double u_lap = u_xx + u_yy + u_zz;
     const double v_lap = v_xx + v_yy + v_zz;
@@ -749,7 +752,8 @@ void PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::Assem_Mass_Residual(
 
     const double gwts = element->get_detJac(qua) * quad->get_qw(qua);
 
-    get_f(coor_x, coor_y, coor_z, curr, fx, fy, fz);
+    const Vector_3 f_body = LoadData::body_force( Vector_3(coor_x, coor_y, coor_z), curr );
+    fx = f_body.x(); fy = f_body.y(); fz = f_body.z();
 
     for(int A=0; A<nLocBas; ++A)
     {

--- a/examples/ns/src/PLocAssem_Block_VMS_NS_HERK.cpp
+++ b/examples/ns/src/PLocAssem_Block_VMS_NS_HERK.cpp
@@ -1,4 +1,5 @@
 #include "PLocAssem_Block_VMS_NS_HERK.hpp"
+#include "LoadData.hpp"
 
 PLocAssem_Block_VMS_NS_HERK::PLocAssem_Block_VMS_NS_HERK(
     const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
@@ -590,19 +591,19 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Sub(
                                                v[jj] * u_y[jj] + w[jj] * u_z[jj] );
         sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj]
                                          + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
-        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
 
         sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj]
                                              + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
         sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj]
                                          + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
-        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
         sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj]
                                              + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
         sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj]
                                          + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
-        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
       }
 
       for(int jj=0; jj<index-1; ++jj)
@@ -639,7 +640,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Sub(
       sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj]
                                                    + w_pre_xz[jj] + u_pre_xx[jj]
                                                    + u_pre_yy[jj] + u_pre_zz[jj] );
-      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
 
       sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj]
                                                    + v_pre[jj] * v_pre_y[jj]
@@ -647,7 +648,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Sub(
       sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj]
                                                    + w_pre_yz[jj] + v_pre_xx[jj]
                                                    + v_pre_yy[jj] + v_pre_zz[jj] );
-      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj]
                                                    + v_pre[jj] * w_pre_y[jj]
@@ -655,7 +656,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Sub(
       sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj]
                                                    + w_pre_zz[jj] + w_pre_xx[jj]
                                                    + w_pre_yy[jj] + w_pre_zz[jj] );
-      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -1006,19 +1007,19 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Final(
                                              + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
         sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj]
                                          + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
-        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
 
         sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj]
                                              + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
         sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj]
                                          + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
-        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
         sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj]
                                              + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
         sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj]
                                          + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
-        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
       }
 
       for(int jj=0; jj<index-1; ++jj)
@@ -1057,7 +1058,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Final(
       sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj]
                                                    + w_pre_xz[jj] + u_pre_xx[jj]
                                                    + u_pre_yy[jj] + u_pre_zz[jj] );
-      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
 
       sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj]
                                                    + v_pre[jj] * v_pre_y[jj]
@@ -1065,7 +1066,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Final(
       sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj]
                                                    + w_pre_yz[jj] + v_pre_xx[jj]
                                                    + v_pre_yy[jj] + v_pre_zz[jj] );
-      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj]
                                                    + v_pre[jj] * w_pre_y[jj]
@@ -1073,7 +1074,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Final(
       sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj]
                                                    + w_pre_zz[jj] + w_pre_xx[jj]
                                                    + w_pre_yy[jj] + w_pre_zz[jj] );
-      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -1098,19 +1099,19 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Final(
                                                    + w[jj] * u_z[jj] );
       sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj]
                                                    + u_yy[jj] + u_zz[jj] );
-      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
 
       sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj]
                                                    + w[jj] * v_z[jj] );
       sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj]
                                                    + v_yy[jj] + v_zz[jj] );
-      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj]
                                                    + w[jj] * w_z[jj] );
       sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj]
                                                    + w_yy[jj] + w_zz[jj] );
-      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -1451,19 +1452,19 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Pressure(
                                                    + w[jj] * u_z[jj] );
       sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj]
                                                    + u_yy[jj] + u_zz[jj] );
-      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
 
       sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj]
                                                    + w[jj] * v_z[jj] );
       sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj]
                                                    + v_yy[jj] + v_zz[jj] );
-      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj]
                                                    + w[jj] * w_z[jj] );
       sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj]
                                                    + w_yy[jj] + w_zz[jj] );
-      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -1496,11 +1497,11 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Pressure(
     const double w_np1_diffu = u_np1_xz + v_np1_yz + w_np1_zz + w_np1_xx + w_np1_yy + w_np1_zz;
 
     const double dot_u_np1_prime = -1.0 * tau_m * ( rho0 * dot_u_np1 +  p_np1_x + rho0 * u_np1_adevc
-                                        - vis_mu * u_np1_diffu - rho0 * get_f( coor, time + dt ).x() );
+                                        - vis_mu * u_np1_diffu - rho0 * LoadData::body_force( coor, time + dt ).x() );
     const double dot_v_np1_prime = -1.0 * tau_m * ( rho0 * dot_v_np1 +  p_np1_y + rho0 * v_np1_adevc
-                                        - vis_mu * v_np1_diffu - rho0 * get_f( coor, time + dt ).y() );
+                                        - vis_mu * v_np1_diffu - rho0 * LoadData::body_force( coor, time + dt ).y() );
     const double dot_w_np1_prime = -1.0 * tau_m * ( rho0 * dot_w_np1 +  p_np1_z + rho0 * w_np1_adevc
-                                        - vis_mu * w_np1_diffu - rho0 * get_f( coor, time + dt ).z() );    
+                                        - vis_mu * w_np1_diffu - rho0 * LoadData::body_force( coor, time + dt ).z() );    
 
     const double div_dot_vel_np1 = dot_u_np1_x + dot_v_np1_y + dot_w_np1_z;
     const double p_np1_prime = -1.0 * tau_c * div_dot_vel_np1;
@@ -1559,7 +1560,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Pressure(
                                    - NA_y * dot_v_np1_prime - NA_z * dot_w_np1_prime );
 
       Residual1[3*A + 0] += gwts * ( NA * rho0 * dot_u_np1 - NA_x * p_np1 + NA * rho0 * dot_u_np1_prime 
-                                   - NA_x * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).x() 
+                                   - NA_x * p_np1_prime - NA * rho0 * LoadData::body_force( coor, time + dt ).x() 
                                    + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu *  u_diffu1_3 
                                    - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
                                    - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
@@ -1567,7 +1568,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Pressure(
                                    - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
 
       Residual1[3*A + 1] += gwts * ( NA * rho0 * dot_v_np1 - NA_y * p_np1 + NA * rho0 * dot_v_np1_prime
-                                   - NA_y * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).y() 
+                                   - NA_y * p_np1_prime - NA * rho0 * LoadData::body_force( coor, time + dt ).y() 
                                    + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
                                    - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
                                    - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
@@ -1575,7 +1576,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_Pressure(
                                    - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
 
       Residual1[3*A + 2] += gwts * ( NA * rho0 * dot_w_np1 - NA_z * p_np1+ NA * rho0 * dot_w_np1_prime 
-                                   - NA_z * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).z()
+                                   - NA_z * p_np1_prime - NA * rho0 * LoadData::body_force( coor, time + dt ).z()
                                    + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
                                    - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
                                    - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3
@@ -1811,15 +1812,15 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Sub(
       {
         sum_u_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
         sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
-        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
 
         sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
         sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
-        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
         sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
         sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
-        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
       }
 
       for(int jj=0; jj<index-1; ++jj)
@@ -1846,15 +1847,15 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Sub(
     {
       sum_u_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * u_pre_x[jj] + v_pre[jj] * u_pre_y[jj] + w_pre[jj] * u_pre_z[jj] );
       sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj] + w_pre_xz[jj] + u_pre_xx[jj] + u_pre_yy[jj] + u_pre_zz[jj] );
-      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
   
       sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj] + v_pre[jj] * v_pre_y[jj] + w_pre[jj] * v_pre_z[jj] );
       sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj] + w_pre_yz[jj] + v_pre_xx[jj] + v_pre_yy[jj] + v_pre_zz[jj] );
-      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj] + v_pre[jj] * w_pre_y[jj] + w_pre[jj] * w_pre_z[jj] );
       sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj] + w_pre_zz[jj] + w_pre_xx[jj] + w_pre_yy[jj] + w_pre_zz[jj] );
-      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -2270,15 +2271,15 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Final(
       {
         sum_u_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
         sum_u_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
-        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
+        sum_a_fx[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x();
 
         sum_v_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
         sum_v_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
-        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+        sum_a_fy[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
         sum_w_advec[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
         sum_w_diffu[index] += tm_RK_ptr->get_RK_a(index, jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
-        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
+        sum_a_fz[index] += tm_RK_ptr->get_RK_a(index, jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z();     
       }
 
       for(int jj=0; jj<index-1; ++jj)
@@ -2307,15 +2308,15 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Final(
     {
       sum_u_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * u_pre_x[jj] + v_pre[jj] * u_pre_y[jj] + w_pre[jj] * u_pre_z[jj] );
       sum_u_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xx[jj] + v_pre_xy[jj] + w_pre_xz[jj] + u_pre_xx[jj] + u_pre_yy[jj] + u_pre_zz[jj] );
-      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
   
       sum_v_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * v_pre_x[jj] + v_pre[jj] * v_pre_y[jj] + w_pre[jj] * v_pre_z[jj] );
       sum_v_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xy[jj] + v_pre_yy[jj] + w_pre_yz[jj] + v_pre_xx[jj] + v_pre_yy[jj] + v_pre_zz[jj] );
-      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_pre_advec += tm_RK_ptr->get_RK_b(jj) * ( u_pre[jj] * w_pre_x[jj] + v_pre[jj] * w_pre_y[jj] + w_pre[jj] * w_pre_z[jj] );
       sum_w_pre_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_pre_xz[jj] + v_pre_yz[jj] + w_pre_zz[jj] + w_pre_xx[jj] + w_pre_yy[jj] + w_pre_zz[jj] );
-      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_pre += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time - dt + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -2344,15 +2345,15 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Final(
     {
       sum_u_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
       sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
-      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
   
       sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
       sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
-      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
       sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
-      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -2740,15 +2741,15 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Pressure(
     {
       sum_u_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * u_x[jj] + v[jj] * u_y[jj] + w[jj] * u_z[jj] );
       sum_u_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xx[jj] + v_xy[jj] + w_xz[jj] + u_xx[jj] + u_yy[jj] + u_zz[jj] );
-      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
+      sum_a_fx_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).x(); 
   
       sum_v_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * v_x[jj] + v[jj] * v_y[jj] + w[jj] * v_z[jj] );
       sum_v_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xy[jj] + v_yy[jj] + w_yz[jj] + v_xx[jj] + v_yy[jj] + v_zz[jj] );
-      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
+      sum_a_fy_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).y();
 
       sum_w_cur_advec += tm_RK_ptr->get_RK_b(jj) * ( u[jj] * w_x[jj] + v[jj] * w_y[jj] + w[jj] * w_z[jj] );
       sum_w_cur_diffu += tm_RK_ptr->get_RK_b(jj) * ( u_xz[jj] + v_yz[jj] + w_zz[jj] + w_xx[jj] + w_yy[jj] + w_zz[jj] );
-      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * get_f( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
+      sum_a_fz_cur += tm_RK_ptr->get_RK_b(jj) * LoadData::body_force( coor, time + tm_RK_ptr->get_RK_c(jj) * dt ).z(); 
     }
 
     for(int jj=0; jj<num_steps-1; ++jj)
@@ -2775,11 +2776,11 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Pressure(
     const double w_np1_diffu = u_np1_xz + v_np1_yz + w_np1_zz + w_np1_xx + w_np1_yy + w_np1_zz;
 
     const double dot_u_np1_prime = -1.0 * tau_m * ( rho0 * dot_u_np1 +  p_np1_x + rho0 * u_np1_adevc 
-                                        - vis_mu * u_np1_diffu - rho0 * get_f( coor, time + dt ).x() );
+                                        - vis_mu * u_np1_diffu - rho0 * LoadData::body_force( coor, time + dt ).x() );
     const double dot_v_np1_prime = -1.0 * tau_m * ( rho0 * dot_v_np1 +  p_np1_y + rho0 * v_np1_adevc
-                                        - vis_mu * v_np1_diffu - rho0 * get_f( coor, time + dt ).y() );
+                                        - vis_mu * v_np1_diffu - rho0 * LoadData::body_force( coor, time + dt ).y() );
     const double dot_w_np1_prime = -1.0 * tau_m * ( rho0 * dot_w_np1 +  p_np1_z + rho0 * w_np1_adevc
-                                        - vis_mu * w_np1_diffu - rho0 * get_f( coor, time + dt ).z() );    
+                                        - vis_mu * w_np1_diffu - rho0 * LoadData::body_force( coor, time + dt ).z() );    
 
     const double div_dot_vel_np1 = dot_u_np1_x + dot_v_np1_y + dot_w_np1_z;
     const double p_np1_prime = -1.0 * tau_c * div_dot_vel_np1;
@@ -2837,7 +2838,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Pressure(
       Residual0[ A     ] += gwts * ( NA * div_dot_vel_np1 - NA_x * dot_u_np1_prime - NA_y * dot_v_np1_prime - NA_z * dot_w_np1_prime );
 
       Residual1[3*A + 0] += gwts * ( NA * rho0 * dot_u_np1 - NA_x * p_np1 + NA * rho0 * dot_u_np1_prime 
-                                   - NA_x * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).x() 
+                                   - NA_x * p_np1_prime - NA * rho0 * LoadData::body_force( coor, time + dt ).x() 
                                    + NA_x * vis_mu * u_diffu1_1 + NA_y * vis_mu * u_diffu1_2 + NA_z * vis_mu *  u_diffu1_3 
                                    - NA_xx * vis_mu * u_diffu2_1 - NA_xy * vis_mu * v_diffu2_2 - NA_xz * vis_mu * w_diffu2_3 
                                    - NA_xx * vis_mu * u_diffu2_1 - NA_yy * vis_mu * u_diffu2_1 - NA_zz * vis_mu * u_diffu2_1
@@ -2845,7 +2846,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Pressure(
                                    - NA_x * rho0 * u_stab2_1 - NA_y * rho0 * u_stab2_2 - NA_z * rho0 * u_stab2_3 );
 
       Residual1[3*A + 1] += gwts * ( NA * rho0 * dot_v_np1 - NA_y * p_np1 + NA * rho0 * dot_v_np1_prime 
-                                   - NA_y * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).y() 
+                                   - NA_y * p_np1_prime - NA * rho0 * LoadData::body_force( coor, time + dt ).y() 
                                    + NA_x * vis_mu * v_diffu1_1 + NA_y * vis_mu * v_diffu1_2 + NA_z * vis_mu * v_diffu1_3
                                    - NA_xy * vis_mu * u_diffu2_1 - NA_yy * vis_mu * v_diffu2_2 - NA_yz * vis_mu * w_diffu2_3
                                    - NA_xx * vis_mu * v_diffu2_2 - NA_yy * vis_mu * v_diffu2_2 - NA_zz * vis_mu * v_diffu2_2
@@ -2853,7 +2854,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Tangent_Residual_Pressure(
                                    - NA_x * rho0 * v_stab2_1 - NA_y * rho0 * v_stab2_2 - NA_z * rho0 * v_stab2_3 );
 
       Residual1[3*A + 2] += gwts * ( NA * rho0 * dot_w_np1 - NA_z * p_np1+ NA * rho0 * dot_w_np1_prime
-                                   - NA_z * p_np1_prime - NA * rho0 * get_f( coor, time + dt ).z()
+                                   - NA_z * p_np1_prime - NA * rho0 * LoadData::body_force( coor, time + dt ).z()
                                    + NA_x * vis_mu * w_diffu1_1 + NA_y * vis_mu * w_diffu1_2 + NA_z * vis_mu * w_diffu1_3
                                    - NA_xz * vis_mu * u_diffu2_1 - NA_yz * vis_mu * v_diffu2_2 - NA_zz * vis_mu * w_diffu2_3
                                    - NA_xx * vis_mu * w_diffu2_3 - NA_yy * vis_mu * w_diffu2_3 - NA_zz * vis_mu * w_diffu2_3

--- a/examples/ns/src/PLocAssem_VMS_NS_GenAlpha.cpp
+++ b/examples/ns/src/PLocAssem_VMS_NS_GenAlpha.cpp
@@ -1,4 +1,5 @@
 #include "PLocAssem_VMS_NS_GenAlpha.hpp"
+#include "LoadData.hpp"
 
 PLocAssem_VMS_NS_GenAlpha::PLocAssem_VMS_NS_GenAlpha(
     const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
@@ -207,7 +208,7 @@ void PLocAssem_VMS_NS_GenAlpha::Assem_Residual(
     const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua);
 
     // Get the body force
-    const Vector_3 f_body = get_f( coor, curr );
+    const Vector_3 f_body = LoadData::body_force( coor, curr );
 
     const double u_lap = u_xx + u_yy + u_zz;
     const double v_lap = v_xx + v_yy + v_zz;
@@ -377,7 +378,7 @@ void PLocAssem_VMS_NS_GenAlpha::Assem_Tangent_Residual(
 
     const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua); 
 
-    const Vector_3 f_body = get_f( coor, curr );
+    const Vector_3 f_body = LoadData::body_force( coor, curr );
 
     const double u_lap = u_xx + u_yy + u_zz;
     const double v_lap = v_xx + v_yy + v_zz;
@@ -701,7 +702,7 @@ void PLocAssem_VMS_NS_GenAlpha::Assem_Mass_Residual(
 
     const double gwts = elementv->get_detJac(qua) * quadv->get_qw(qua);
 
-    const Vector_3 f_body = get_f( coor, curr );
+    const Vector_3 f_body = LoadData::body_force( coor, curr );
 
     for(int A=0; A<nLocBas; ++A)
     {


### PR DESCRIPTION
### Motivation

- Centralize the body force definition used by Navier–Stokes example assemblers to provide a single place to customize `b(x,t)` instead of duplicating `get_f` stubs across classes.
- Remove duplicated local `get_f` implementations and unify the interface so different time integrators and assembler variants use the same body-force provider.

### Description

- Add `examples/ns/include/LoadData.hpp` that provides `inline Vector_3 body_force(const Vector_3 &pt, const double &tt)` returning a zero vector by default.
- Replace calls to local `get_f(...)` with `LoadData::body_force(...)` in `PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.cpp`, `PLocAssem_Block_VMS_NS_HERK.cpp`, and `PLocAssem_VMS_NS_GenAlpha.cpp` and add `#include "LoadData.hpp"` where needed.
- Remove or comment out redundant `get_f` stub methods in the assembler headers so the centralized `LoadData::body_force` is the single source for body-force data.

### Testing

- Performed a local build of the examples after the change using the project build system (`make` / CMake), and the project compiled successfully.
- No automated unit test changes were included in this PR and no additional test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac22ac870832aa08907d2456ed1ee)