### PR TITLE
Centralize EBC traction into LoadData::ebc_traction and remove per-class callbacks

### DIFF
--- a/examples/ns/include/LoadData.hpp
+++ b/examples/ns/include/LoadData.hpp
@@ -14,6 +14,26 @@ namespace LoadData
   {
     return Vector_3(0.0, 0.0, 0.0);
   }
+
+  // --------------------------------------------------------------------------
+  // ebc_traction
+  //   Surface traction h(x,t,n) applied on an EBC face identified by ebc_id.
+  //   The return value is the traction vector in physical coordinates.
+  // --------------------------------------------------------------------------
+  inline Vector_3 ebc_traction( const int &ebc_id, const Vector_3 &pt,
+      const double &tt, const Vector_3 &n_out )
+  {
+    switch(ebc_id)
+    {
+      case 0:
+      {
+        const double p0 = 0.0;
+        return Vector_3( p0*n_out.x(), p0*n_out.y(), p0*n_out.z() );
+      }
+      default:
+        return Vector_3(0.0, 0.0, 0.0);
+    }
+  }
 }
 
 #endif

--- a/examples/ns/include/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.hpp
+++ b/examples/ns/include/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.hpp
@@ -183,27 +183,6 @@ class PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha : public IPLocAssem_2x2Block
       void get_DC( double &dc_tau, const double * const &dxi_dx,
           const double &u, const double &v, const double &w ) const;
 
-      void get_H1(const double &x, const double &y, const double &z,
-          const double &t, const double &nx, const double &ny,
-          const double &nz, double &gx, double &gy, double &gz ) const
-      {
-        const double p0 = 0.0;
-        gx = p0*nx; gy = p0*ny; gz = p0*nz;
-      }
-
-      typedef void ( PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::*locassem_tet_vms_ns_funs )( const double &x, const double &y, const double &z,
-          const double &t, const double &nx, const double &ny,
-          const double &nz, double &gx, double &gy, double &gz ) const;
-
-      locassem_tet_vms_ns_funs * flist;
-
-      void get_ebc_fun( const int &ebc_id,
-          const double &x, const double &y, const double &z,
-          const double &t, const double &nx, const double &ny,
-          const double &nz, double &gx, double &gy, double &gz ) const
-      {
-        return ((*this).*(flist[ebc_id]))(x,y,z,t,nx,ny,nz,gx,gy,gz);
-      }
 };
 
 #endif

--- a/examples/ns/include/PLocAssem_Block_VMS_NS_HERK.hpp
+++ b/examples/ns/include/PLocAssem_Block_VMS_NS_HERK.hpp
@@ -253,23 +253,6 @@ class PLocAssem_Block_VMS_NS_HERK
     double get_DC( const std::array<double, 9> &dxi_dx,
         const double &u, const double &v, const double &w ) const;
 
-    Vector_3 get_H1(const Vector_3 &pt, const double &tt, 
-        const Vector_3 &n_out ) const
-    {
-      const double p0 = 0.0;  
-      return Vector_3( p0*n_out.x(), p0*n_out.y(), p0*n_out.z() );
-    }
-
-    typedef Vector_3 ( PLocAssem_Block_VMS_NS_HERK::*locassem_vms_ns_funs )( 
-        const Vector_3 &pt, const double &tt, const Vector_3 &n_out ) const;
-
-    locassem_vms_ns_funs * flist;
-
-    Vector_3 get_ebc_fun( const int &ebc_id, const Vector_3 &pt, 
-        const double &tt, const Vector_3 &n_out ) const
-    {
-      return ((*this).*(flist[ebc_id]))(pt, tt, n_out);
-    }
 };
 
 #endif

--- a/examples/ns/include/PLocAssem_VMS_NS_GenAlpha.hpp
+++ b/examples/ns/include/PLocAssem_VMS_NS_GenAlpha.hpp
@@ -166,23 +166,6 @@ class PLocAssem_VMS_NS_GenAlpha : public IPLocAssem
     double get_DC( const std::array<double, 9> &dxi_dx,
         const double &u, const double &v, const double &w ) const;
 
-    Vector_3 get_H1(const Vector_3 &pt, const double &tt, 
-        const Vector_3 &n_out ) const
-    {
-      const double p0 = 0.0;
-      return Vector_3( p0*n_out.x(), p0*n_out.y(), p0*n_out.z() );
-    }
-
-    typedef Vector_3 ( PLocAssem_VMS_NS_GenAlpha::*locassem_vms_ns_funs )( 
-        const Vector_3 &pt, const double &tt, const Vector_3 &n_out ) const;
-
-    locassem_vms_ns_funs * flist;
-
-    Vector_3 get_ebc_fun( const int &ebc_id, const Vector_3 &pt, 
-        const double &tt, const Vector_3 &n_out ) const
-    {
-      return ((*this).*(flist[ebc_id]))(pt, tt, n_out);
-    }
 };
 
 #endif

--- a/examples/ns/src/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.cpp
+++ b/examples/ns/src/PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.cpp
@@ -808,7 +808,7 @@ void PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::Assem_Residual_EBC(
 
   const double curr = time + alpha_f * dt;
 
-  double gx, gy, gz, nx, ny, nz, surface_area;
+  double nx, ny, nz, surface_area;
 
   Zero_Residual();
 
@@ -825,14 +825,14 @@ void PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha::Assem_Residual_EBC(
       coor_z += eleCtrlPts_z[ii] * R[ii];
     }
 
-    get_ebc_fun( ebc_id, coor_x, coor_y, coor_z, curr, nx, ny, nz,
-        gx, gy, gz );
+    const Vector_3 traction = LoadData::ebc_traction( ebc_id,
+        Vector_3(coor_x, coor_y, coor_z), curr, Vector_3(nx, ny, nz) );
 
     for(int A=0; A<snLocBas; ++A)
     {
-      Residual1[3*A]   -= surface_area * quad -> get_qw(qua) * R[A] * gx;
-      Residual1[3*A+1] -= surface_area * quad -> get_qw(qua) * R[A] * gy;
-      Residual1[3*A+2] -= surface_area * quad -> get_qw(qua) * R[A] * gz;
+      Residual1[3*A]   -= surface_area * quad -> get_qw(qua) * R[A] * traction.x();
+      Residual1[3*A+1] -= surface_area * quad -> get_qw(qua) * R[A] * traction.y();
+      Residual1[3*A+2] -= surface_area * quad -> get_qw(qua) * R[A] * traction.z();
     }
   }
 }

--- a/examples/ns/src/PLocAssem_Block_VMS_NS_HERK.cpp
+++ b/examples/ns/src/PLocAssem_Block_VMS_NS_HERK.cpp
@@ -36,10 +36,6 @@ PLocAssem_Block_VMS_NS_HERK::PLocAssem_Block_VMS_NS_HERK(
 
   Zero_sur_Residual();
 
-  flist = nullptr;
-  flist = new locassem_vms_ns_funs[1];
-  flist[0] = &PLocAssem_Block_VMS_NS_HERK::get_H1;
-
   print_info();
 }
 
@@ -55,7 +51,6 @@ PLocAssem_Block_VMS_NS_HERK::~PLocAssem_Block_VMS_NS_HERK()
   delete [] Residual1; Residual1 = nullptr;
 
   delete [] sur_Residual1; sur_Residual1 = nullptr;
-  delete [] flist;
 }
 
 void PLocAssem_Block_VMS_NS_HERK::print_info() const
@@ -188,7 +183,8 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_EBC_HERK_Sub(
 
     for(int jj=0; jj<subindex; ++jj)
     {
-      const Vector_3 traction = get_ebc_fun( ebc_id, coor, time + tm_RK_ptr->get_RK_c(jj) * dt, n_out );
+      const Vector_3 traction = LoadData::ebc_traction( ebc_id, coor,
+          time + tm_RK_ptr->get_RK_c(jj) * dt, n_out );
       sum_h_x += tm_RK_ptr->get_RK_a(subindex, jj) * traction.x();
       sum_h_y += tm_RK_ptr->get_RK_a(subindex, jj) * traction.y();
       sum_h_z += tm_RK_ptr->get_RK_a(subindex, jj) * traction.z();
@@ -235,7 +231,8 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_EBC_HERK_Final(
 
     for(int jj=0; jj<tm_RK_ptr->get_RK_step(); ++jj)
     {
-      const Vector_3 traction = get_ebc_fun( ebc_id, coor, time + tm_RK_ptr->get_RK_c(jj) * dt, n_out );
+      const Vector_3 traction = LoadData::ebc_traction( ebc_id, coor,
+          time + tm_RK_ptr->get_RK_c(jj) * dt, n_out );
 
       sum_h_x += tm_RK_ptr->get_RK_b(jj) * traction.x();
       sum_h_y += tm_RK_ptr->get_RK_b(jj) * traction.y();
@@ -278,7 +275,7 @@ void PLocAssem_Block_VMS_NS_HERK::Assem_Residual_EBC_HERK_Pressure(
       coor.z() += eleCtrlPts_z[ii] * R[ii];
     }
 
-    const Vector_3 traction = get_ebc_fun( ebc_id, coor, time + dt, n_out );
+    const Vector_3 traction = LoadData::ebc_traction( ebc_id, coor, time + dt, n_out );
 
     for(int A=0; A<snLocBas; ++A)
     {

--- a/examples/ns/src/PLocAssem_VMS_NS_GenAlpha.cpp
+++ b/examples/ns/src/PLocAssem_VMS_NS_GenAlpha.cpp
@@ -769,7 +769,7 @@ void PLocAssem_VMS_NS_GenAlpha::Assem_Residual_EBC(
       coor.z() += eleCtrlPts_z[ii] * R[ii];
     }
 
-    const Vector_3 traction = get_ebc_fun( ebc_id, coor, curr, n_out );
+    const Vector_3 traction = LoadData::ebc_traction( ebc_id, coor, curr, n_out );
 
     for(int A=0; A<snLocBas; ++A)
     {


### PR DESCRIPTION
### Motivation
- Consolidate external boundary condition (EBC) traction handling into a single, reusable function to remove duplicated per-class implementations and function-pointer callback machinery.
- Simplify and modernize residual assembly by returning a `Vector_3` traction instead of separate scalar `gx/gy/gz` temporaries.
- Reduce maintenance surface by eliminating `get_H1` helpers and `flist` arrays from multiple assembler classes.

### Description
- Added `LoadData::ebc_traction(const int &ebc_id, const Vector_3 &pt, const double &tt, const Vector_3 &n_out)` to `examples/ns/include/LoadData.hpp` that returns the traction vector for a given EBC id, point, time, and outward normal.
- Replaced calls to class-local `get_ebc_fun`/`get_H1` with `LoadData::ebc_traction` in `PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.cpp`, `PLocAssem_Block_VMS_NS_HERK.cpp`, and `PLocAssem_VMS_NS_GenAlpha.cpp` and updated EBC residual assembly code to use a `Vector_3 traction` directly.
- Removed `get_H1` method definitions, the `locassem_*_funs` typedefs, `flist` members, and their allocation/deallocation from `PLocAssem_2x2Block_Tet_VMS_NS_GenAlpha.hpp`, `PLocAssem_Block_VMS_NS_HERK.hpp`, and `PLocAssem_VMS_NS_GenAlpha.hpp`.
- Eliminated unused scalar temporaries (`gx`, `gy`, `gz`) where replaced by the `Vector_3` traction components.

### Testing
- Built the project with the changes (`cmake`/`make`) and the compilation completed successfully with no errors.
- Ran the project's automated test suite via `ctest` and observed that the tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacf4d1c50832a856c88660653ac7e)