### PR TITLE
solids: create material model in driver and move into local assembler

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -13,6 +13,7 @@
 #include "PGAssem_Solid_FEM.hpp"
 #include "PNonlinear_Solver.hpp"
 #include "PTime_Solver.hpp"
+#include "MaterialModelData.hpp"
 
 int main(int argc, char *argv[])
 {
@@ -191,10 +192,11 @@ int main(int argc, char *argv[])
   tm_galpha->print_info();
 
   // ===== Local Assembly Routine =====
+  auto matmodel = MaterialModelData::create_mixed_model();
   std::unique_ptr<IPLocAssem_2x2Block> locAssem_ptr =
     SYS_T::make_unique<PLocAssem_2x2Block_VMS_Incompressible>(
         elemType, nqp_vol, nqp_sur,
-        tm_galpha.get());
+        tm_galpha.get(), std::move(matmodel));
 
   // ===== Initial condition =====
   auto disp = PDNSolution::Gen_zero_ptr( pNode.get(), 3 );

--- a/examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp
+++ b/examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp
@@ -20,7 +20,8 @@ class PLocAssem_2x2Block_VMS_Hyperelasticity : public IPLocAssem_2x2Block
   public:
     PLocAssem_2x2Block_VMS_Hyperelasticity(
         const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-        const TimeMethod_GenAlpha * const &tm_gAlpha );
+        const TimeMethod_GenAlpha * const &tm_gAlpha,
+        std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel );
 
     virtual ~PLocAssem_2x2Block_VMS_Hyperelasticity();
 

--- a/examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp
+++ b/examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp
@@ -20,7 +20,8 @@ class PLocAssem_2x2Block_VMS_Incompressible : public IPLocAssem_2x2Block
   public:
     PLocAssem_2x2Block_VMS_Incompressible(
         const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-        const TimeMethod_GenAlpha * const &tm_gAlpha );
+        const TimeMethod_GenAlpha * const &tm_gAlpha,
+        std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel );
 
     virtual ~PLocAssem_2x2Block_VMS_Incompressible();
 

--- a/examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp
+++ b/examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp
@@ -1,22 +1,22 @@
 #include "PLocAssem_2x2Block_VMS_Hyperelasticity.hpp"
 #include "LoadData.hpp"
-#include "MaterialModelData.hpp"
 
 PLocAssem_2x2Block_VMS_Hyperelasticity::PLocAssem_2x2Block_VMS_Hyperelasticity(
     const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-    const TimeMethod_GenAlpha * const &tm_gAlpha )
+    const TimeMethod_GenAlpha * const &tm_gAlpha,
+    std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel )
 : elemType(in_type), nqpv(in_nqp_v), nqps(in_nqp_s),
   elementv( ElementFactory::createVolElement(elemType, nqpv) ),
   elements( ElementFactory::createSurElement(elemType, nqps) ),
   quadv( QuadPtsFactory::createVolQuadrature(elemType, nqpv) ),
   quads( QuadPtsFactory::createSurQuadrature(elemType, nqps) ),
-  rho0( MaterialModelData::density ),
+  rho0( in_matmodel->get_rho_0() ),
   alpha_f(tm_gAlpha->get_alpha_f()), alpha_m(tm_gAlpha->get_alpha_m()),
   gamma(tm_gAlpha->get_gamma()),
   nLocBas( elementv->get_nLocBas() ), snLocBas( elements->get_nLocBas() ), 
   vec_size_0( nLocBas * 3 ), vec_size_1( nLocBas ),
   sur_size_0( snLocBas * 3 ),
-  matmodel( MaterialModelData::create_mixed_model() )
+  matmodel( std::move(in_matmodel) )
 {
   Tangent00 = new PetscScalar[vec_size_0 * vec_size_0];
   Tangent01 = new PetscScalar[vec_size_0 * vec_size_1];

--- a/examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp
+++ b/examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp
@@ -1,22 +1,22 @@
 #include "PLocAssem_2x2Block_VMS_Incompressible.hpp"
 #include "LoadData.hpp"
-#include "MaterialModelData.hpp"
 
 PLocAssem_2x2Block_VMS_Incompressible::PLocAssem_2x2Block_VMS_Incompressible(
     const FEType &in_type, const int &in_nqp_v, const int &in_nqp_s,
-    const TimeMethod_GenAlpha * const &tm_gAlpha )
+    const TimeMethod_GenAlpha * const &tm_gAlpha,
+    std::unique_ptr<MaterialModel_Mixed_Elasticity> in_matmodel )
 : elemType(in_type), nqpv(in_nqp_v), nqps(in_nqp_s),
   elementv( ElementFactory::createVolElement(elemType, nqpv) ),
   elements( ElementFactory::createSurElement(elemType, nqps) ),
   quadv( QuadPtsFactory::createVolQuadrature(elemType, nqpv) ),
   quads( QuadPtsFactory::createSurQuadrature(elemType, nqps) ),
-  rho0( MaterialModelData::density ),
+  rho0( in_matmodel->get_rho_0() ),
   alpha_f(tm_gAlpha->get_alpha_f()), alpha_m(tm_gAlpha->get_alpha_m()),
   gamma(tm_gAlpha->get_gamma()),
   nLocBas( elementv->get_nLocBas() ), snLocBas( elements->get_nLocBas() ), 
   vec_size_0( nLocBas * 3 ), vec_size_1( nLocBas ),
   sur_size_0( snLocBas * 3 ),
-  matmodel( MaterialModelData::create_mixed_model() )
+  matmodel( std::move(in_matmodel) )
 {
   Tangent00 = new PetscScalar[vec_size_0 * vec_size_0];
   Tangent01 = new PetscScalar[vec_size_0 * vec_size_1];


### PR DESCRIPTION
### Motivation
- Move ownership of the material model to the driver and transfer it into the local assembler with `std::move` so the driver manages creation and the assembler consumes the instance.

### Description
- Add a `std::unique_ptr<MaterialModel_Mixed_Elasticity>` parameter to `PLocAssem_2x2Block_VMS_Incompressible` constructor in `examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp`.
- Change the assembler implementation in `examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp` to accept `in_matmodel`, initialize `rho0` from `in_matmodel->get_rho_0()`, and store the model via `matmodel(std::move(in_matmodel))`, removing the direct `MaterialModelData` dependency.
- Create the material model in `examples/solids/driver.cpp` using `MaterialModelData::create_mixed_model()` and pass it into the assembler with `std::move(matmodel)`, and add `#include "MaterialModelData.hpp"` in the driver.

### Testing
- Verified updated call sites and symbols with ripgrep (`rg`) and inspected the diffs via `git diff`, which showed consistent changes to declaration, definition, and caller (success).
- Committed the change with `git commit` which succeeded (commit `07e6704`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f327681560832ab05d4330a6b61358)