### PR TITLE
Refactor solids IS creation out of driver and localize dot-solution setup

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -188,23 +188,6 @@ int main(int argc, char *argv[])
   auto pmat = SYS_T::make_unique<Matrix_PETSc>(pNode.get(), locnbc.get());
   pmat->gen_perm_bc(pNode.get(), locnbc.get());
 
-  const int dof_mat = locnbc->get_dof_LID();
-  const int nlocal = pNode->get_nlocalnode();
-
-  std::vector<PetscInt> idx_v(3 * nlocal);
-  std::vector<PetscInt> idx_p(nlocal);
-  for(int ii=0; ii<nlocal; ++ii)
-  {
-    const PetscInt gid = pNode->get_node_loc(ii);
-    idx_p[ii] = dof_mat * gid;
-    idx_v[3*ii  ] = dof_mat * gid + 1;
-    idx_v[3*ii+1] = dof_mat * gid + 2;
-    idx_v[3*ii+2] = dof_mat * gid + 3;
-  }
-
-  IS is_velo, is_pres;
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()), idx_p.data(), PETSC_COPY_VALUES, &is_pres);
 
   // ===== Generalized-alpha =====
   SYS_T::commPrint("===> Setup the Generalized-alpha time scheme.\n");
@@ -257,7 +240,7 @@ int main(int argc, char *argv[])
       initial_index, initial_time, initial_step );
 
   // ===== Initialize the dot_sol vectors by solving mass matrix =====
-  SOLID_INIT::initialize_dot_solution( gloAssem_ptr.get(), is_velo, is_pres,
+  SOLID_INIT::initialize_dot_solution( gloAssem_ptr.get(),
       dot_disp.get(), dot_velo.get(), dot_pres.get(),
       disp.get(), velo.get(), pres.get(), is_restart );
 
@@ -282,14 +265,12 @@ int main(int argc, char *argv[])
 
   SYS_T::commPrint("===> Start Finite Element Analysis:\n");
 
-  tsolver->TM_Solid_GenAlpha( is_restart, is_velo, is_pres,
+  tsolver->TM_Solid_GenAlpha( is_restart,
       locnbc_disp.get(),
       std::move(dot_disp), std::move(dot_velo), std::move(dot_pres),
       std::move(disp), std::move(velo), std::move(pres),
       std::move(timeinfo) );
 
-  ISDestroy(&is_velo);
-  ISDestroy(&is_pres);
 
   // Ensure PETSc objects are destroyed before PetscFinalize
   tsolver.reset();

--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -71,7 +71,6 @@ namespace SOLID_INIT
   }
 
   inline void initialize_dot_solution( PGAssem_Solid_FEM * const gloAssem,
-      const IS &is_velo, const IS &is_pres,
       PDNSolution * const &dot_disp,
       PDNSolution * const &dot_velo,
       PDNSolution * const &dot_pres,
@@ -103,6 +102,24 @@ namespace SOLID_INIT
     lsolver_acce->Solve( gloAssem->K, gloAssem->G, dot_vp );
     VecScale(dot_vp, -1.0);
 
+    PetscInt rstart, rend;
+    VecGetOwnershipRange(dot_vp, &rstart, &rend);
+
+    const PetscInt nlocalnode = static_cast<PetscInt>(dot_pres->get_nlocalnode());
+    std::vector<PetscInt> idx_v(3 * nlocalnode), idx_p(nlocalnode);
+    for(PetscInt ii=0; ii<nlocalnode; ++ii)
+    {
+      const PetscInt base = rstart + 4 * ii;
+      idx_p[ii] = base;
+      idx_v[3*ii  ] = base + 1;
+      idx_v[3*ii+1] = base + 2;
+      idx_v[3*ii+2] = base + 3;
+    }
+
+    IS is_velo, is_pres;
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()), idx_p.data(), PETSC_COPY_VALUES, &is_pres);
+
     Vec sol_v, sol_p;
     VecGetSubVector(dot_vp, is_velo, &sol_v);
     VecGetSubVector(dot_vp, is_pres, &sol_p);
@@ -115,6 +132,8 @@ namespace SOLID_INIT
 
     VecRestoreSubVector(dot_vp, is_velo, &sol_v);
     VecRestoreSubVector(dot_vp, is_pres, &sol_p);
+    ISDestroy(&is_velo);
+    ISDestroy(&is_pres);
     VecDestroy(&dot_vp);
 
     dot_disp->Copy( velo );

--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -102,19 +102,8 @@ namespace SOLID_INIT
     lsolver_acce->Solve( gloAssem->K, gloAssem->G, dot_vp );
     VecScale(dot_vp, -1.0);
 
-    PetscInt rstart, rend;
-    VecGetOwnershipRange(dot_vp, &rstart, &rend);
-
-    const PetscInt nlocalnode = static_cast<PetscInt>(dot_pres->get_nlocalnode());
-    std::vector<PetscInt> idx_v(3 * nlocalnode), idx_p(nlocalnode);
-    for(PetscInt ii=0; ii<nlocalnode; ++ii)
-    {
-      const PetscInt base = rstart + 4 * ii;
-      idx_p[ii] = base;
-      idx_v[3*ii  ] = base + 1;
-      idx_v[3*ii+1] = base + 2;
-      idx_v[3*ii+2] = base + 3;
-    }
+    std::vector<PetscInt> idx_v, idx_p;
+    gloAssem->GetSubVecIndex_vp(idx_v, idx_p);
 
     IS is_velo, is_pres;
     ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);

--- a/examples/solids/include/PTime_Solid_Solver.hpp
+++ b/examples/solids/include/PTime_Solid_Solver.hpp
@@ -28,8 +28,6 @@ class PTime_Solver
 
     void TM_Solid_GenAlpha(
         const bool &restart_init_assembly_flag,
-        const IS &is_v,
-        const IS &is_p,
         const ALocal_NBC * const &nbc_disp,
         std::unique_ptr<PDNSolution> init_dot_disp,
         std::unique_ptr<PDNSolution> init_dot_velo,

--- a/examples/solids/src/PTime_Solid_Solver.cpp
+++ b/examples/solids/src/PTime_Solid_Solver.cpp
@@ -42,8 +42,6 @@ std::string PTime_Solver::Name_dot_Generator( const std::string &middle_name,
 
 void PTime_Solver::TM_Solid_GenAlpha(
     const bool &restart_init_assembly_flag,
-    const IS &is_v,
-    const IS &is_p,
     const ALocal_NBC * const &nbc_disp,
     std::unique_ptr<PDNSolution> init_dot_disp,
     std::unique_ptr<PDNSolution> init_dot_velo,


### PR DESCRIPTION
### Motivation
- Reduce responsibility of the driver by removing global `IS` construction for velocity/pressure and encapsulate index-set logic inside the initialization routine.
- Make `initialize_dot_solution` responsible for producing the index sets needed to extract velocity/pressure subvectors so the driver no longer needs to maintain `is_velo`/`is_pres`.
- Simplify the time-solver interface by removing unused `IS` parameters from `PTime_Solver::TM_Solid_GenAlpha`.

### Description
- Removed creation and destruction of `is_velo` / `is_pres` from `examples/solids/driver.cpp` and updated the call sites to omit those parameters.
- Updated `SOLID_INIT::initialize_dot_solution` in `examples/solids/include/InitHelpers.hpp` to compute the owned `Vec` range via `VecGetOwnershipRange`, build `idx_v`/`idx_p` from that range, call `ISCreateGeneral` locally, use the `IS` to `VecGetSubVector` velocity/pressure portions, and `ISDestroy` them before returning.
- Removed `const IS &is_v, const IS &is_p` from the declaration and definition of `PTime_Solver::TM_Solid_GenAlpha` in `examples/solids/include/PTime_Solid_Solver.hpp` and `examples/solids/src/PTime_Solid_Solver.cpp` and updated its call in the driver.
- Kept all PETSc subvector extraction and restoration logic intact while moving `IS` lifecycle management into the initialization routine.

### Testing
- Ran pattern searches with `rg` to verify updated references to `initialize_dot_solution`, `TM_Solid_GenAlpha`, and `is_velo`/`is_pres` and confirmed the signatures and call sites were updated (commands returned successfully).
- Inspected diffs with `git diff` for `examples/solids/driver.cpp`, `examples/solids/include/InitHelpers.hpp`, `examples/solids/include/PTime_Solid_Solver.hpp`, and `examples/solids/src/PTime_Solid_Solver.cpp` to confirm the intended edits were applied (command returned successfully).
- Checked repository status with `git status --short` to confirm the modified files are staged/modified as expected (command returned successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f314b23184832ab0ce6131f2573c1b)