### PR TITLE
Move displacement NBC ownership into PNonlinear_Solver and simplify solver interfaces

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
 
   auto nsolver = SYS_T::make_unique<PNonlinear_Solver>(
       std::move(gloAssem_ptr), std::move(lsolver), std::move(pmat),
-      std::move(tm_galpha),
+      std::move(tm_galpha), std::move(locnbc_disp),
       nl_rtol, nl_atol, nl_dtol, nl_maxits, nl_refreq, nl_threshold );
 
   nsolver->print_info();
@@ -249,7 +249,6 @@ int main(int argc, char *argv[])
   SYS_T::commPrint("===> Start Finite Element Analysis:\n");
 
   tsolver->TM_Solid_GenAlpha( is_restart,
-      locnbc_disp.get(),
       std::move(dot_disp), std::move(dot_velo), std::move(dot_pres),
       std::move(disp), std::move(velo), std::move(pres),
       std::move(timeinfo) );

--- a/examples/solids/include/PNonlinear_Solver.hpp
+++ b/examples/solids/include/PNonlinear_Solver.hpp
@@ -22,6 +22,7 @@ class PNonlinear_Solver
         std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
         std::unique_ptr<Matrix_PETSc> in_bc_mat,
         std::unique_ptr<TimeMethod_GenAlpha> in_tmga,
+        std::unique_ptr<ALocal_NBC> in_nbc_disp,
         const double &input_nrtol, const double &input_natol,
         const double &input_ndtol, const int &input_max_iteration,
         const int &input_renew_freq, const int &input_renew_threshold );
@@ -38,7 +39,6 @@ class PNonlinear_Solver
         const bool &new_tangent_flag,
         const double &curr_time,
         const double &dt,
-        const ALocal_NBC * const &nbc_disp,
         const PDNSolution * const &pre_dot_disp,
         const PDNSolution * const &pre_dot_velo,
         const PDNSolution * const &pre_dot_pres,
@@ -61,6 +61,7 @@ class PNonlinear_Solver
     const std::unique_ptr<PLinear_Solver_PETSc> lsolver;
     const std::unique_ptr<Matrix_PETSc> bc_mat;
     const std::unique_ptr<TimeMethod_GenAlpha> tmga;
+    const std::unique_ptr<ALocal_NBC> nbc_disp;
     IS is_velo, is_pres;
 
     void Print_convergence_info( const int &count,
@@ -73,8 +74,7 @@ class PNonlinear_Solver
         const Vec &input,
         PDNSolution * const &output ) const;
 
-    void apply_disp_loading( const ALocal_NBC * const &nbc_disp,
-        const double &time,
+    void apply_disp_loading( const double &time,
         PDNSolution * const &dot_disp,
         PDNSolution * const &dot_velo,
         PDNSolution * const &disp,

--- a/examples/solids/include/PTime_Solver.hpp
+++ b/examples/solids/include/PTime_Solver.hpp
@@ -28,7 +28,6 @@ class PTime_Solver
 
     void TM_Solid_GenAlpha(
         const bool &restart_init_assembly_flag,
-        const ALocal_NBC * const &nbc_disp,
         std::unique_ptr<PDNSolution> init_dot_disp,
         std::unique_ptr<PDNSolution> init_dot_velo,
         std::unique_ptr<PDNSolution> init_dot_pres,

--- a/examples/solids/src/PNonlinear_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solver.cpp
@@ -6,6 +6,7 @@ PNonlinear_Solver::PNonlinear_Solver(
     std::unique_ptr<PLinear_Solver_PETSc> in_lsolver,
     std::unique_ptr<Matrix_PETSc> in_bc_mat,
     std::unique_ptr<TimeMethod_GenAlpha> in_tmga,
+    std::unique_ptr<ALocal_NBC> in_nbc_disp,
     const double &input_nrtol, const double &input_natol,
     const double &input_ndtol, const int &input_max_iteration,
     const int &input_renew_freq, const int &input_renew_threshold )
@@ -16,6 +17,7 @@ PNonlinear_Solver::PNonlinear_Solver(
   lsolver(std::move(in_lsolver)),
   bc_mat(std::move(in_bc_mat)),
   tmga(std::move(in_tmga)),
+  nbc_disp(std::move(in_nbc_disp)),
   is_velo(nullptr), is_pres(nullptr)
 {
   std::vector<PetscInt> idx_v, idx_p;
@@ -74,13 +76,14 @@ void PNonlinear_Solver::update_solid_kinematics( const double &val,
 }
 
 void PNonlinear_Solver::apply_disp_loading(
-    const ALocal_NBC * const &nbc_disp,
     const double &time,
     PDNSolution * const &dot_disp,
     PDNSolution * const &dot_velo,
     PDNSolution * const &disp,
     PDNSolution * const &velo ) const
 {
+  const ALocal_NBC &disp_nbc = *nbc_disp;
+
   for(int field=1; field<=3; ++field)
   {
     double uval = 0.0;
@@ -89,10 +92,10 @@ void PNonlinear_Solver::apply_disp_loading(
 
     LoadData::disp_loading( field, time, uval, vval, aval );
 
-    const int num_disp_ld = nbc_disp->get_Num_LD(field);
+    const int num_disp_ld = disp_nbc.get_Num_LD(field);
     for(int ii=0; ii<num_disp_ld; ++ii)
     {
-      const PetscInt gid = nbc_disp->get_LDN(field, ii);
+      const PetscInt gid = disp_nbc.get_LDN(field, ii);
       const PetscInt idx = gid * 3 + (field - 1);
 
       VecSetValue(disp->solution, idx, uval, INSERT_VALUES);
@@ -112,7 +115,6 @@ void PNonlinear_Solver::GenAlpha_Seg_solve_Solid(
     const bool &new_tangent_flag,
     const double &curr_time,
     const double &dt,
-    const ALocal_NBC * const &nbc_disp,
     const PDNSolution * const &pre_dot_disp,
     const PDNSolution * const &pre_dot_velo,
     const PDNSolution * const &pre_dot_pres,
@@ -146,7 +148,7 @@ void PNonlinear_Solver::GenAlpha_Seg_solve_Solid(
   velo -> Copy( pre_velo );
   pres -> Copy( pre_pres );
 
-  apply_disp_loading( nbc_disp, curr_time + dt,
+  apply_disp_loading( curr_time + dt,
       dot_disp, dot_velo, disp, velo );
 
   // Define intermediate solutions

--- a/examples/solids/src/PNonlinear_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solver.cpp
@@ -82,8 +82,6 @@ void PNonlinear_Solver::apply_disp_loading(
     PDNSolution * const &disp,
     PDNSolution * const &velo ) const
 {
-  const ALocal_NBC &disp_nbc = *nbc_disp;
-
   for(int field=1; field<=3; ++field)
   {
     double uval = 0.0;
@@ -92,10 +90,10 @@ void PNonlinear_Solver::apply_disp_loading(
 
     LoadData::disp_loading( field, time, uval, vval, aval );
 
-    const int num_disp_ld = disp_nbc.get_Num_LD(field);
+    const int num_disp_ld = nbc_disp->get_Num_LD(field);
     for(int ii=0; ii<num_disp_ld; ++ii)
     {
-      const PetscInt gid = disp_nbc.get_LDN(field, ii);
+      const PetscInt gid = nbc_disp->get_LDN(field, ii);
       const PetscInt idx = gid * 3 + (field - 1);
 
       VecSetValue(disp->solution, idx, uval, INSERT_VALUES);

--- a/examples/solids/src/PTime_Solver.cpp
+++ b/examples/solids/src/PTime_Solver.cpp
@@ -42,7 +42,6 @@ std::string PTime_Solver::Name_dot_Generator( const std::string &middle_name,
 
 void PTime_Solver::TM_Solid_GenAlpha(
     const bool &restart_init_assembly_flag,
-    const ALocal_NBC * const &nbc_disp,
     std::unique_ptr<PDNSolution> init_dot_disp,
     std::unique_ptr<PDNSolution> init_dot_velo,
     std::unique_ptr<PDNSolution> init_dot_pres,
@@ -110,7 +109,6 @@ void PTime_Solver::TM_Solid_GenAlpha(
 
     nsolver->GenAlpha_Seg_solve_Solid( renew_flag,
         time_info->get_time(), time_info->get_step(),
-        nbc_disp,
         pre_dot_disp.get(), pre_dot_velo.get(), pre_dot_pres.get(),
         pre_disp.get(), pre_velo.get(), pre_pres.get(),
         cur_dot_disp.get(), cur_dot_velo.get(), cur_dot_pres.get(),


### PR DESCRIPTION
### Motivation
- Reduce parameter passing of displacement natural boundary conditions (NBC) through time and nonlinear solver call sites by giving the nonlinear solver ownership of the displacement NBC data.
- Simplify the runtime interfaces for `PTime_Solver::TM_Solid_GenAlpha` and `PNonlinear_Solver::GenAlpha_Seg_solve_Solid` so they no longer require an explicit `ALocal_NBC` pointer for displacement loading.

### Description
- Added a `std::unique_ptr<ALocal_NBC> nbc_disp` member to `PNonlinear_Solver` and extended its constructor to accept and take ownership of the displacement NBC via `in_nbc_disp`.
- Removed the `ALocal_NBC` pointer parameter from `PNonlinear_Solver::GenAlpha_Seg_solve_Solid`, `PNonlinear_Solver::apply_disp_loading`, and `PTime_Solver::TM_Solid_GenAlpha` function signatures and updated call sites accordingly.
- Updated `apply_disp_loading` to read displacement loading data from the owned `nbc_disp` member instead of an external pointer, and adjusted all affected source and header files (`driver.cpp`, `PNonlinear_Solver.hpp/.cpp`, `PTime_Solver.hpp/.cpp`).

### Testing
- Performed a build of the solids example after the changes and the compilation completed successfully.
- No automated unit tests were added; existing example build served as a smoke test and passed compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3286ab1e0832ab02b0cc7a8647cf1)