### PR TITLE
Provide PDNSolution factory functions returning unique_ptr and use them in init helpers

### DIFF
--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -25,19 +25,13 @@ namespace SOLID_INIT
       std::unique_ptr<PDNSolution> &dot_pres,
       int &initial_index, double &initial_time, double &initial_step )
   {
-    disp = SYS_T::make_unique<PDNSolution>(
-        PDNSolution::Gen_zero( pNode, 3 ) );
-    velo = SYS_T::make_unique<PDNSolution>(
-        PDNSolution::Gen_zero( pNode, 3 ) );
-    pres = SYS_T::make_unique<PDNSolution>(
-        PDNSolution::Gen_zero( pNode, 1 ) );
+    disp = PDNSolution::Gen_zero_ptr( pNode, 3 );
+    velo = PDNSolution::Gen_zero_ptr( pNode, 3 );
+    pres = PDNSolution::Gen_zero_ptr( pNode, 1 );
 
-    dot_disp = SYS_T::make_unique<PDNSolution>(
-        PDNSolution::Gen_zero( pNode, 3 ) );
-    dot_velo = SYS_T::make_unique<PDNSolution>(
-        PDNSolution::Gen_zero( pNode, 3 ) );
-    dot_pres = SYS_T::make_unique<PDNSolution>(
-        PDNSolution::Gen_zero( pNode, 1 ) );
+    dot_disp = PDNSolution::Gen_zero_ptr( pNode, 3 );
+    dot_velo = PDNSolution::Gen_zero_ptr( pNode, 3 );
+    dot_pres = PDNSolution::Gen_zero_ptr( pNode, 1 );
 
     if(is_restart)
     {

--- a/include/PDNSolution.hpp
+++ b/include/PDNSolution.hpp
@@ -66,6 +66,12 @@ class PDNSolution
     static PDNSolution Gen_zero( const APart_Node * const &pNode,
         int input_dof_num = -1 );
 
+    static std::unique_ptr<PDNSolution> Gen_random_ptr(
+        const APart_Node * const &pNode, int input_dof_num = -1 );
+
+    static std::unique_ptr<PDNSolution> Gen_zero_ptr(
+        const APart_Node * const &pNode, int input_dof_num = -1 );
+
     // ------------------------------------------------------------------------
     // ! Copy the INPUT's Vec, nlocal, nghost to the current vector.
     //   (similar to the copy constructor)

--- a/src/Solver/PDNSolution.cpp
+++ b/src/Solver/PDNSolution.cpp
@@ -118,7 +118,7 @@ PDNSolution PDNSolution::Gen_random( const APart_Node * const &pNode,
 
   PetscScalar * val = new PetscScalar[sol.nlocal];
   PetscInt * idx = new PetscInt[sol.nlocal];
-  
+
   for(int ii=0; ii<sol.nlocal; ++ii)
   {
     val[ii] = dis(gen);
@@ -126,7 +126,6 @@ PDNSolution PDNSolution::Gen_random( const APart_Node * const &pNode,
   }
 
   VecSetValuesLocal(sol.solution, sol.nlocal, idx, val, INSERT_VALUES);
-
   VecAssemblyBegin(sol.solution);
   VecAssemblyEnd(sol.solution);
 
@@ -149,6 +148,51 @@ PDNSolution PDNSolution::Gen_zero( const APart_Node * const &pNode,
   VecAssemblyEnd(sol.solution);
 
   sol.GhostUpdate();
+
+  return sol;
+}
+
+std::unique_ptr<PDNSolution> PDNSolution::Gen_random_ptr(
+    const APart_Node * const &pNode, int input_dof_num )
+{
+  auto sol = SYS_T::make_unique<PDNSolution>(
+      pNode, input_dof_num > 0 ? input_dof_num : pNode->get_dof() );
+
+  thread_local std::mt19937_64 gen( std::random_device{}() );
+  std::uniform_real_distribution<double> dis(-1.0, 1.0);
+
+  PetscScalar * val = new PetscScalar[sol->nlocal];
+  PetscInt * idx = new PetscInt[sol->nlocal];
+
+  for(int ii=0; ii<sol->nlocal; ++ii)
+  {
+    val[ii] = dis(gen);
+    idx[ii] = ii;
+  }
+
+  VecSetValuesLocal(sol->solution, sol->nlocal, idx, val, INSERT_VALUES);
+  VecAssemblyBegin(sol->solution);
+  VecAssemblyEnd(sol->solution);
+
+  sol->GhostUpdate();
+
+  delete [] val; val = nullptr; delete [] idx; idx = nullptr;
+
+  return sol;
+}
+
+std::unique_ptr<PDNSolution> PDNSolution::Gen_zero_ptr(
+    const APart_Node * const &pNode, int input_dof_num )
+{
+  auto sol = SYS_T::make_unique<PDNSolution>(
+      pNode, input_dof_num > 0 ? input_dof_num : pNode->get_dof() );
+
+  VecSet(sol->solution, 0.0);
+
+  VecAssemblyBegin(sol->solution);
+  VecAssemblyEnd(sol->solution);
+
+  sol->GhostUpdate();
 
   return sol;
 }


### PR DESCRIPTION
### Motivation
- Reduce repetitive `make_unique` boilerplate when creating `PDNSolution` objects and centralize creation logic into factory functions.
- Provide safe, move-friendly constructors that directly return `std::unique_ptr<PDNSolution>` for common usage patterns.

### Description
- Added static factory declarations `Gen_random_ptr` and `Gen_zero_ptr` to `PDNSolution` in `include/PDNSolution.hpp` to return `std::unique_ptr<PDNSolution>`.
- Implemented `Gen_random_ptr` and `Gen_zero_ptr` in `src/Solver/PDNSolution.cpp` using `SYS_T::make_unique`, setting up vector values, calling `VecAssembly*` and `GhostUpdate` as appropriate.
- Replaced manual `SYS_T::make_unique<PDNSolution>( PDNSolution::Gen_zero(...) )` usages in `examples/solids/include/InitHelpers.hpp` with the new `PDNSolution::Gen_zero_ptr` to simplify initialization.
- Minor whitespace/format cleanups in `PDNSolution.cpp` around the new functions.

### Testing
- Performed a full project build using the standard build system and `make`, and the build completed successfully.
- Ran the automated test suite via `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2de759d90832aa2903f7bf8da1e63)