### PR TITLE
Add delegating constructor and Assembly_GhostUpdate helper to PDNSolution

### DIFF
--- a/include/PDNSolution.hpp
+++ b/include/PDNSolution.hpp
@@ -28,6 +28,13 @@ class PDNSolution
     Vec solution; 
     
     // ------------------------------------------------------------------------
+    // ! Construct a solution vec compatible with the analysis node partition,
+    //   with the solution vector's dof value being equal to the APart_Node
+    //   class's dof value.
+    // ------------------------------------------------------------------------
+    PDNSolution( const APart_Node * const &pNode );
+
+    // ------------------------------------------------------------------------
     // ! Construct a solution vec compatible with the analysis node partition, 
     //   but with a different dof_num from pNode->dof. 
     //   The users specify a dof number for the solution class.
@@ -114,6 +121,16 @@ class PDNSolution
     void GetLocalArray( double * const &local_array ) const;
     
     std::vector<double> GetLocalArray() const;
+
+    // ------------------------------------------------------------------------
+    // ! Assembly the vector and update its ghost values. It is just a routine
+    //   calling the following things.
+    //          VecAssemblyBegin(solution);
+    //          VecAssemblyEnd(solution);
+    //          GhostUpdate();
+    //   This is called after VecSetValues to finish the assembly of vector.
+    // ------------------------------------------------------------------------
+    void Assembly_GhostUpdate();
 
     // ------------------------------------------------------------------------
     // ! Print the vec solution on screen with or without the ghost part

--- a/src/Solver/PDNSolution.cpp
+++ b/src/Solver/PDNSolution.cpp
@@ -1,6 +1,10 @@
 #include "PDNSolution.hpp"
 #include <random>
 
+PDNSolution::PDNSolution( const APart_Node * const &pNode )
+: PDNSolution( pNode, pNode->get_dof() )
+{}
+
 PDNSolution::PDNSolution( const APart_Node * const &pNode, int input_dof_num )
 : dof_num( input_dof_num ),
   nlocalnode( pNode->get_nlocalnode() ),
@@ -233,6 +237,14 @@ std::vector<double> PDNSolution::GetLocalArray() const
   VecGhostRestoreLocalForm(solution, &lsol);
 
   return local_array;
+}
+
+void PDNSolution::Assembly_GhostUpdate()
+{
+  VecAssemblyBegin(solution);
+  VecAssemblyEnd(solution);
+  VecGhostUpdateBegin(solution, INSERT_VALUES, SCATTER_FORWARD);
+  VecGhostUpdateEnd(solution, INSERT_VALUES, SCATTER_FORWARD);
 }
 
 void PDNSolution::PrintWithGhost() const


### PR DESCRIPTION
### Motivation
- Provide a convenient constructor that uses the analysis node partition's own `dof` and add a small helper to finish vector assembly and update ghost values after `VecSetValues`.

### Description
- Added `PDNSolution(const APart_Node * const &pNode)` which delegates to `PDNSolution(pNode, pNode->get_dof())` to construct a solution with the node partition's `dof`.
- Declared and implemented `Assembly_GhostUpdate()` which runs `VecAssemblyBegin/End` and `VecGhostUpdateBegin/End` to finalize assembly and refresh ghost entries.
- Included brief documentation comments for the new constructor and the assembly helper in the header.

### Testing
- Built the project with `make` and ran the test suite with `ctest --output-on-failure`, and the build and automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f006665ec8832aaba38e9e02347927)