### PR TITLE
Centralize material-model construction for solids examples

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -7,9 +7,6 @@
 // ==========================================================================
 #include "HDF5_Writer.hpp"
 #include "ANL_Tools.hpp"
-#include "MaterialModel_ich_NeoHookean.hpp"
-#include "MaterialModel_vol_Incompressible.hpp"
-#include "MaterialModel_Mixed_Elasticity.hpp"
 #include "PLocAssem_2x2Block_VMS_Incompressible.hpp"
 #include "InitHelpers.hpp"
 #include "ALocal_NBC.hpp"
@@ -48,10 +45,6 @@ int main(int argc, char *argv[])
   std::string sol_bName("SOL_"); // base name of the solution file
   int ttan_renew_freq = 1;   // frequency of tangent matrix renewal
   int sol_record_freq = 1;   // frequency of recording the solution
-
-  // solid material parameters
-  const double solid_density = 1.0e3;
-  const double solid_mu = 6.666666666e4;
 
   // displacement-driven BC parameters (edit here)
 
@@ -198,19 +191,10 @@ int main(int argc, char *argv[])
   tm_galpha->print_info();
 
   // ===== Local Assembly Routine =====
-  std::unique_ptr<IMaterialModel_ich> imodel =
-    SYS_T::make_unique<MaterialModel_ich_NeoHookean>(solid_mu);
-
-  std::unique_ptr<IMaterialModel_vol> vmodel =
-    SYS_T::make_unique<MaterialModel_vol_Incompressible>(solid_density);
-
-  std::unique_ptr<MaterialModel_Mixed_Elasticity> matmodel =
-    SYS_T::make_unique<MaterialModel_Mixed_Elasticity>(std::move(vmodel), std::move(imodel));
-
   std::unique_ptr<IPLocAssem_2x2Block> locAssem_ptr =
     SYS_T::make_unique<PLocAssem_2x2Block_VMS_Incompressible>(
         elemType, nqp_vol, nqp_sur,
-        tm_galpha.get(), std::move(matmodel));
+        tm_galpha.get());
 
   // ===== Initial condition =====
   auto disp = PDNSolution::Gen_zero_ptr( pNode.get(), 3 );

--- a/examples/solids/include/MaterialModelData.hpp
+++ b/examples/solids/include/MaterialModelData.hpp
@@ -1,0 +1,37 @@
+#ifndef MATERIALMODELDATA_HPP
+#define MATERIALMODELDATA_HPP
+// --------------------------------------------------------------------------
+// Centralized material parameters for examples/solids.
+//
+// Design goal:
+//   Keep one single source of truth for material-model construction so that
+//   drivers, local assembly routines, and post-processing use exactly the
+//   same constitutive setup.
+// --------------------------------------------------------------------------
+#include "MaterialModel_Mixed_Elasticity.hpp"
+#include "MaterialModel_ich_NeoHookean.hpp"
+#include "MaterialModel_vol_Incompressible.hpp"
+
+namespace MaterialModelData
+{
+  constexpr double density = 1.0e3;
+  constexpr double shear_modulus = 6.666666666e4;
+
+  inline std::unique_ptr<IMaterialModel_vol> create_vol_model()
+  {
+    return SYS_T::make_unique<MaterialModel_vol_Incompressible>( density );
+  }
+
+  inline std::unique_ptr<IMaterialModel_ich> create_isochoric_model()
+  {
+    return SYS_T::make_unique<MaterialModel_ich_NeoHookean>( shear_modulus );
+  }
+
+  inline std::unique_ptr<MaterialModel_Mixed_Elasticity> create_mixed_model()
+  {
+    return SYS_T::make_unique<MaterialModel_Mixed_Elasticity>(
+        create_vol_model(), create_isochoric_model() );
+  }
+}
+
+#endif

--- a/examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp
+++ b/examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp
@@ -20,8 +20,7 @@ class PLocAssem_2x2Block_VMS_Hyperelasticity : public IPLocAssem_2x2Block
   public:
     PLocAssem_2x2Block_VMS_Hyperelasticity(
         const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-        const TimeMethod_GenAlpha * const &tm_gAlpha,
-        std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel );
+        const TimeMethod_GenAlpha * const &tm_gAlpha );
 
     virtual ~PLocAssem_2x2Block_VMS_Hyperelasticity();
 

--- a/examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp
+++ b/examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp
@@ -20,8 +20,7 @@ class PLocAssem_2x2Block_VMS_Incompressible : public IPLocAssem_2x2Block
   public:
     PLocAssem_2x2Block_VMS_Incompressible(
         const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-        const TimeMethod_GenAlpha * const &tm_gAlpha,
-        std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel );
+        const TimeMethod_GenAlpha * const &tm_gAlpha );
 
     virtual ~PLocAssem_2x2Block_VMS_Incompressible();
 

--- a/examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp
+++ b/examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp
@@ -1,22 +1,22 @@
 #include "PLocAssem_2x2Block_VMS_Hyperelasticity.hpp"
 #include "LoadData.hpp"
+#include "MaterialModelData.hpp"
 
 PLocAssem_2x2Block_VMS_Hyperelasticity::PLocAssem_2x2Block_VMS_Hyperelasticity(
     const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-    const TimeMethod_GenAlpha * const &tm_gAlpha,
-    std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel )
+    const TimeMethod_GenAlpha * const &tm_gAlpha )
 : elemType(in_type), nqpv(in_nqp_v), nqps(in_nqp_s),
   elementv( ElementFactory::createVolElement(elemType, nqpv) ),
   elements( ElementFactory::createSurElement(elemType, nqps) ),
   quadv( QuadPtsFactory::createVolQuadrature(elemType, nqpv) ),
   quads( QuadPtsFactory::createSurQuadrature(elemType, nqps) ),
-  rho0( in_matmodel->get_rho_0() ),
+  rho0( MaterialModelData::density ),
   alpha_f(tm_gAlpha->get_alpha_f()), alpha_m(tm_gAlpha->get_alpha_m()),
   gamma(tm_gAlpha->get_gamma()),
   nLocBas( elementv->get_nLocBas() ), snLocBas( elements->get_nLocBas() ), 
   vec_size_0( nLocBas * 3 ), vec_size_1( nLocBas ),
   sur_size_0( snLocBas * 3 ),
-  matmodel( std::move(in_matmodel) )
+  matmodel( MaterialModelData::create_mixed_model() )
 {
   Tangent00 = new PetscScalar[vec_size_0 * vec_size_0];
   Tangent01 = new PetscScalar[vec_size_0 * vec_size_1];

--- a/examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp
+++ b/examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp
@@ -1,22 +1,22 @@
 #include "PLocAssem_2x2Block_VMS_Incompressible.hpp"
 #include "LoadData.hpp"
+#include "MaterialModelData.hpp"
 
 PLocAssem_2x2Block_VMS_Incompressible::PLocAssem_2x2Block_VMS_Incompressible(
     const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-    const TimeMethod_GenAlpha * const &tm_gAlpha,
-    std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel )
+    const TimeMethod_GenAlpha * const &tm_gAlpha )
 : elemType(in_type), nqpv(in_nqp_v), nqps(in_nqp_s),
   elementv( ElementFactory::createVolElement(elemType, nqpv) ),
   elements( ElementFactory::createSurElement(elemType, nqps) ),
   quadv( QuadPtsFactory::createVolQuadrature(elemType, nqpv) ),
   quads( QuadPtsFactory::createSurQuadrature(elemType, nqps) ),
-  rho0( in_matmodel->get_rho_0() ),
+  rho0( MaterialModelData::density ),
   alpha_f(tm_gAlpha->get_alpha_f()), alpha_m(tm_gAlpha->get_alpha_m()),
   gamma(tm_gAlpha->get_gamma()),
   nLocBas( elementv->get_nLocBas() ), snLocBas( elements->get_nLocBas() ), 
   vec_size_0( nLocBas * 3 ), vec_size_1( nLocBas ),
   sur_size_0( snLocBas * 3 ),
-  matmodel( std::move(in_matmodel) )
+  matmodel( MaterialModelData::create_mixed_model() )
 {
   Tangent00 = new PetscScalar[vec_size_0 * vec_size_0];
   Tangent01 = new PetscScalar[vec_size_0 * vec_size_1];


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for material parameters and material-model construction used by drivers, local assembly, and post-processing. 
- Simplify interfaces by removing ownership passing of material-model objects through multiple constructors. 

### Description
- Add `examples/solids/include/MaterialModelData.hpp` that exposes centralized constants (`density`, `shear_modulus`) and factory functions `create_vol_model()`, `create_isochoric_model()`, and `create_mixed_model()`. 
- Remove inline material-model construction from `examples/solids/driver.cpp` and stop passing `MaterialModel_Mixed_Elasticity` into local-assembly constructors. 
- Update `PLocAssem_2x2Block_VMS_Hyperelasticity` and `PLocAssem_2x2Block_VMS_Incompressible` headers and sources to include `MaterialModelData.hpp`, drop the material-model parameter from their constructors, and initialize `matmodel` and `rho0` from `MaterialModelData` factories/values. 
- Clean up includes and construct `matmodel` internally using `MaterialModelData::create_mixed_model()`. 

### Testing
- Built the project with `cmake --build .` which completed successfully. 
- Built the `examples/solids` target (including the modified `driver.cpp` and local-assembly sources) and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31e535eb8832aa2149e96e0d86aea)