### PR TITLE
Select local assembler by volumetric material model and add hyperelastic assembler include

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -8,6 +8,7 @@
 #include "HDF5_Writer.hpp"
 #include "ANL_Tools.hpp"
 #include "PLocAssem_2x2Block_VMS_Incompressible.hpp"
+#include "PLocAssem_2x2Block_VMS_Hyperelasticity.hpp"
 #include "InitHelpers.hpp"
 #include "ALocal_NBC.hpp"
 #include "PGAssem_Solid_FEM.hpp"
@@ -193,8 +194,15 @@ int main(int argc, char *argv[])
 
   // ===== Local Assembly Routine =====
   auto matmodel = MaterialModelData::create_mixed_model();
-  std::unique_ptr<IPLocAssem_2x2Block> locAssem_ptr =
-    SYS_T::make_unique<PLocAssem_2x2Block_VMS_Incompressible>(
+  const bool is_incompressible = matmodel->get_vol_model_name() == "Incompressible";
+
+  std::unique_ptr<IPLocAssem_2x2Block> locAssem_ptr;
+  if( is_incompressible )
+    locAssem_ptr = SYS_T::make_unique<PLocAssem_2x2Block_VMS_Incompressible>(
+        elemType, nqp_vol, nqp_sur,
+        tm_galpha.get(), std::move(matmodel));
+  else
+    locAssem_ptr = SYS_T::make_unique<PLocAssem_2x2Block_VMS_Hyperelasticity>(
         elemType, nqp_vol, nqp_sur,
         tm_galpha.get(), std::move(matmodel));
 

--- a/include/MaterialModel_Mixed_Elasticity.hpp
+++ b/include/MaterialModel_Mixed_Elasticity.hpp
@@ -26,6 +26,9 @@ class MaterialModel_Mixed_Elasticity
     std::string get_model_name() const
     {return imodel->get_model_name() + '-' + vmodel->get_model_name();}
 
+    std::string get_vol_model_name() const
+    {return vmodel->get_model_name();}
+
     SymmTensor2_3D get_PK_2nd( const Tensor2_3D &F ) const 
     {return imodel->get_PK_2nd(F);}
 


### PR DESCRIPTION
### Motivation
- Enable the driver to choose a different local assembly routine when the volumetric material model is not incompressible so hyperelastic formulations can be used.
- Expose the volumetric submodel name from the mixed material model so runtime selection can be made.

### Description
- Added `#include "PLocAssem_2x2Block_VMS_Hyperelasticity.hpp"` to `examples/solids/driver.cpp` and introduced an `is_incompressible` boolean to detect the volumetric model via `get_vol_model_name()` and conditionally construct either `PLocAssem_2x2Block_VMS_Incompressible` or `PLocAssem_2x2Block_VMS_Hyperelasticity` into `locAssem_ptr`.
- Modified `MaterialModel_Mixed_Elasticity.hpp` to add the accessor `get_vol_model_name()` which returns the volumetric model name from the contained `vmodel`.
- Updated the `locAssem_ptr` initialization to use the selected assembler and pass the `matmodel` with `std::move` in both branches.

### Testing
- Built the project and compiled the `examples/solids/driver` binary successfully with the new conditional assembler selection. 
- Ran the existing automated test suite and the tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32adff5b8832a95bdd6a62014ce03)