### PR TITLE
Normalize parameter passing styles in include/FE_Tools.hpp

### DIFF
--- a/include/FE_Tools.hpp
+++ b/include/FE_Tools.hpp
@@ -26,15 +26,15 @@ namespace FE_T
   // given points
   // --------------------------------------------------------------------------
   void get_tet_sphere_info(
-      const double &x0, const double &x1, const double &x2, const double &x3,
-      const double &y0, const double &y1, const double &y2, const double &y3,
-      const double &z0, const double &z1, const double &z2, const double &z3,
+      double x0, double x1, double x2, double x3,
+      double y0, double y1, double y2, double y3,
+      double z0, double z1, double z2, double z3,
       double &xx, double &yy, double &zz, double &rr );
 
   double get_tet_sphere_radius(
-      const double &x0, const double &x1, const double &x2, const double &x3,
-      const double &y0, const double &y1, const double &y2, const double &y3,
-      const double &z0, const double &z1, const double &z2, const double &z3 );
+      double x0, double x1, double x2, double x3,
+      double y0, double y1, double y2, double y3,
+      double z0, double z1, double z2, double z3 );
 
   Vector_3 get_tet_sphere_info( const Vector_3 &pt0, const Vector_3 &pt1,
       const Vector_3 &pt2, const Vector_3 &pt3, double &radius );
@@ -50,9 +50,9 @@ namespace FE_T
   // --------------------------------------------------------------------------
   bool search_closest_point( const Vector_3 &target_xyz,
       FEAElement * const &elements,
-      const double * const &electrl_x,
-      const double * const &electrl_y,
-      const double * const &electrl_z,
+      const double * electrl_x,
+      const double * electrl_y,
+      const double * electrl_z,
       IQuadPts * const &closest_point );
 
   // --------------------------------------------------------------------------
@@ -66,8 +66,8 @@ namespace FE_T
   // return a scalar Prof(f) := int_omega f dx / int_omega 1 dx
   //                          = sum(f * gwts) / sum(gwts)
   // --------------------------------------------------------------------------
-  double L2Proj_DGP0( const double * const &f,
-      const double * const &gwts, const int &nqp );
+  double L2Proj_DGP0( const double * f,
+      const double * gwts, int nqp );
 
   // --------------------------------------------------------------------------
   // L2-projection of a function to a piecewise linear (DGP1 space) in 2D.
@@ -80,11 +80,11 @@ namespace FE_T
   // The projected polynomial is
   //         coeff_0 + coeff_x x + coeff_y y.
   // --------------------------------------------------------------------------
-  void L2Proj_DGP1_2D( const double * const &f,
-      const double * const &gwts,
-      const double * const &qp_x,
-      const double * const &qp_y,
-      const int &nqp,
+  void L2Proj_DGP1_2D( const double * f,
+      const double * gwts,
+      const double * qp_x,
+      const double * qp_y,
+      int nqp,
       double &coeff_0, double &coeff_x, double &coeff_y );
 
   // --------------------------------------------------------------------------
@@ -99,12 +99,12 @@ namespace FE_T
   // The projected polynomial is
   //         coeff_0 + coeff_x x + coeff_y y + coeff_z z.
   // --------------------------------------------------------------------------
-  void L2Proj_DGP1_3D( const double * const &f,
-      const double * const &gwts,
-      const double * const &qp_x,
-      const double * const &qp_y,
-      const double * const &qp_z,
-      const int &nqp,
+  void L2Proj_DGP1_3D( const double * f,
+      const double * gwts,
+      const double * qp_x,
+      const double * qp_y,
+      const double * qp_z,
+      int nqp,
       double &coeff_0, double &coeff_x, double &coeff_y, double &coeff_z );
 
   // ============================================================================
@@ -124,10 +124,10 @@ namespace FE_T
       Matrix_double_3by3_Array();
 
       // Explicitly define the matrix components
-      Matrix_double_3by3_Array( const double &a11, const double &a12,
-          const double &a13, const double &a21, const double &a22,
-          const double &a23, const double &a31, const double &a32,
-          const double &a33 );
+      Matrix_double_3by3_Array( double a11, double a12,
+          double a13, double a21, double a22,
+          double a23, double a31, double a32,
+          double a33 );
 
       // Destructor
       ~Matrix_double_3by3_Array() = default;
@@ -137,16 +137,16 @@ namespace FE_T
 
       // Parenthesis operator. It allows both access matrix entries as well as
       // assigning values to the entry.
-      double& operator()(const int &index) {return mat[index];}
+      double& operator()(int index) {return mat[index];}
 
-      const double& operator()(const int &index) const {return mat[index];}
+      const double& operator()(int index) const {return mat[index];}
 
       // Generate an identity matrix. Erase all previous values and reset pp to default values.
       void gen_id();
 
       // Generate a matrix with random entries
       // All previous values are erased and pp is reset to default.
-      void gen_rand(const double &min = -1.0, const double &max = 1.0);
+      void gen_rand(double min = -1.0, double max = 1.0);
 
       // Generate a Hilbert matrix
       // all previous values are earsed and pp is reset to default.
@@ -165,7 +165,7 @@ namespace FE_T
 
       // Perofrm LU solve for the 3 mat x = b equations
       // LU_fac() has to be called first.
-      void LU_solve(const double &b1, const double &b2, const double &b3,
+      void LU_solve(double b1, double b2, double b3,
           double &x1, double &x2, double &x3) const;
 
       // Transpose operation for the matrix
@@ -180,7 +180,7 @@ namespace FE_T
 
       // Vector multiplication y = Ax
       // make sure the x y vector has length 3.
-      void VecMult( const double * const &xx, double * const &yy ) const;
+      void VecMult( const double * xx, double * yy ) const;
 
       // Matrix multiplication
       void MatMult( const Matrix_double_3by3_Array &mleft,
@@ -220,10 +220,10 @@ namespace FE_T
     public:
       // This constructor is designed for the special structure when
       // solving for 2nd order derivatives.
-      Matrix_double_6by6_Array(const double &aa, const double &bb,
-          const double &cc, const double &dd, const double &ee,
-          const double &ff, const double &gg, const double &hh,
-          const double &ii);
+      Matrix_double_6by6_Array(double aa, double bb,
+          double cc, double dd, double ee,
+          double ff, double gg, double hh,
+          double ii);
 
       ~Matrix_double_6by6_Array() = default;
 


### PR DESCRIPTION
### Motivation

- Simplify and standardize function parameter declarations for primitive and pointer types in `include/FE_Tools.hpp` to use value or simple pointer types rather than references to const pointers/references.
- Ensure pointer parameters are consistently formatted with one space between `*` and the variable name for readability.

### Description

- Replaced `const int &` with `int` and `const double &` with `double` across function and method signatures in `include/FE_Tools.hpp`.
- Replaced `const double * const &` with `const double *` and `double * const &` with `double *`, and adjusted spacing so `*` is followed by a single space before the variable name.
- Updated affected constructors, member functions, free functions, and matrix/vector utility signatures (e.g. `L2Proj_*`, `get_tet_sphere_*`, `Matrix_double_3by3_Array`, `Matrix_double_6by6_Array`, `VecMult`, `LU_solve`, etc.).
- Kept return types and other non-requested types unchanged while normalizing parameter formatting in the same file (`include/FE_Tools.hpp`).

### Testing

- Scanned the modified file with `rg` for the old patterns (`const int &`, `const double &`, `const double * const &`, `double * const &`) and confirmed no remaining matches were found.
- Scanned for pointer-spacing issues using the pattern `\*[^\s]` and confirmed pointer declarations now have a space after `*`.
- Reviewed the file diff to verify that the intended signature changes and formatting updates appear only in `include/FE_Tools.hpp` and match the requested transformations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec44e68b54832a86c3fbbfb23ff352)