### PR TITLE
Change VisDataPrep_Solid::get_pointArray to accept three filename strings

### DIFF
--- a/examples/solids/include/VisDataPrep_Solid.hpp
+++ b/examples/solids/include/VisDataPrep_Solid.hpp
@@ -22,7 +22,9 @@ class VisDataPrep_Solid : public IVisDataPrep
     { return pt_array_len[ii]; }
 
     virtual void get_pointArray(
-        const std::vector<std::string> solution_file_names,
+        const std::string &disp_solution_file_name,
+        const std::string &pres_solution_file_name,
+        const std::string &velo_solution_file_name,
         const std::vector<int> &analysis_node_mapping,
         const std::vector<int> &post_node_mapping,
         const APart_Node * const &nNode_ptr,

--- a/examples/solids/src/VisDataPrep_Solid.cpp
+++ b/examples/solids/src/VisDataPrep_Solid.cpp
@@ -23,22 +23,21 @@ VisDataPrep_Solid::VisDataPrep_Solid()
 }
 
 void VisDataPrep_Solid::get_pointArray(
-    const std::vector<std::string> solution_file_names,
+    const std::string &disp_solution_file_name,
+    const std::string &pres_solution_file_name,
+    const std::string &velo_solution_file_name,
     const std::vector<int> &analysis_node_mapping,
     const std::vector<int> &post_node_mapping,
     const APart_Node * const &nNode_ptr,
     double ** &pointArrays ) const
 {
-  SYS_T::print_fatal_if(solution_file_names.size() != 3,
-      "Error: VisDataPrep_Solid expects three solution files (disp, pres, velo).\n");
-
-  PostVectSolution pvsolu_disp(solution_file_names[0],
+  PostVectSolution pvsolu_disp(disp_solution_file_name,
       analysis_node_mapping, post_node_mapping, nNode_ptr, 3);
 
-  PostVectSolution pvsolu_pres(solution_file_names[1],
+  PostVectSolution pvsolu_pres(pres_solution_file_name,
       analysis_node_mapping, post_node_mapping, nNode_ptr, 1);
 
-  PostVectSolution pvsolu_velo(solution_file_names[2],
+  PostVectSolution pvsolu_velo(velo_solution_file_name,
       analysis_node_mapping, post_node_mapping, nNode_ptr, 3);
 
   const int ntotal = nNode_ptr->get_nlocghonode();

--- a/examples/solids/vis.cpp
+++ b/examples/solids/vis.cpp
@@ -134,11 +134,8 @@ int main( int argc, char * argv[] )
         time, disp_name_to_read.c_str(), pres_name_to_read.c_str(),
         velo_name_to_read.c_str(), name_to_write.c_str() );
 
-    std::vector<std::string> sol_names { disp_name_to_read, 
-      pres_name_to_read, velo_name_to_read };
-
-    visprep->get_pointArray(sol_names, anode_mapping, pnode_mapping,
-        pNode.get(), solArrays);
+    visprep->get_pointArray(disp_name_to_read, pres_name_to_read,
+        velo_name_to_read, anode_mapping, pnode_mapping, pNode.get(), solArrays);
 
     vtk_w->writeOutput( fNode.get(), locIEN.get(), locElem.get(), visprep.get(),
         element.get(), quad.get(), solArrays, epart_map, rank, size,

--- a/include/IVisDataPrep.hpp
+++ b/include/IVisDataPrep.hpp
@@ -79,6 +79,24 @@ class IVisDataPrep
       SYS_T::print_fatal("Warning: get_pointArray is not implemented.\n");
     }
 
+
+    // -------------------------------------------------------------------
+    // ! input gives three solution names for displacement, pressure,
+    //   and velocity. This is used when these solutions are stored as
+    //   separate petsc binary vectors on disk.
+    // -------------------------------------------------------------------
+    virtual void get_pointArray(
+        const std::string &disp_solution_file_name,
+        const std::string &pres_solution_file_name,
+        const std::string &velo_solution_file_name,
+        const std::vector<int> &analysis_node_mapping,
+        const std::vector<int> &post_node_mapping,
+        const APart_Node * const &nNode_ptr,
+        double ** &pointArrays ) const
+    {
+      SYS_T::print_fatal("Warning: get_pointArray is not implemented.\n");
+    }
+
     // ------------------------------------------------------------------------
     // ! input gives three solution names for the disp, pres, and velo
     // respectively. The kinematic variables (i.e. disp and velo) were


### PR DESCRIPTION
### Motivation
- Make the `VisDataPrep_Solid::get_pointArray` API explicit by taking three string filenames for displacement, pressure, and velocity rather than a `std::vector<std::string>`, removing a runtime size check and clarifying call sites.

### Description
- Updated `examples/solids/include/VisDataPrep_Solid.hpp` to change the `get_pointArray` signature to take `const std::string &disp_solution_file_name`, `const std::string &pres_solution_file_name`, and `const std::string &velo_solution_file_name` instead of a `std::vector<std::string>`.
- Modified `examples/solids/src/VisDataPrep_Solid.cpp` to accept the three filename parameters and construct `PostVectSolution` objects directly from them, removing the previous `solution_file_names.size() != 3` check.
- Updated the solids driver `examples/solids/vis.cpp` to call `visprep->get_pointArray` with the three filename strings instead of building a `std::vector<std::string>`.
- Added a matching virtual overload in `include/IVisDataPrep.hpp` for the three-string `get_pointArray` to preserve polymorphic usage through `IVisDataPrep`.

### Testing
- Ran `rg "get_pointArray\("` to verify updated declarations and call sites, which succeeded.
- Inspected diffs with `git diff -- <files>` to confirm changes, which succeeded.
- Verified working tree status with `git status --short`, which showed the intended modifications.
- Committed the changes with `git commit -m "Update solid vis point array API to take three filenames"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f411bdab24832ab261807a67567ff5)