### PR TITLE
Remove APart_Node dependency from PNonlinear_Solid_Solver and derive local node count from PDNSolution

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
 
   auto nsolver = SYS_T::make_unique<PNonlinear_Solid_Solver>(
       std::move(gloAssem_ptr), std::move(lsolver), std::move(pmat),
-      std::move(tm_galpha), std::move(pNode_bc),
+      std::move(tm_galpha),
       nl_rtol, nl_atol, nl_dtol, nl_maxits, nl_refreq, nl_threshold );
 
   nsolver->print_info();

--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -245,10 +245,15 @@ int main(int argc, char *argv[])
   // ===== Initial condition =====
   auto pNode_sol = SYS_T::make_unique<APart_Node>(part_file, rank);
 
-  std::unique_ptr<PDNSolution> disp, velo, pres;
-  std::unique_ptr<PDNSolution> dot_disp, dot_velo, dot_pres;
+  auto disp = PDNSolution::Gen_zero_ptr( pNode_sol.get(), 3 );
+  auto velo = PDNSolution::Gen_zero_ptr( pNode_sol.get(), 3 );
+  auto pres = PDNSolution::Gen_zero_ptr( pNode_sol.get(), 1 );
 
-  SOLID_INIT::initialize_solution_state( pNode_sol.get(), is_restart,
+  auto dot_disp = PDNSolution::Gen_zero_ptr( pNode_sol.get(), 3 );
+  auto dot_velo = PDNSolution::Gen_zero_ptr( pNode_sol.get(), 3 );
+  auto dot_pres = PDNSolution::Gen_zero_ptr( pNode_sol.get(), 1 );
+
+  SOLID_INIT::initialize_solution_state( is_restart,
       restart_index, restart_time, restart_step,
       restart_u_name, restart_v_name, restart_p_name,
       disp, velo, pres, dot_disp, dot_velo, dot_pres,

--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -11,8 +11,8 @@
 
 namespace SOLID_INIT
 {
-  inline void initialize_solution_state( const APart_Node * const pNode,
-      const bool is_restart, const int restart_index,
+  inline void initialize_solution_state( const bool is_restart,
+      const int restart_index,
       const double restart_time, const double restart_step,
       const std::string &restart_disp_name,
       const std::string &restart_velo_name,
@@ -25,14 +25,6 @@ namespace SOLID_INIT
       std::unique_ptr<PDNSolution> &dot_pres,
       int &initial_index, double &initial_time, double &initial_step )
   {
-    disp = PDNSolution::Gen_zero_ptr( pNode, 3 );
-    velo = PDNSolution::Gen_zero_ptr( pNode, 3 );
-    pres = PDNSolution::Gen_zero_ptr( pNode, 1 );
-
-    dot_disp = PDNSolution::Gen_zero_ptr( pNode, 3 );
-    dot_velo = PDNSolution::Gen_zero_ptr( pNode, 3 );
-    dot_pres = PDNSolution::Gen_zero_ptr( pNode, 1 );
-
     if(is_restart)
     {
       initial_index = restart_index;

--- a/examples/solids/include/PNonlinear_Solid_Solver.hpp
+++ b/examples/solids/include/PNonlinear_Solid_Solver.hpp
@@ -12,7 +12,6 @@
 #include "PLinear_Solver_PETSc.hpp"
 #include "Matrix_PETSc.hpp"
 #include "PDNSolution.hpp"
-#include "APart_Node.hpp"
 #include "ALocal_NBC.hpp"
 
 class PNonlinear_Solid_Solver
@@ -23,7 +22,6 @@ class PNonlinear_Solid_Solver
         std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
         std::unique_ptr<Matrix_PETSc> in_bc_mat,
         std::unique_ptr<TimeMethod_GenAlpha> in_tmga,
-        std::unique_ptr<APart_Node> in_pnode,
         const double &input_nrtol, const double &input_natol,
         const double &input_ndtol, const int &input_max_iteration,
         const int &input_renew_freq, const int &input_renew_threshold );
@@ -65,7 +63,6 @@ class PNonlinear_Solid_Solver
     const std::unique_ptr<PLinear_Solver_PETSc> lsolver;
     const std::unique_ptr<Matrix_PETSc> bc_mat;
     const std::unique_ptr<TimeMethod_GenAlpha> tmga;
-    const std::unique_ptr<const APart_Node> pnode;
 
     void Print_convergence_info( const int &count,
         const double &rel_err, const double &abs_err ) const

--- a/examples/solids/src/PNonlinear_Solid_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solid_Solver.cpp
@@ -6,7 +6,6 @@ PNonlinear_Solid_Solver::PNonlinear_Solid_Solver(
     std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
     std::unique_ptr<Matrix_PETSc> in_bc_mat,
     std::unique_ptr<TimeMethod_GenAlpha> in_tmga,
-    std::unique_ptr<APart_Node> in_pnode,
     const double &input_nrtol, const double &input_natol,
     const double &input_ndtol, const int &input_max_iteration,
     const int &input_renew_freq, const int &input_renew_threshold )
@@ -16,8 +15,7 @@ PNonlinear_Solid_Solver::PNonlinear_Solid_Solver(
   gassem(std::move(in_gassem)),
   lsolver(std::move(in_lsolver)),
   bc_mat(std::move(in_bc_mat)),
-  tmga(std::move(in_tmga)),
-  pnode(std::move(in_pnode))
+  tmga(std::move(in_tmga))
 {}
 
 void PNonlinear_Solid_Solver::print_info() const
@@ -36,7 +34,7 @@ void PNonlinear_Solid_Solver::update_solid_kinematics( const double &val,
     const Vec &input,
     PDNSolution * const &output ) const
 {
-  const int nlocal = pnode->get_nlocalnode();
+  const int nlocal = output->get_nlocalnode();
 
   Vec local_output;
   VecGhostGetLocalForm(output->solution, &local_output);


### PR DESCRIPTION
### Motivation
- Decouple the nonlinear solid solver from the mesh/partition object by removing the stored `APart_Node` pointer and get local node counts from the solution object instead.

### Description
- Remove `#include "APart_Node.hpp"` and the `pnode` member from `PNonlinear_Solid_Solver`.
- Update the solver constructor to drop the `APart_Node` parameter and adjust the initializer list accordingly.
- Change `update_solid_kinematics` to call `output->get_nlocalnode()` instead of using `pnode->get_nlocalnode()`.
- Update `examples/solids/driver.cpp` call-site to stop passing the `APart_Node` instance when constructing `PNonlinear_Solid_Solver`.

### Testing
- Built the project and compiled the `examples/solids` target successfully.
- Performed a basic smoke run of the solids driver which started and executed initialization without errors.
- Ran the repository's automated test suite and observed all tests that exercised the modified code passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ffc47738832aa211832ef2509ae6)