### PR TITLE
Refactor PNonlinear_Solver to own velocity/pressure PETSc IS

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -188,23 +188,6 @@ int main(int argc, char *argv[])
   auto pmat = SYS_T::make_unique<Matrix_PETSc>(pNode.get(), locnbc.get());
   pmat->gen_perm_bc(pNode.get(), locnbc.get());
 
-  const int dof_mat = locnbc->get_dof_LID();
-  const int nlocal = pNode->get_nlocalnode();
-
-  std::vector<PetscInt> idx_v(3 * nlocal);
-  std::vector<PetscInt> idx_p(nlocal);
-  for(int ii=0; ii<nlocal; ++ii)
-  {
-    const PetscInt gid = pNode->get_node_loc(ii);
-    idx_p[ii] = dof_mat * gid;
-    idx_v[3*ii  ] = dof_mat * gid + 1;
-    idx_v[3*ii+1] = dof_mat * gid + 2;
-    idx_v[3*ii+2] = dof_mat * gid + 3;
-  }
-
-  IS is_velo, is_pres;
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()), idx_p.data(), PETSC_COPY_VALUES, &is_pres);
 
   // ===== Generalized-alpha =====
   SYS_T::commPrint("===> Setup the Generalized-alpha time scheme.\n");
@@ -257,7 +240,7 @@ int main(int argc, char *argv[])
       initial_index, initial_time, initial_step );
 
   // ===== Initialize the dot_sol vectors by solving mass matrix =====
-  SOLID_INIT::initialize_dot_solution( gloAssem_ptr.get(), is_velo, is_pres,
+  SOLID_INIT::initialize_dot_solution( gloAssem_ptr.get(),
       dot_disp.get(), dot_velo.get(), dot_pres.get(),
       disp.get(), velo.get(), pres.get(), is_restart );
 
@@ -282,14 +265,12 @@ int main(int argc, char *argv[])
 
   SYS_T::commPrint("===> Start Finite Element Analysis:\n");
 
-  tsolver->TM_Solid_GenAlpha( is_restart, is_velo, is_pres,
+  tsolver->TM_Solid_GenAlpha( is_restart,
       locnbc_disp.get(),
       std::move(dot_disp), std::move(dot_velo), std::move(dot_pres),
       std::move(disp), std::move(velo), std::move(pres),
       std::move(timeinfo) );
 
-  ISDestroy(&is_velo);
-  ISDestroy(&is_pres);
 
   // Ensure PETSc objects are destroyed before PetscFinalize
   tsolver.reset();

--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -71,7 +71,6 @@ namespace SOLID_INIT
   }
 
   inline void initialize_dot_solution( PGAssem_Solid_FEM * const gloAssem,
-      const IS &is_velo, const IS &is_pres,
       PDNSolution * const &dot_disp,
       PDNSolution * const &dot_velo,
       PDNSolution * const &dot_pres,
@@ -103,6 +102,13 @@ namespace SOLID_INIT
     lsolver_acce->Solve( gloAssem->K, gloAssem->G, dot_vp );
     VecScale(dot_vp, -1.0);
 
+    std::vector<PetscInt> idx_v, idx_p;
+    gloAssem->GetSubVecIndex_vp(idx_v, idx_p);
+
+    IS is_velo, is_pres;
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()), idx_p.data(), PETSC_COPY_VALUES, &is_pres);
+
     Vec sol_v, sol_p;
     VecGetSubVector(dot_vp, is_velo, &sol_v);
     VecGetSubVector(dot_vp, is_pres, &sol_p);
@@ -115,6 +121,8 @@ namespace SOLID_INIT
 
     VecRestoreSubVector(dot_vp, is_velo, &sol_v);
     VecRestoreSubVector(dot_vp, is_pres, &sol_p);
+    ISDestroy(&is_velo);
+    ISDestroy(&is_pres);
     VecDestroy(&dot_vp);
 
     dot_disp->Copy( velo );

--- a/examples/solids/include/PGAssem_Solid_FEM.hpp
+++ b/examples/solids/include/PGAssem_Solid_FEM.hpp
@@ -55,6 +55,10 @@ class PGAssem_Solid_FEM : public IPGAssem
         const PDNSolution * const &velo,
         const PDNSolution * const &pres ) override;
 
+    void GetSubVecIndex_vp(
+        std::vector<PetscInt> &idx_v,
+        std::vector<PetscInt> &idx_p ) const;
+
   private:
     const std::unique_ptr<const ALocal_IEN> locien;
     const std::unique_ptr<const ALocal_Elem> locelem;

--- a/examples/solids/include/PNonlinear_Solid_Solver.hpp
+++ b/examples/solids/include/PNonlinear_Solid_Solver.hpp
@@ -26,7 +26,7 @@ class PNonlinear_Solver
         const double &input_ndtol, const int &input_max_iteration,
         const int &input_renew_freq, const int &input_renew_threshold );
 
-    ~PNonlinear_Solver() = default;
+    ~PNonlinear_Solver();
 
     int get_non_max_its() const {return nmaxits;}
 
@@ -38,8 +38,6 @@ class PNonlinear_Solver
         const bool &new_tangent_flag,
         const double &curr_time,
         const double &dt,
-        const IS &is_v,
-        const IS &is_p,
         const ALocal_NBC * const &nbc_disp,
         const PDNSolution * const &pre_dot_disp,
         const PDNSolution * const &pre_dot_velo,
@@ -63,6 +61,7 @@ class PNonlinear_Solver
     const std::unique_ptr<PLinear_Solver_PETSc> lsolver;
     const std::unique_ptr<Matrix_PETSc> bc_mat;
     const std::unique_ptr<TimeMethod_GenAlpha> tmga;
+    IS is_velo, is_pres;
 
     void Print_convergence_info( const int &count,
         const double &rel_err, const double &abs_err ) const

--- a/examples/solids/include/PTime_Solid_Solver.hpp
+++ b/examples/solids/include/PTime_Solid_Solver.hpp
@@ -28,8 +28,6 @@ class PTime_Solver
 
     void TM_Solid_GenAlpha(
         const bool &restart_init_assembly_flag,
-        const IS &is_v,
-        const IS &is_p,
         const ALocal_NBC * const &nbc_disp,
         std::unique_ptr<PDNSolution> init_dot_disp,
         std::unique_ptr<PDNSolution> init_dot_velo,

--- a/examples/solids/src/PGAssem_Solid_FEM.cpp
+++ b/examples/solids/src/PGAssem_Solid_FEM.cpp
@@ -75,6 +75,25 @@ PGAssem_Solid_FEM::~PGAssem_Solid_FEM()
   MatDestroy(&K);
 }
 
+void PGAssem_Solid_FEM::GetSubVecIndex_vp(
+    std::vector<PetscInt> &idx_v,
+    std::vector<PetscInt> &idx_p ) const
+{
+  const int nlocal = pnode->get_nlocalnode();
+
+  idx_v.resize(3 * nlocal);
+  idx_p.resize(nlocal);
+
+  for(int ii=0; ii<nlocal; ++ii)
+  {
+    const PetscInt gid = pnode->get_node_loc(ii);
+    idx_p[ii] = 4 * gid;
+    idx_v[3*ii  ] = 4 * gid + 1;
+    idx_v[3*ii+1] = 4 * gid + 2;
+    idx_v[3*ii+2] = 4 * gid + 3;
+  }
+}
+
 void PGAssem_Solid_FEM::EssBC_KG( const int &field )
 {
   const int local_dir = nbc->get_Num_LD(field);

--- a/examples/solids/src/PNonlinear_Solid_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solid_Solver.cpp
@@ -15,8 +15,23 @@ PNonlinear_Solver::PNonlinear_Solver(
   gassem(std::move(in_gassem)),
   lsolver(std::move(in_lsolver)),
   bc_mat(std::move(in_bc_mat)),
-  tmga(std::move(in_tmga))
-{}
+  tmga(std::move(in_tmga)),
+  is_velo(nullptr), is_pres(nullptr)
+{
+  std::vector<PetscInt> idx_v, idx_p;
+  gassem->GetSubVecIndex_vp(idx_v, idx_p);
+
+  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()),
+      idx_v.data(), PETSC_COPY_VALUES, &is_velo);
+  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()),
+      idx_p.data(), PETSC_COPY_VALUES, &is_pres);
+}
+
+PNonlinear_Solver::~PNonlinear_Solver()
+{
+  ISDestroy(&is_velo);
+  ISDestroy(&is_pres);
+}
 
 void PNonlinear_Solver::print_info() const
 {
@@ -97,8 +112,6 @@ void PNonlinear_Solver::GenAlpha_Seg_solve_Solid(
     const bool &new_tangent_flag,
     const double &curr_time,
     const double &dt,
-    const IS &is_v,
-    const IS &is_p,
     const ALocal_NBC * const &nbc_disp,
     const PDNSolution * const &pre_dot_disp,
     const PDNSolution * const &pre_dot_velo,
@@ -207,8 +220,8 @@ void PNonlinear_Solver::GenAlpha_Seg_solve_Solid(
 
     nl_counter += 1;
 
-    VecGetSubVector(sol_vp, is_v, &sol_v);
-    VecGetSubVector(sol_vp, is_p, &sol_p);
+    VecGetSubVector(sol_vp, is_velo, &sol_v);
+    VecGetSubVector(sol_vp, is_pres, &sol_p);
 
     dot_velo       -> PlusAX( sol_v, -1.0 );
     dot_velo_alpha -> PlusAX( sol_v, -1.0 * alpha_m );
@@ -225,8 +238,8 @@ void PNonlinear_Solver::GenAlpha_Seg_solve_Solid(
     update_solid_kinematics( -1.0 * val_1 * alpha_m, sol_v, dot_disp_alpha.get() );
     update_solid_kinematics( -1.0 * val_1 * alpha_f * gamma * dt, sol_v, disp_alpha.get() );
 
-    VecRestoreSubVector(sol_vp, is_v, &sol_v);
-    VecRestoreSubVector(sol_vp, is_p, &sol_p);
+    VecRestoreSubVector(sol_vp, is_velo, &sol_v);
+    VecRestoreSubVector(sol_vp, is_pres, &sol_p);
 
     if( nl_counter % nrenew_freq == 0 || nl_counter >= nrenew_threshold )
     {

--- a/examples/solids/src/PTime_Solid_Solver.cpp
+++ b/examples/solids/src/PTime_Solid_Solver.cpp
@@ -42,8 +42,6 @@ std::string PTime_Solver::Name_dot_Generator( const std::string &middle_name,
 
 void PTime_Solver::TM_Solid_GenAlpha(
     const bool &restart_init_assembly_flag,
-    const IS &is_v,
-    const IS &is_p,
     const ALocal_NBC * const &nbc_disp,
     std::unique_ptr<PDNSolution> init_dot_disp,
     std::unique_ptr<PDNSolution> init_dot_velo,

--- a/examples/solids/src/PTime_Solid_Solver.cpp
+++ b/examples/solids/src/PTime_Solid_Solver.cpp
@@ -112,7 +112,6 @@ void PTime_Solver::TM_Solid_GenAlpha(
 
     nsolver->GenAlpha_Seg_solve_Solid( renew_flag,
         time_info->get_time(), time_info->get_step(),
-        is_v, is_p,
         nbc_disp,
         pre_dot_disp.get(), pre_dot_velo.get(), pre_dot_pres.get(),
         pre_disp.get(), pre_velo.get(), pre_pres.get(),


### PR DESCRIPTION
### Motivation
- 将速度/压力子向量索引封装到求解器内部以避免每次调用时传入外部 `IS` 并确保映射与 driver 保持一致。
- 在构造阶段创建并在析构时释放 PETSc `IS`，以避免运行时的资源泄漏。
- 提供 assembly 侧的索引生成接口以在求解器构造时复用与现有 `driver.cpp` 相同的映射规则（`dof_mat = 4`）。

### Description
- 在 `PNonlinear_Solver` 中新增私有成员 `IS is_velo, is_pres` 并将析构函数由 `= default` 改为显式实现以销毁 `IS` 资源。
- 在 `PNonlinear_Solver` 构造函数中调用 `gassem->GetSubVecIndex_vp(...)` 获取 `idx_v/idx_p`，并使用 `ISCreateGeneral(...)` 初始化 `is_velo` 与 `is_pres`。
- 将 `GenAlpha_Seg_solve_Solid(...)` 的签名移除 `const IS &is_v, const IS &is_p` 参数，并在实现中改为使用成员 `is_velo/is_pres` 进行 `VecGetSubVector` / `VecRestoreSubVector` 操作。
- 在 `PGAssem_Solid_FEM` 中新增 `GetSubVecIndex_vp(...)` 方法以按照现有规则生成速度/压力子向量索引，并在 `PTime_Solid_Solver` 中同步移除对旧参数的传递点。

### Testing
- 运行基于文本的代码检查与搜索（例如使用 `rg` 检索 `GenAlpha_Seg_solve_Solid` 与 `is_v|is_p` 的引用）以确认调用点已更新且不再传递外部 `IS`，搜索命令执行成功。
- 使用 `sed` / `nl` 等查看修改后的头/源文件以人工审查改动位置与一致性，文件检查成功。
- 未在此变更中执行编译或单元测试，建议在 CI 或本地环境中运行完整构建与回归测试以验证运行时行为。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30fc5a398832a9a86a636642c1143)