### PR TITLE
Simplify redundant Global_Part constructor arguments in example preprocessors

### DIFF
--- a/examples/linearPDE/preprocess.cpp
+++ b/examples/linearPDE/preprocess.cpp
@@ -121,9 +121,9 @@ int main( int argc, char * argv[] )
   IGlobal_Part * global_part = nullptr;
   if(cpu_size > 1)
     global_part = new Global_Part_METIS( cpu_size, in_ncommon,
-        isDualGraph, nElem, nFunc, nLocBas, IEN, "epart", "npart" );
+        isDualGraph, nElem, nFunc, nLocBas, IEN );
   else if(cpu_size == 1)
-    global_part = new Global_Part_Serial( nElem, nFunc, "epart", "npart" );
+    global_part = new Global_Part_Serial( nElem, nFunc );
   else SYS_T::print_fatal("ERROR: wrong cpu_size: %d \n", cpu_size);
   
   // Generate the new nodal numbering

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -159,9 +159,9 @@ int main( int argc, char * argv[] )
   std::unique_ptr<IGlobal_Part> global_part = nullptr;
   if(cpu_size > 1)
     global_part = SYS_T::make_unique<Global_Part_METIS>( cpu_size, in_ncommon,
-        isDualGraph, nElem, nFunc, nLocBas, IEN.get(), "epart", "npart" );
+        isDualGraph, nElem, nFunc, nLocBas, IEN.get() );
   else if(cpu_size == 1)
-    global_part = SYS_T::make_unique<Global_Part_Serial>( nElem, nFunc, "epart", "npart" );
+    global_part = SYS_T::make_unique<Global_Part_Serial>( nElem, nFunc );
   else SYS_T::print_fatal("ERROR: wrong cpu_size: %d \n", cpu_size);
 
   // Generate the new nodal numbering

--- a/examples/solids/preprocess.cpp
+++ b/examples/solids/preprocess.cpp
@@ -147,9 +147,9 @@ int main( int argc, char * argv[] )
   std::unique_ptr<IGlobal_Part> global_part = nullptr;
   if(cpu_size > 1)
     global_part = SYS_T::make_unique<Global_Part_METIS>( cpu_size, in_ncommon,
-        isDualGraph, nElem, nFunc, nLocBas, IEN.get(), "epart", "npart" );
+        isDualGraph, nElem, nFunc, nLocBas, IEN.get() );
   else if(cpu_size == 1)
-    global_part = SYS_T::make_unique<Global_Part_Serial>( nElem, nFunc, "epart", "npart" );
+    global_part = SYS_T::make_unique<Global_Part_Serial>( nElem, nFunc );
   else SYS_T::print_fatal("ERROR: wrong cpu_size: %d \n", cpu_size);
 
   // Generate the new nodal numbering


### PR DESCRIPTION
## Summary
- remove explicit `"epart"` / `"npart"` arguments where `Global_Part_METIS` and `Global_Part_Serial` already provide those defaults
- update the following preprocessors:
  - `examples/ns/preprocess.cpp`
  - `examples/solids/preprocess.cpp`
  - `examples/linearPDE/preprocess.cpp`

## Why
These call sites were passing the constructor default values redundantly, which adds noise without changing behavior.

## Validation
- static review only (no runtime tests executed)
- verified diffs only remove redundant default-argument passing

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee0668948832a84ecff583cffba93)