### PR TITLE
Use `HDF5_Reader` filename constructor and `make_unique` to avoid manual H5Fopen/H5Fclose

### DIFF
--- a/examples/solids/prepost.cpp
+++ b/examples/solids/prepost.cpp
@@ -28,9 +28,7 @@ int main( int argc, char * argv[] )
   const std::string part_file("./ppart/part");
 
   // Read the problem setting recorded in the .h5 file
-  hid_t prepcmd_file = H5Fopen("preprocessor_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  auto cmd_h5r = SYS_T::make_unique<HDF5_Reader>("preprocessor_cmd.h5");
 
   const std::string geo_file     = cmd_h5r -> read_string("/", "geo_file");
   const std::string elemType_str = cmd_h5r -> read_string("/","elemType");
@@ -39,7 +37,6 @@ int main( int argc, char * argv[] )
   const int dofNum = cmd_h5r -> read_intScalar("/","dof_num");
   const int dofMat = cmd_h5r -> read_intScalar("/","dof_mat");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("preprocess.yml");

--- a/examples/solids/prepost.cpp
+++ b/examples/solids/prepost.cpp
@@ -37,6 +37,7 @@ int main( int argc, char * argv[] )
   const int dofNum = cmd_h5r -> read_intScalar("/","dof_num");
   const int dofMat = cmd_h5r -> read_intScalar("/","dof_mat");
 
+  cmd_h5r.reset();
 
   // The user can specify the new mesh partition options from the yaml file
   const std::string yaml_file("preprocess.yml");

--- a/examples/solids/src/ALocal_NBC_Solid.cpp
+++ b/examples/solids/src/ALocal_NBC_Solid.cpp
@@ -7,12 +7,9 @@ ALocal_NBC_Solid::ALocal_NBC_Solid( const std::string &fileBaseName,
 {
   const std::string fName = SYS_T::gen_partfile_name( fileBaseName, cpu_rank );
 
-  hid_t file_id = H5Fopen( fName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );
-  auto h5r = SYS_T::make_unique<HDF5_Reader>(file_id);
+  auto h5r = SYS_T::make_unique<HDF5_Reader>(fName);
 
   read_disp_flag( h5r.get(), gname );
-
-  H5Fclose( file_id );
 }
 
 ALocal_NBC_Solid::ALocal_NBC_Solid( const HDF5_Reader * const &h5r,

--- a/examples/solids/vis_solid.cpp
+++ b/examples/solids/vis_solid.cpp
@@ -36,6 +36,7 @@ int main( int argc, char * argv[] )
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
   const int sol_rec_freq = cmd_h5r -> read_intScalar("/", "sol_record_freq");
 
+  cmd_h5r.reset();
 
   // ===== PETSc Initialization =====
 #if PETSC_VERSION_LT(3,19,0)

--- a/examples/solids/vis_solid.cpp
+++ b/examples/solids/vis_solid.cpp
@@ -29,15 +29,13 @@ int main( int argc, char * argv[] )
   bool isClean = true;
 
   // Read analysis code parameter if the solver_cmd.h5 exists
-  hid_t prepcmd_file = H5Fopen("solver_cmd.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
-  HDF5_Reader * cmd_h5r = new HDF5_Reader( prepcmd_file );
+  auto cmd_h5r = SYS_T::make_unique<HDF5_Reader>("solver_cmd.h5");
 
   const int init_index = cmd_h5r -> read_intScalar("/","init_index");
   const int final_index = cmd_h5r -> read_intScalar("/","final_index");
   double dt = cmd_h5r -> read_doubleScalar("/","init_step");
   const int sol_rec_freq = cmd_h5r -> read_intScalar("/", "sol_record_freq");
 
-  delete cmd_h5r; H5Fclose(prepcmd_file);
 
   // ===== PETSc Initialization =====
 #if PETSC_VERSION_LT(3,19,0)


### PR DESCRIPTION
### Motivation

- Simplify HDF5 reader lifetime management and remove manual `H5Fopen`/`H5Fclose` and raw `new`/`delete` usage to reduce resource-leak risk.

### Description

- Replace manual `H5Fopen` + `HDF5_Reader(file_id)` + `H5Fclose` with `SYS_T::make_unique<HDF5_Reader>(filename)` in `examples/solids/prepost.cpp` to construct the reader directly from a filename.
- Make the same replacement in `examples/solids/vis_solid.cpp` to read `solver_cmd.h5` via `make_unique` instead of opening the hid_t and deleting the reader manually.
- Update `ALocal_NBC_Solid` constructor in `examples/solids/src/ALocal_NBC_Solid.cpp` to construct the `HDF5_Reader` with the partition file name via `make_unique` and remove explicit `H5Fclose`.
- Remove explicit `delete` calls and HDF5 file handle closes where the `HDF5_Reader` now owns the file resource.

### Testing

- Built the project with the changes using the standard build system via `make` and executed the project's automated test suite with `ctest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed57d6cbc832a91f1f63fddd8b976)