### PR TITLE
Move NS inflow rescaling logic into LoadData helper

### DIFF
--- a/examples/ns/include/LoadData.hpp
+++ b/examples/ns/include/LoadData.hpp
@@ -2,6 +2,10 @@
 #define NS_LOADDATA_HPP
 
 #include "Vector_3.hpp"
+#include "ALocal_InflowBC.hpp"
+#include "IFlowRate.hpp"
+#include "PDNSolution.hpp"
+#include "Math_Tools.hpp"
 
 namespace LoadData
 {
@@ -34,6 +38,52 @@ namespace LoadData
         return Vector_3(0.0, 0.0, 0.0);
     }
   }
+
+  // --------------------------------------------------------------------------
+  // rescale_inflow_value
+  //   Rescale the baseline inflow velocity profile using time-dependent
+  //   flow-rate factors and optional turbulence-intensity perturbations.
+  // --------------------------------------------------------------------------
+  inline void rescale_inflow_value( const double &stime,
+      const ALocal_InflowBC * const &infbc,
+      const IFlowRate * const &flrate,
+      const PDNSolution * const &sol_base,
+      PDNSolution * const &sol )
+  {
+    const int num_nbc = infbc -> get_num_nbc();
+
+    for(int nbc_id=0; nbc_id<num_nbc; ++nbc_id)
+    {
+      const int numnode = infbc -> get_Num_LD( nbc_id );
+
+      const double factor  = flrate -> get_flow_rate( nbc_id, stime );
+      const double std_dev = flrate -> get_flow_TI_std_dev( nbc_id );
+
+      for(int ii=0; ii<numnode; ++ii)
+      {
+        const int node_index = infbc -> get_LDN( nbc_id, ii );
+
+        const int base_idx[3] = { node_index*4+1, node_index*4+2, node_index*4+3 };
+
+        double base_vals[3];
+
+        VecGetValues(sol_base->solution, 3, base_idx, base_vals);
+
+        const double perturb_x = MATH_T::gen_double_rand_normal(0, std_dev);
+        const double perturb_y = MATH_T::gen_double_rand_normal(0, std_dev);
+        const double perturb_z = MATH_T::gen_double_rand_normal(0, std_dev);
+
+        const double vals[3] = { base_vals[0] * factor * (1.0 + perturb_x),
+          base_vals[1] * factor * (1.0 + perturb_y),
+          base_vals[2] * factor * (1.0 + perturb_z) };
+
+        VecSetValues(sol->solution, 3, base_idx, vals, INSERT_VALUES);
+      }
+    }
+
+    sol->Assembly_GhostUpdate();
+  }
+
 }
 
 #endif

--- a/examples/ns/include/PNonlinear_NS_Solver.hpp
+++ b/examples/ns/include/PNonlinear_NS_Solver.hpp
@@ -80,9 +80,6 @@ class PNonlinear_NS_Solver
           count, rel_err, abs_err);
     }
 
-    void rescale_inflow_value( const double &stime,
-        const ALocal_InflowBC * const &infbc,
-        PDNSolution * const &sol ) const;
 };
 
 #endif

--- a/examples/ns/src/PNonlinear_NS_Solver.cpp
+++ b/examples/ns/src/PNonlinear_NS_Solver.cpp
@@ -1,4 +1,5 @@
 #include "PNonlinear_NS_Solver.hpp"
+#include "LoadData.hpp"
 
 PNonlinear_NS_Solver::PNonlinear_NS_Solver(
     std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
@@ -81,8 +82,8 @@ void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
 
   // ------------------------------------------------- 
   // Update the inflow boundary values
-  rescale_inflow_value(curr_time+dt, infnbc_part, sol);
-  rescale_inflow_value(curr_time+alpha_f*dt, infnbc_part, &sol_alpha);
+  LoadData::rescale_inflow_value(curr_time+dt, infnbc_part, flrate.get(), sol_base.get(), sol);
+  LoadData::rescale_inflow_value(curr_time+alpha_f*dt, infnbc_part, flrate.get(), sol_base.get(), &sol_alpha);
   // ------------------------------------------------- 
 
   // If new_tangent_flag == TRUE, update the tangent matrix;
@@ -194,44 +195,6 @@ void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
 
   Print_convergence_info(nl_counter, relative_error, residual_norm);
 
-}
-
-void PNonlinear_NS_Solver::rescale_inflow_value( const double &stime,
-    const ALocal_InflowBC * const &infbc,
-    PDNSolution * const &sol ) const
-{
-  const int num_nbc = infbc -> get_num_nbc();
-
-  for(int nbc_id=0; nbc_id<num_nbc; ++nbc_id)
-  {
-    const int numnode = infbc -> get_Num_LD( nbc_id );
-
-    const double factor  = flrate -> get_flow_rate( nbc_id, stime );
-    const double std_dev = flrate -> get_flow_TI_std_dev( nbc_id );
-
-    for(int ii=0; ii<numnode; ++ii)
-    {
-      const int node_index = infbc -> get_LDN( nbc_id, ii );
-      
-      const int base_idx[3] = { node_index*4+1, node_index*4+2, node_index*4+3 };
-
-      double base_vals[3];
-
-      VecGetValues(sol_base->solution, 3, base_idx, base_vals);
-
-      const double perturb_x = MATH_T::gen_double_rand_normal(0, std_dev);
-      const double perturb_y = MATH_T::gen_double_rand_normal(0, std_dev);
-      const double perturb_z = MATH_T::gen_double_rand_normal(0, std_dev);
-
-      const double vals[3] = { base_vals[0] * factor * (1.0 + perturb_x), 
-        base_vals[1] * factor * (1.0 + perturb_y),
-        base_vals[2] * factor * (1.0 + perturb_z) };
-
-      VecSetValues(sol->solution, 3, base_idx, vals, INSERT_VALUES);
-    }
-  }
-
-  sol->Assembly_GhostUpdate();
 }
 
 // EOF


### PR DESCRIPTION
### Motivation
- Decouple inflow rescaling from the nonlinear solver to reduce class responsibility and enable reuse across examples.
- Make the inflow rescaling utility available in a central place (`LoadData`) so it can be shared and tested independently.

### Description
- Moved the implementation of `rescale_inflow_value` out of `PNonlinear_NS_Solver` into `examples/ns/include/LoadData.hpp` as `LoadData::rescale_inflow_value` and added the necessary includes (`ALocal_InflowBC.hpp`, `IFlowRate.hpp`, `PDNSolution.hpp`, `Math_Tools.hpp`).
- Updated `PNonlinear_NS_Solver::GenAlpha_Solve_NS` to call `LoadData::rescale_inflow_value(...)` and pass `flrate.get()` and `sol_base.get()` instead of the old member method.
- Removed the private declaration and the old implementation of `PNonlinear_NS_Solver::rescale_inflow_value` from `examples/ns/include/PNonlinear_NS_Solver.hpp` and `examples/ns/src/PNonlinear_NS_Solver.cpp` respectively.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff errors and it completed without issues.
- Ran `rg -n "rescale_inflow_value"` to confirm all call sites now reference `LoadData::rescale_inflow_value` and it found the updated references.
- Inspected the diffs for `examples/ns/include/LoadData.hpp`, `examples/ns/include/PNonlinear_NS_Solver.hpp`, and `examples/ns/src/PNonlinear_NS_Solver.cpp` to validate the refactor and found no remaining references to the removed member method.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda06668c4832aac6b11ad8b6d788e)