### PR TITLE
Return Newton iteration count from GenAlpha_Solve_NS

### DIFF
--- a/examples/ale_ns_rotate/include/PNonlinear_NS_Solver.hpp
+++ b/examples/ale_ns_rotate/include/PNonlinear_NS_Solver.hpp
@@ -48,7 +48,7 @@ class PNonlinear_NS_Solver
     // This solver solves the Navier-Stokes using 2nd-order Generalized
     // alpha method.
     // --------------------------------------------------------------
-    void GenAlpha_Solve_NS(
+    int GenAlpha_Solve_NS(
         const bool &new_tangent_flag,
         const double &curr_time,
         const double &dt,
@@ -66,7 +66,7 @@ class PNonlinear_NS_Solver
         const PDNSolution * const &disp_mesh,
         const PDNSolution * const &mvelo_alpha,    
         const PDNSolution * const &mdisp_alpha,  
-        bool &conv_flag, int &nl_counter,
+        bool &conv_flag,
         Mat &shell ) const;
 
   private:

--- a/examples/ale_ns_rotate/src/PNonlinear_NS_Solver.cpp
+++ b/examples/ale_ns_rotate/src/PNonlinear_NS_Solver.cpp
@@ -42,7 +42,7 @@ void PNonlinear_NS_Solver::print_info() const
   SYS_T::commPrint("----------------------------------------------------------- \n");
 }
 
-void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
+int PNonlinear_NS_Solver::GenAlpha_Solve_NS(
     const bool &new_tangent_flag,
     const double &curr_time,
     const double &dt,
@@ -60,11 +60,11 @@ void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
     const PDNSolution * const &disp_mesh,
     const PDNSolution * const &mvelo_alpha,    
     const PDNSolution * const &mdisp_alpha,    
-    bool &conv_flag, int &nl_counter,
+    bool &conv_flag,
     Mat &shell ) const
 {
   // Initialize the counter and error
-  nl_counter = 0;
+  int nl_counter = 0;
   double residual_norm = 0.0, initial_norm = 0.0, relative_error = 0.0;
 
   // Gen-alpha parameters
@@ -224,6 +224,8 @@ void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
 
   if(relative_error <= nr_tol || residual_norm <= na_tol) conv_flag = true;
   else conv_flag = false;
+
+  return nl_counter;
 }
 
 void PNonlinear_NS_Solver::rescale_inflow_value( const double &stime,

--- a/examples/ale_ns_rotate/src/PTime_NS_Solver.cpp
+++ b/examples/ale_ns_rotate/src/PTime_NS_Solver.cpp
@@ -27,7 +27,7 @@ void PTime_NS_Solver::Write_restart_file(const PDNTimeStep * const &timeinfo,
     SYS_T::print_fatal("Error: PTimeSolver cannot open restart_file.txt");
 }
 
-void PTime_NS_Solver::TM_NS_GenAlpha( 
+void PTime_NS_Solver::TM_NS_GenAlpha(
     const bool &restart_init_assembly_flag,
     std::unique_ptr<PDNSolution> init_dot_sol,
     std::unique_ptr<PDNSolution> init_sol,
@@ -52,17 +52,17 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
 
   auto pre_velo_mesh   = SYS_T::make_unique<PDNSolution>(*init_mvelo);
   auto cur_velo_mesh   = SYS_T::make_unique<PDNSolution>(*init_mvelo);
-  auto alpha_velo_mesh = SYS_T::make_unique<PDNSolution>(*init_mvelo); 
+  auto alpha_velo_mesh = SYS_T::make_unique<PDNSolution>(*init_mvelo);
 
   // If this is a restart run, do not re-write the solution binaries
   if(restart_init_assembly_flag == false)
   {
     const auto sol_name = Name_Generator(time_info->get_index());
     cur_sol->WriteBinary(sol_name);
-    
+
     const auto sol_dot_name = Name_dot_Generator(time_info->get_index());
     cur_dot_sol->WriteBinary(sol_dot_name);
-  
+
     const auto sol_disp_name = Name_disp_Generator(time_info->get_index());
     cur_disp_mesh->WriteBinary(sol_disp_name);
 
@@ -94,41 +94,41 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
     VecGhostGetLocalForm(cur_velo_mesh->solution, &lvelo_mesh);
     VecGhostGetLocalForm(cur_disp_mesh->solution, &ldisp_mesh);
     VecGhostGetLocalForm(alpha_velo_mesh->solution, &lvelo_alp_mesh);
-    VecGhostGetLocalForm(alpha_disp_mesh->solution, &ldisp_alp_mesh);    
+    VecGhostGetLocalForm(alpha_disp_mesh->solution, &ldisp_alp_mesh);
     VecGetArray(lvelo_mesh, &array_cur_velo_mesh);
     VecGetArray(ldisp_mesh, &array_cur_disp_mesh);
     VecGetArray(lvelo_alp_mesh, &array_alp_velo_mesh);
     VecGetArray(ldisp_alp_mesh, &array_alp_disp_mesh);
 
     for( int ii=0; ii<pNode_ptr->get_nlocalnode_rotated(); ++ii )
-    { 
+    {
       // Update the coordinates of the rotated nodes
       const Vector_3 init_pt_xyz = feanode_ptr->get_ctrlPts_xyz(pNode_ptr->get_node_loc_rotated(ii));
       const Vector_3 curr_pt_xyz = get_currPts(init_pt_xyz, time_info->get_time() + time_info->get_step(), rot_info.get()); //get_currPts() may be writtern into Sl_tools
       const Vector_3 alpha_pt_xyz = get_currPts(init_pt_xyz, time_info->get_time() + alpha_f * time_info->get_step(), rot_info.get());
 
-      const Vector_3 radius_alpha = get_radius(alpha_pt_xyz, rot_info.get()); 
+      const Vector_3 radius_alpha = get_radius(alpha_pt_xyz, rot_info.get());
       const Vector_3 velo_mesh_alpha = Vec3::cross_product(rot_info->get_angular_velo(time_info->get_time() + alpha_f * time_info->get_step())*rot_info->get_direction_rotated(), radius_alpha);
 
-      const Vector_3 radius_curr = get_radius(curr_pt_xyz, rot_info.get()); //get_radius() may be writtern into Sl_tools  
+      const Vector_3 radius_curr = get_radius(curr_pt_xyz, rot_info.get()); //get_radius() may be writtern into Sl_tools
       const Vector_3 velo_mesh_curr = Vec3::cross_product(rot_info->get_angular_velo(time_info->get_time() + time_info->get_step())*rot_info->get_direction_rotated(), radius_curr);
 
-      const int offset = pNode_ptr->get_node_loc_rotated(ii) * 3;   
+      const int offset = pNode_ptr->get_node_loc_rotated(ii) * 3;
 
       for(int jj=0; jj<3; ++jj)
       {
         array_cur_velo_mesh[offset + jj] = velo_mesh_curr(jj);
-        array_cur_disp_mesh[offset + jj] = curr_pt_xyz(jj)-init_pt_xyz(jj);  
+        array_cur_disp_mesh[offset + jj] = curr_pt_xyz(jj)-init_pt_xyz(jj);
 
         array_alp_velo_mesh[offset + jj] = velo_mesh_alpha(jj);
-        array_alp_disp_mesh[offset + jj] = alpha_pt_xyz(jj)-init_pt_xyz(jj);  
+        array_alp_disp_mesh[offset + jj] = alpha_pt_xyz(jj)-init_pt_xyz(jj);
       }
     }
 
     VecRestoreArray(lvelo_mesh, &array_cur_velo_mesh);
     VecRestoreArray(ldisp_mesh, &array_cur_disp_mesh);
     VecRestoreArray(lvelo_alp_mesh, &array_alp_velo_mesh);
-    VecRestoreArray(ldisp_alp_mesh, &array_alp_disp_mesh);    
+    VecRestoreArray(ldisp_alp_mesh, &array_alp_disp_mesh);
     VecGhostRestoreLocalForm(cur_velo_mesh->solution, &lvelo_mesh);
     VecGhostRestoreLocalForm(cur_disp_mesh->solution, &ldisp_mesh);
     VecGhostRestoreLocalForm(alpha_velo_mesh->solution, &lvelo_alp_mesh);
@@ -151,13 +151,13 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
     if( nl_counter == 1 ) renew_flag = false;
 
     // Call the nonlinear equation solver
-    nsolver->GenAlpha_Solve_NS( renew_flag, 
-        time_info->get_time(), time_info->get_step(), 
+    nl_counter = nsolver->GenAlpha_Solve_NS( renew_flag,
+        time_info->get_time(), time_info->get_step(),
         pre_dot_sol.get(), pre_sol.get(), pre_velo_mesh.get(), pre_disp_mesh.get(),
         infnbc_part.get(), rotnbc_part.get(), gbc.get(), gassem_ptr.get(),
         cur_dot_sol.get(), cur_sol.get(), cur_velo_mesh.get(), cur_disp_mesh.get(),
         alpha_velo_mesh.get(), alpha_disp_mesh.get(),
-        conv_flag, nl_counter, shell );
+        conv_flag, shell );
 
     // Update the time step information
     time_info->TimeIncrement();
@@ -186,15 +186,15 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
     for(int face=0; face<gbc -> get_num_ebc(); ++face)
     {
       // Calculate the 3D dot flow rate on the outlet
-      const double dot_face_flrate = gassem_ptr -> Assem_surface_flowrate( 
-          cur_dot_sol.get(), face); 
+      const double dot_face_flrate = gassem_ptr -> Assem_surface_flowrate(
+          cur_dot_sol.get(), face);
 
       // Calculate the 3D flow rate on the outlet
-      const double face_flrate = gassem_ptr -> Assem_surface_flowrate( 
-          cur_sol.get(), face); 
+      const double face_flrate = gassem_ptr -> Assem_surface_flowrate(
+          cur_sol.get(), face);
 
       // Calculate the 3D averaged pressure on the outlet
-      const double face_avepre = gassem_ptr -> Assem_surface_ave_pressure( 
+      const double face_avepre = gassem_ptr -> Assem_surface_ave_pressure(
           cur_sol.get(), face);
 
       // Calculate the 0D pressure from LPN model
@@ -218,12 +218,12 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
       }
       MPI_Barrier(PETSC_COMM_WORLD);
     }
-   
+
     // Calcualte the inlet data
     for(int face=0; face<infnbc_part -> get_num_nbc(); ++face)
     {
       const double inlet_face_flrate = gassem_ptr -> Assem_surface_flowrate(
-          cur_sol.get(), infnbc_part.get(), face ); 
+          cur_sol.get(), infnbc_part.get(), face );
 
       const double inlet_face_avepre = gassem_ptr -> Assem_surface_ave_pressure(
           cur_sol.get(), infnbc_part.get(), face );
@@ -234,14 +234,14 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
         ofile.open( gen_flowfile_name("Inlet_", face).c_str(), std::ofstream::out | std::ofstream::app );
         ofile<<time_info->get_index()<<'\t'<<time_info->get_time()<<'\t'<<inlet_face_flrate<<'\t'<<inlet_face_avepre<<'\n';
         ofile.close();
-      } 
+      }
       MPI_Barrier(PETSC_COMM_WORLD);
     }
 
     // Prepare for next time step
     pre_sol->Copy(*cur_sol);
     pre_dot_sol->Copy(*cur_dot_sol);
-    pre_disp_mesh->Copy(*cur_disp_mesh);    
+    pre_disp_mesh->Copy(*cur_disp_mesh);
     pre_velo_mesh->Copy(*cur_velo_mesh);
   }
 }

--- a/examples/ns/include/PNonlinear_NS_Solver.hpp
+++ b/examples/ns/include/PNonlinear_NS_Solver.hpp
@@ -44,7 +44,7 @@ class PNonlinear_NS_Solver
     // This solver solves the Navier-Stokes using 2nd-order Generalized
     // alpha method.
     // --------------------------------------------------------------
-    void GenAlpha_Solve_NS(
+    int GenAlpha_Solve_NS(
         const bool &new_tangent_flag,
         const double &curr_time,
         const double &dt,
@@ -54,8 +54,7 @@ class PNonlinear_NS_Solver
         PDNSolution * const &sol,
         const ALocal_InflowBC * const &infnbc_part,
         const IGenBC * const &gbc,
-        IPGAssem * const &gassem_ptr,
-        int &nl_counter ) const;
+        IPGAssem * const &gassem_ptr ) const;
 
   private:
     const double nr_tol, na_tol, nd_tol;

--- a/examples/ns/src/PNonlinear_NS_Solver.cpp
+++ b/examples/ns/src/PNonlinear_NS_Solver.cpp
@@ -43,7 +43,7 @@ void PNonlinear_NS_Solver::print_info() const
   SYS_T::commPrint("----------------------------------------------------------- \n");
 }
 
-void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
+int PNonlinear_NS_Solver::GenAlpha_Solve_NS(
     const bool &new_tangent_flag,
     const double &curr_time,
     const double &dt,
@@ -53,11 +53,10 @@ void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
     PDNSolution * const &sol,
     const ALocal_InflowBC * const &infnbc_part,
     const IGenBC * const &gbc,
-    IPGAssem * const &gassem_ptr,
-    int &nl_counter ) const
+    IPGAssem * const &gassem_ptr ) const
 {
   // Initialize the counter and error
-  nl_counter = 0;
+  int nl_counter = 0;
   double residual_norm = 0.0, initial_norm = 0.0, relative_error = 0.0;
 
   // Gen-alpha parameters
@@ -195,6 +194,7 @@ void PNonlinear_NS_Solver::GenAlpha_Solve_NS(
 
   Print_convergence_info(nl_counter, relative_error, residual_norm);
 
+  return nl_counter;
 }
 
 // EOF

--- a/examples/ns/src/PTime_NS_Solver.cpp
+++ b/examples/ns/src/PTime_NS_Solver.cpp
@@ -1,6 +1,6 @@
 #include "PTime_NS_Solver.hpp"
 
-PTime_NS_Solver::PTime_NS_Solver( 
+PTime_NS_Solver::PTime_NS_Solver(
     std::unique_ptr<PNonlinear_NS_Solver> in_nsolver,
     const std::string &input_name,
     const int &input_record_freq, const int &input_renew_tang_freq,
@@ -36,7 +36,7 @@ void PTime_NS_Solver::Write_restart_file(const PDNTimeStep * const &timeinfo,
     SYS_T::print_fatal("Error: PTimeSolver cannot open restart_file.txt");
 }
 
-void PTime_NS_Solver::TM_NS_GenAlpha( 
+void PTime_NS_Solver::TM_NS_GenAlpha(
     const bool &restart_init_assembly_flag,
     std::unique_ptr<PDNSolution> init_dot_sol,
     std::unique_ptr<PDNSolution> init_sol,
@@ -55,7 +55,7 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
   {
     const auto sol_name = Name_Generator(time_info->get_index());
     cur_sol->WriteBinary(sol_name);
-    
+
     const auto sol_dot_name = Name_dot_Generator(time_info->get_index());
     cur_dot_sol->WriteBinary(sol_dot_name);
   }
@@ -84,10 +84,10 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
     if( nl_counter == 1 ) renew_flag = false;
 
     // Call the nonlinear equation solver
-    nsolver->GenAlpha_Solve_NS( renew_flag, 
-        time_info->get_time(), time_info->get_step(), pre_dot_sol.get(), 
-        pre_sol.get(), cur_dot_sol.get(), cur_sol.get(), infnbc_part, 
-        gbc, gassem_ptr, nl_counter );
+    nl_counter = nsolver->GenAlpha_Solve_NS( renew_flag,
+        time_info->get_time(), time_info->get_step(), pre_dot_sol.get(),
+        pre_sol.get(), cur_dot_sol.get(), cur_sol.get(), infnbc_part,
+        gbc, gassem_ptr );
 
     // Update the time step information
     time_info->TimeIncrement();
@@ -108,7 +108,7 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
 
     // Calculate the flow rate & averaged pressure on all outlets
     record_outlet_data(cur_sol.get(), cur_dot_sol.get(), time_info.get(), gbc, gassem_ptr, false, true);
-   
+
     // Calcualte the inlet data
     record_inlet_data(cur_sol.get(), time_info.get(), infnbc_part, gassem_ptr, false, true);
 
@@ -118,7 +118,7 @@ void PTime_NS_Solver::TM_NS_GenAlpha(
   }
 }
 
-void PTime_NS_Solver::record_inlet_data( 
+void PTime_NS_Solver::record_inlet_data(
     const PDNSolution * const &sol,
     const PDNTimeStep * const &time_info,
     const ALocal_InflowBC * const &infnbc_part,
@@ -130,7 +130,7 @@ void PTime_NS_Solver::record_inlet_data(
 
   for(int ff=0; ff<infnbc_part->get_num_nbc(); ++ff)
   {
-    const double flrate = gassem_ptr->Assem_surface_flowrate(sol, infnbc_part, ff); 
+    const double flrate = gassem_ptr->Assem_surface_flowrate(sol, infnbc_part, ff);
 
     const double avepre = gassem_ptr->Assem_surface_ave_pressure(sol, infnbc_part, ff);
 
@@ -138,7 +138,7 @@ void PTime_NS_Solver::record_inlet_data(
     {
       std::ofstream ofile;
       ofile.open( gen_flowfile_name("Inlet_", ff).c_str(), std::ofstream::out | mode );
-      
+
       if( !is_driver )
         ofile<<time_info->get_index()<<'\t'<<time_info->get_time()<<'\t'
            <<flrate<<'\t'<<avepre<<std::endl;
@@ -147,7 +147,7 @@ void PTime_NS_Solver::record_inlet_data(
         if( !is_restart )
         {
           ofile<<"Time index"<<'\t'<<"Time"<<'\t'<<"Flow rate"<<'\t'<<"Face averaged pressure"<<'\n';
-      
+
           ofile<<time_info->get_index()<<'\t'
              <<time_info->get_time()<<'\t'
              <<flrate<<'\t'<<avepre<<std::endl;
@@ -155,7 +155,7 @@ void PTime_NS_Solver::record_inlet_data(
       }
 
       ofile.close();
-    } 
+    }
     MPI_Barrier(PETSC_COMM_WORLD);
   }
 }
@@ -173,13 +173,13 @@ void PTime_NS_Solver::record_outlet_data(
 
   for(int ff=0; ff<gbc->get_num_ebc(); ++ff)
   {
-    const double dot_face_flrate = gassem_ptr -> Assem_surface_flowrate( 
-        dot_sol, ff); 
+    const double dot_face_flrate = gassem_ptr -> Assem_surface_flowrate(
+        dot_sol, ff);
 
-    const double face_flrate = gassem_ptr -> Assem_surface_flowrate( 
-        sol, ff); 
+    const double face_flrate = gassem_ptr -> Assem_surface_flowrate(
+        sol, ff);
 
-    const double face_avepre = gassem_ptr -> Assem_surface_ave_pressure( 
+    const double face_avepre = gassem_ptr -> Assem_surface_ave_pressure(
         sol, ff);
 
     double lpn_pressure;
@@ -187,7 +187,7 @@ void PTime_NS_Solver::record_outlet_data(
     if ( is_driver )
     {
       gbc -> reset_initial_sol( ff, face_flrate, face_avepre, time_info->get_time(), is_restart );
-    
+
       lpn_pressure = gbc -> get_P( ff, dot_face_flrate, face_flrate,
         time_info -> get_time() );
     }
@@ -195,10 +195,10 @@ void PTime_NS_Solver::record_outlet_data(
     {
       lpn_pressure = gbc -> get_P( ff, dot_face_flrate, face_flrate,
         time_info -> get_time() );
-      
+
       gbc -> reset_initial_sol( ff, face_flrate, lpn_pressure, time_info->get_time(), false );
     }
-    
+
     if( SYS_T::get_MPI_rank() == 0 )
     {
       std::ofstream ofile;
@@ -214,7 +214,7 @@ void PTime_NS_Solver::record_outlet_data(
         {
           ofile<<"Time index"<<'\t'<<"Time"<<'\t'<<"dot Flow rate"<<'\t'<<"Flow rate"<<'\t'
                <<"Face averaged pressure"<<'\t'<<"Reduced model pressure"<<'\n';
-          
+
           ofile<<time_info->get_index()<<'\t'<<time_info->get_time()<<'\t'
                <<dot_face_flrate<<'\t'<<face_flrate<<'\t'
                <<face_avepre<<'\t'<<lpn_pressure<<std::endl;


### PR DESCRIPTION
### Motivation
- Make the Newton iteration count an explicit function return value instead of an output reference to simplify the API and ownership of the counter.
- Keep `conv_flag` as an output parameter for the ALE variant while removing the output-only `nl_counter` parameter.

### Description
- Changed signature of `PNonlinear_NS_Solver::GenAlpha_Solve_NS` to return `int` in both `examples/ns` and `examples/ale_ns_rotate` headers and implementations (removed the `int &nl_counter` output parameter and return the local `nl_counter`).
- Updated both implementations to use a local `int nl_counter` and `return nl_counter;` at the end of the routine.
- Updated caller sites in `PTime_NS_Solver.cpp` for both examples to assign `nl_counter = nsolver->GenAlpha_Solve_NS(...)` instead of passing `nl_counter` by reference.
- Small whitespace/formatting fixes applied where necessary to satisfy style checks.

### Testing
- Searched call sites with `rg -n "GenAlpha_Solve_NS("` to verify signatures and invocations were updated consistently, which succeeded.
- Ran `git diff --check` to confirm no trailing-whitespace/style issues, which reported no problems after fixes.
- Performed automated whitespace normalization with a small script to remove trailing spaces, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda2720a00832a82e67806691f70c1)