### PR TITLE
Add move constructor and move assignment for PDNSolution

### DIFF
--- a/include/PDNSolution.hpp
+++ b/include/PDNSolution.hpp
@@ -48,9 +48,9 @@ class PDNSolution
 
     PDNSolution &operator=( const PDNSolution &INPUT ) noexcept;
 
-    PDNSolution( PDNSolution && ) = delete;
+    PDNSolution( PDNSolution &&INPUT ) noexcept;
 
-    PDNSolution &operator=( PDNSolution && ) = delete;
+    PDNSolution &operator=( PDNSolution &&INPUT ) noexcept;
 
     PDNSolution( const PDNSolution * INPUT_ptr );
 

--- a/src/Solver/PDNSolution.cpp
+++ b/src/Solver/PDNSolution.cpp
@@ -59,6 +59,35 @@ PDNSolution &PDNSolution::operator=( const PDNSolution &INPUT ) noexcept
   return *this;
 }
 
+PDNSolution::PDNSolution( PDNSolution &&INPUT ) noexcept
+: dof_num( INPUT.get_dof_num() ),
+  nlocalnode( INPUT.get_nlocalnode() ),
+  nghostnode( INPUT.get_nghostnode() ),
+  nlocal( INPUT.get_nlocal() ),
+  nghost( INPUT.get_nghost() ),
+  solution( INPUT.solution )
+{
+  INPUT.solution = nullptr;
+}
+
+PDNSolution &PDNSolution::operator=( PDNSolution &&INPUT ) noexcept
+{
+  if( this == &INPUT ) return *this;
+
+  SYS_T::print_fatal_if( dof_num != INPUT.get_dof_num(),
+      "Error: PDNSolution::operator=(move), dof_num does not match.\n" );
+  SYS_T::print_fatal_if( nlocal != INPUT.get_nlocal(),
+      "Error: PDNSolution::operator=(move), nlocal does not match.\n" );
+  SYS_T::print_fatal_if( nghost != INPUT.get_nghost(),
+      "Error: PDNSolution::operator=(move), nghost does not match.\n" );
+
+  VecDestroy(&solution);
+  solution = INPUT.solution;
+  INPUT.solution = nullptr;
+
+  return *this;
+}
+
 PDNSolution::PDNSolution( const PDNSolution * INPUT_ptr )
 : dof_num( INPUT_ptr->get_dof_num() ),
   nlocalnode( INPUT_ptr->get_nlocalnode() ),


### PR DESCRIPTION
### Motivation
- Enable safe and efficient transfer of internal PETSc `Vec` ownership between `PDNSolution` instances to avoid expensive copies and potential double-free errors.
- Restore move semantics for `PDNSolution` which were previously deleted so objects can be relocated without duplicating underlying vector resources.

### Description
- Implemented a move constructor `PDNSolution::PDNSolution(PDNSolution &&)` that steals `solution` and copies scalar metadata (`dof_num`, `nlocalnode`, `nghostnode`, `nlocal`, `nghost`) then nulls the source `solution` pointer.
- Implemented a move assignment `PDNSolution &PDNSolution::operator=(PDNSolution &&)` that verifies compatibility, destroys the current `solution` via `VecDestroy`, takes ownership of the source `solution`, and nulls the source `solution` pointer.
- Updated header declarations to expose the move constructor and move assignment as `noexcept` and accept named parameters.

### Testing
- Project was built with the changes using `make` and the build completed successfully.
- The automated test suite was run via `ctest` and the existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f085122e9c832ab3c29a6acc4759b6)