### PR TITLE
Refactor PDNSolution random generator into static factory

### DIFF
--- a/include/PDNSolution.hpp
+++ b/include/PDNSolution.hpp
@@ -57,9 +57,11 @@ class PDNSolution
     virtual ~PDNSolution() noexcept;
 
     // ------------------------------------------------------------------------
-    // ! Generate a random solution vector.
+    // ! Construct and return a random solution vector.
+    // ! If input_dof_num <= 0, use pNode->get_dof().
     // ------------------------------------------------------------------------
-    void Gen_random();
+    static PDNSolution Gen_random( const APart_Node * const &pNode,
+        int input_dof_num = -1 );
 
     // ------------------------------------------------------------------------
     // ! Copy the INPUT's Vec, nlocal, nghost to the current vector.

--- a/src/Solver/PDNSolution.cpp
+++ b/src/Solver/PDNSolution.cpp
@@ -78,28 +78,34 @@ PDNSolution::~PDNSolution() noexcept
   VecDestroy(&solution);
 }
 
-void PDNSolution::Gen_random()
+PDNSolution PDNSolution::Gen_random( const APart_Node * const &pNode,
+    int input_dof_num )
 {
+  PDNSolution sol( pNode,
+      input_dof_num > 0 ? input_dof_num : pNode->get_dof() );
+
   thread_local std::mt19937_64 gen( std::random_device{}() );
   std::uniform_real_distribution<double> dis(-1.0, 1.0);
 
-  PetscScalar * val = new PetscScalar[nlocal];
-  PetscInt * idx = new PetscInt[nlocal];
+  PetscScalar * val = new PetscScalar[sol.nlocal];
+  PetscInt * idx = new PetscInt[sol.nlocal];
   
-  for(int ii=0; ii<nlocal; ++ii) 
+  for(int ii=0; ii<sol.nlocal; ++ii)
   {
     val[ii] = dis(gen);
     idx[ii] = ii;
   }
 
-  VecSetValuesLocal(solution, nlocal, idx, val, INSERT_VALUES);
+  VecSetValuesLocal(sol.solution, sol.nlocal, idx, val, INSERT_VALUES);
 
-  VecAssemblyBegin(solution);
-  VecAssemblyEnd(solution);
+  VecAssemblyBegin(sol.solution);
+  VecAssemblyEnd(sol.solution);
 
-  GhostUpdate();
+  sol.GhostUpdate();
 
   delete [] val; val = nullptr; delete [] idx; idx = nullptr;
+
+  return sol;
 }
 
 void PDNSolution::Copy(const PDNSolution &INPUT)


### PR DESCRIPTION
### Motivation
- Provide a convenience factory that directly constructs a random `PDNSolution` rather than requiring a caller to create an object and then call a mutating `Gen_random` method.
- Allow callers to optionally override the solution `dof` when generating a random solution via a single API.
- Improve API clarity by making random generation a pure factory operation that returns a fully assembled and ghost-updated `PDNSolution`.

### Description
- Changed the header declaration from `void Gen_random()` to a static factory `static PDNSolution Gen_random(const APart_Node * const &pNode, int input_dof_num = -1)` in `include/PDNSolution.hpp`.
- Implemented `PDNSolution::Gen_random` in `src/Solver/PDNSolution.cpp` to construct a `PDNSolution` with `input_dof_num` (or `pNode->get_dof()` when <= 0), fill local entries with uniform random values, call `VecAssemblyBegin/End` and `GhostUpdate`, and return the constructed `PDNSolution`.
- Updated uses inside the implementation to allocate buffers based on `sol.nlocal` and to operate on `sol.solution` before returning the object.

### Testing
- Ran `rg -n "Gen_random(` include src examples` to verify the symbol is present in the codebase and the search succeeded.
- Ran `git diff --check` to validate no whitespace/style issues after the change and the check passed after a small trailing-whitespace fix.
- Ran `git status --short` to confirm the working tree contains the two intended changes; no build or unit tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00b0c2fe8832a9d561c4c51b6e6b0)