### PR TITLE
Add PDNSolution::Gen_zero static factory for zero-initialized solution

### DIFF
--- a/include/PDNSolution.hpp
+++ b/include/PDNSolution.hpp
@@ -64,6 +64,13 @@ class PDNSolution
         int input_dof_num = -1 );
 
     // ------------------------------------------------------------------------
+    // ! Construct and return a zero solution vector.
+    // ! If input_dof_num <= 0, use pNode->get_dof().
+    // ------------------------------------------------------------------------
+    static PDNSolution Gen_zero( const APart_Node * const &pNode,
+        int input_dof_num = -1 );
+
+    // ------------------------------------------------------------------------
     // ! Copy the INPUT's Vec, nlocal, nghost to the current vector.
     //   (similar to the copy constructor)
     // ------------------------------------------------------------------------

--- a/src/Solver/PDNSolution.cpp
+++ b/src/Solver/PDNSolution.cpp
@@ -108,6 +108,22 @@ PDNSolution PDNSolution::Gen_random( const APart_Node * const &pNode,
   return sol;
 }
 
+PDNSolution PDNSolution::Gen_zero( const APart_Node * const &pNode,
+    int input_dof_num )
+{
+  PDNSolution sol( pNode,
+      input_dof_num > 0 ? input_dof_num : pNode->get_dof() );
+
+  VecSet(sol.solution, 0.0);
+
+  VecAssemblyBegin(sol.solution);
+  VecAssemblyEnd(sol.solution);
+
+  sol.GhostUpdate();
+
+  return sol;
+}
+
 void PDNSolution::Copy(const PDNSolution &INPUT)
 {
   SYS_T::print_fatal_if( dof_num != INPUT.get_dof_num(), "Error: PDNSolution::Copy, dof_num does not match.\n");


### PR DESCRIPTION
### Motivation
- Provide a convenience factory to create a PDNSolution initialized to all zeros (matching `Gen_random`'s layout behavior) for tests and callers that need a full-zero solution vector.

### Description
- Added `static PDNSolution Gen_zero(const APart_Node * const &pNode, int input_dof_num = -1);` to `include/PDNSolution.hpp` and implemented `PDNSolution::Gen_zero` in `src/Solver/PDNSolution.cpp`, where the new method constructs a compatible `PDNSolution`, sets the vector to zero with `VecSet`, assembles it, and performs a ghost update before returning.

### Testing
- Verified the declaration and definition are present with `rg -n "Gen_zero" include/PDNSolution.hpp src/Solver/PDNSolution.cpp` and checked working-tree changes with `git status --short`, both returning the expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00c809800832a9973d094279407c2)