### PR TITLE
Remove redundant dof/nFunc parameters from NBC_Partition_Solid and hardcode dof=4

### DIFF
--- a/examples/solids/include/NBC_Partition_Solid.hpp
+++ b/examples/solids/include/NBC_Partition_Solid.hpp
@@ -18,9 +18,7 @@ class NBC_Partition_Solid
         const Map_Node_Index * const &mnindex,
         const std::vector<NodalBC_Solid *> &solid_nbc_list_x,
         const std::vector<NodalBC_Solid *> &solid_nbc_list_y,
-        const std::vector<NodalBC_Solid *> &solid_nbc_list_z,
-        const int &dof,
-        const int &nFunc );
+        const std::vector<NodalBC_Solid *> &solid_nbc_list_z );
 
     virtual ~NBC_Partition_Solid() = default;
 

--- a/examples/solids/preprocess.cpp
+++ b/examples/solids/preprocess.cpp
@@ -208,8 +208,7 @@ int main( int argc, char * argv[] )
     // Partition Nodal BC and write to h5 file
     auto nbcpart = SYS_T::make_unique<NBC_Partition_Solid>(
         part.get(), mnindex.get(),
-        solid_nbc_list_x, solid_nbc_list_y, solid_nbc_list_z,
-        dofMat, nFunc );
+        solid_nbc_list_x, solid_nbc_list_y, solid_nbc_list_z );
     nbcpart->write_hdf5( part_file );
 
     // Partition Elemental BC and write to h5 file

--- a/examples/solids/src/NBC_Partition_Solid.cpp
+++ b/examples/solids/src/NBC_Partition_Solid.cpp
@@ -9,11 +9,11 @@ NBC_Partition_Solid::NBC_Partition_Solid( const IPart * const &part,
     const Map_Node_Index * const &mnindex,
     const std::vector<NodalBC_Solid *> &solid_nbc_list_x,
     const std::vector<NodalBC_Solid *> &solid_nbc_list_y,
-    const std::vector<NodalBC_Solid *> &solid_nbc_list_z,
-    const int &dof,
-    const int &nFunc )
+    const std::vector<NodalBC_Solid *> &solid_nbc_list_z )
 : cpu_rank( part->get_cpu_rank() )
 {
+  constexpr int dof = 4;
+
   std::vector<std::vector<unsigned int>> dir_nodes(dof);
   std::vector<std::vector<unsigned int>> disp_nodes(dof);
   std::vector<std::unordered_set<unsigned int>> dir_node_sets(dof);
@@ -25,9 +25,6 @@ NBC_Partition_Solid::NBC_Partition_Solid( const IPart * const &part,
     solid_nbc_list_y,
     solid_nbc_list_z
   };
-
-  SYS_T::print_fatal_if( dof != 4,
-      "Error: NBC_Partition_Solid assumes dof = 4, but received %d.\n", dof );
 
   for(int field=1; field<dof; ++field)
   {


### PR DESCRIPTION
### Motivation
- Simplify the `NBC_Partition_Solid` interface by removing redundant parameters and make the expected degrees-of-freedom explicit for the solids example.

### Description
- Remove `dof` and `nFunc` parameters from the `NBC_Partition_Solid` constructor declaration in `examples/solids/include/NBC_Partition_Solid.hpp` and from its call sites.
- Update `examples/solids/src/NBC_Partition_Solid.cpp` to hardcode `constexpr int dof = 4` inside the constructor and drop the runtime check for `dof` equality.
- Adjust the call site in `examples/solids/preprocess.cpp` to call the updated constructor without the removed arguments.
- Preserve existing behavior of collecting directed and displacement node lists while removing the need to pass `dof` and `nFunc` through the API.

### Testing
- Project was compiled and linked after the changes and the build completed successfully.
- The `examples/solids/preprocess` example was executed to exercise partitioning and writing HDF5 outputs, and it completed without runtime errors while producing the part and NBC HDF5 files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef57ca2a10832a9d7f15dc68b8cd55)