### PR TITLE
Use std::unique_ptr vectors for NBC partition boundary condition lists

### DIFF
--- a/examples/ale_ns_rotate/preprocess.cpp
+++ b/examples/ale_ns_rotate/preprocess.cpp
@@ -315,7 +315,7 @@ int main( int argc, char * argv[] )
   }
 
   // Setup Nodal i.e. Dirichlet type Boundary Conditions
-  std::vector<INodalBC *> NBC_list( dofMat, nullptr );
+  std::vector<std::unique_ptr<INodalBC>> NBC_list( dofMat );
 
   std::vector<std::string> dir_list {};
   std::vector<std::string> weak_list {};
@@ -334,10 +334,10 @@ int main( int argc, char * argv[] )
   else
     SYS_T::print_fatal("Unknown wall model type.");
 
-  NBC_list[0] = new NodalBC( nFunc );
-  NBC_list[1] = new NodalBC( dir_list, rotated_sur_file, sur_file_inner_wall, fixed_geo_file, nFunc );
-  NBC_list[2] = new NodalBC( dir_list, rotated_sur_file, sur_file_inner_wall, fixed_geo_file, nFunc );
-  NBC_list[3] = new NodalBC( dir_list, rotated_sur_file, sur_file_inner_wall, fixed_geo_file, nFunc );
+  NBC_list[0] = SYS_T::make_unique<NodalBC>( nFunc );
+  NBC_list[1] = SYS_T::make_unique<NodalBC>( dir_list, rotated_sur_file, sur_file_inner_wall, fixed_geo_file, nFunc );
+  NBC_list[2] = SYS_T::make_unique<NodalBC>( dir_list, rotated_sur_file, sur_file_inner_wall, fixed_geo_file, nFunc );
+  NBC_list[3] = SYS_T::make_unique<NodalBC>( dir_list, rotated_sur_file, sur_file_inner_wall, fixed_geo_file, nFunc );
 
   // Rotated BC info
   INodalBC * RotBC = new NodalBC_3D_rotated( rotated_sur_file, fixed_geo_file,
@@ -602,8 +602,6 @@ int main( int argc, char * argv[] )
   cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<endl;
 
   // Finalize the code and exit
-  for(auto &it_nbc : NBC_list) delete it_nbc;
-
   delete InFBC; delete RotBC; delete ebc; delete wbc; delete mytimer;
   delete mnindex; delete global_part; delete IEN;
 

--- a/examples/fsi/preprocess.cpp
+++ b/examples/fsi/preprocess.cpp
@@ -427,29 +427,29 @@ int main( int argc, char * argv[] )
   // Physical NodalBC
   std::cout<<"===== Boundary Conditions =====\n";
   std::cout<<"1. Nodal boundary condition for the implicit solver: \n";
-  std::vector<INodalBC *> NBC_list_p( 1, nullptr );
-  std::vector<INodalBC *> NBC_list_v( 3, nullptr );
+  std::vector<std::unique_ptr<INodalBC>> NBC_list_p( 1 );
+  std::vector<std::unique_ptr<INodalBC>> NBC_list_v( 3 );
 
   // Here we assumed that the pressure mesh fluid nodal indices are identical to
   // that in the velocity mesh.
-  NBC_list_p[0] = new NodalBC_3D_FSI( geo_f_file, nFunc_p, fsiBC_type );
+  NBC_list_p[0] = SYS_T::make_unique<NodalBC_3D_FSI>( geo_f_file, nFunc_p, fsiBC_type );
 
   for( int ii=0; ii<3; ++ii )
-    NBC_list_v[ii] = new NodalBC_3D_FSI( geo_f_file, geo_s_file, sur_f_file_wall, 
+    NBC_list_v[ii] = SYS_T::make_unique<NodalBC_3D_FSI>( geo_f_file, geo_s_file, sur_f_file_wall, 
         sur_s_file_wall, sur_f_file_in, sur_f_file_out, sur_s_file_in, sur_s_file_out, 
         nFunc_v, ii, ringBC_type, fsiBC_type );
 
   // Mesh solver NodalBC
   std::cout<<"2. Nodal boundary condition for the mesh motion: \n";
-  std::vector<INodalBC *> meshBC_list( 3, nullptr );
+  std::vector<std::unique_ptr<INodalBC>> meshBC_list( 3 );
 
   std::vector<std::string> meshdir_file_list { geo_s_file };
   VEC_T::insert_end( meshdir_file_list, sur_f_file_in );
   VEC_T::insert_end( meshdir_file_list, sur_f_file_out );
 
-  meshBC_list[0] = new NodalBC( meshdir_file_list, nFunc_v );
-  meshBC_list[1] = new NodalBC( meshdir_file_list, nFunc_v );
-  meshBC_list[2] = new NodalBC( meshdir_file_list, nFunc_v );
+  meshBC_list[0] = SYS_T::make_unique<NodalBC>( meshdir_file_list, nFunc_v );
+  meshBC_list[1] = SYS_T::make_unique<NodalBC>( meshdir_file_list, nFunc_v );
+  meshBC_list[2] = SYS_T::make_unique<NodalBC>( meshdir_file_list, nFunc_v );
 
   // InflowBC info
   std::cout<<"3. Inflow cap surfaces: \n";
@@ -571,12 +571,6 @@ int main( int argc, char * argv[] )
   }
 
   // Clean up the memory
-  for(auto &it_nbc : NBC_list_v) delete it_nbc;
-  
-  for(auto &it_nbc : NBC_list_p) delete it_nbc;
-
-  for(auto &it_nbc : meshBC_list) delete it_nbc;
-
   delete ebc; delete InFBC; delete mesh_ebc; 
   delete mnindex_p; delete mnindex_v;
   delete IEN_p; delete IEN_v; delete mytimer; delete global_part; 

--- a/examples/linearPDE/preprocess.cpp
+++ b/examples/linearPDE/preprocess.cpp
@@ -131,9 +131,9 @@ int main( int argc, char * argv[] )
   mnindex->write_hdf5("node_mapping");
 
   // Setup Nodal (Dirichlet type) boundary condition(s)
-  std::vector<INodalBC *> NBC_list( dofMat, nullptr );
+  std::vector<std::unique_ptr<INodalBC>> NBC_list( dofMat );
   for(int ii = 0; ii < dofMat; ++ii)
-    NBC_list[ii] = new NodalBC( dir_list[ii], nFunc );
+    NBC_list[ii] = SYS_T::make_unique<NodalBC>( dir_list[ii], nFunc );
   
   // Setup Elemental (Neumann type) boundary condition(s)
   auto ebc = SYS_T::make_unique<ElemBC_3D>( neu_list, elemType );
@@ -199,7 +199,6 @@ int main( int argc, char * argv[] )
   cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<endl;
 
   // Finalize the code and exit
-  for(auto &it_nbc : NBC_list ) delete it_nbc;
 
   return EXIT_SUCCESS;
 }

--- a/examples/linearPDE/preprocess.cpp
+++ b/examples/linearPDE/preprocess.cpp
@@ -198,8 +198,6 @@ int main( int argc, char * argv[] )
   cout<<"The maximum / minimum of local node is: ";
   cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<endl;
 
-  // Finalize the code and exit
-
   return EXIT_SUCCESS;
 }
 

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -303,8 +303,6 @@ int main( int argc, char * argv[] )
   cout<<"The maximum / minimum of local node is: ";
   cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<endl;
 
-  // Finalize the code and exit
-
   return EXIT_SUCCESS;
 }
 

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -169,7 +169,7 @@ int main( int argc, char * argv[] )
   mnindex->write_hdf5("node_mapping");
 
   // Setup Nodal i.e. Dirichlet type Boundary Conditions
-  std::vector<INodalBC *> NBC_list( dofMat, nullptr );
+  std::vector<std::unique_ptr<INodalBC>> NBC_list( dofMat );
 
   std::vector<std::string> dir_list {};
   std::vector<std::string> weak_list {};
@@ -183,10 +183,10 @@ int main( int argc, char * argv[] )
   else
     SYS_T::print_fatal("Unknown wall model type.");
 
-  NBC_list[0] = new NodalBC( nFunc );
-  NBC_list[1] = new NodalBC( dir_list, nFunc );
-  NBC_list[2] = new NodalBC( dir_list, nFunc );
-  NBC_list[3] = new NodalBC( dir_list, nFunc );
+  NBC_list[0] = SYS_T::make_unique<NodalBC>( nFunc );
+  NBC_list[1] = SYS_T::make_unique<NodalBC>( dir_list, nFunc );
+  NBC_list[2] = SYS_T::make_unique<NodalBC>( dir_list, nFunc );
+  NBC_list[3] = SYS_T::make_unique<NodalBC>( dir_list, nFunc );
 
   // Inflow BC info
   std::vector< Vector_3 > inlet_outvec( sur_file_in.size() );
@@ -304,7 +304,6 @@ int main( int argc, char * argv[] )
   cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<endl;
 
   // Finalize the code and exit
-  for(auto &it_nbc : NBC_list) delete it_nbc;
 
   return EXIT_SUCCESS;
 }

--- a/examples/solids/preprocess.cpp
+++ b/examples/solids/preprocess.cpp
@@ -157,16 +157,14 @@ int main( int argc, char * argv[] )
   mnindex->write_hdf5("node_mapping");
 
   // Setup Nodal Boundary Conditions, grouped by matrix dof.
-  std::vector<std::unique_ptr<INodalBC>> nbc_list {};
-  nbc_list.reserve( dofMat );
-  nbc_list.push_back( SYS_T::make_unique<NodalBC>( nFunc ) );
-  nbc_list.push_back( SYS_T::make_unique<NodalBC>( sur_file_dir_x, nFunc ) );
-  nbc_list.push_back( SYS_T::make_unique<NodalBC>( sur_file_dir_y, nFunc ) );
-  nbc_list.push_back( SYS_T::make_unique<NodalBC>( sur_file_dir_z, nFunc ) );
+  std::vector<std::unique_ptr<INodalBC>> nbc_list( dofMat );
+  nbc_list[0] = SYS_T::make_unique<NodalBC>( nFunc );
+  nbc_list[1] = SYS_T::make_unique<NodalBC>( sur_file_dir_x, nFunc );
+  nbc_list[2] = SYS_T::make_unique<NodalBC>( sur_file_dir_y, nFunc );
+  nbc_list[3] = SYS_T::make_unique<NodalBC>( sur_file_dir_z, nFunc );
 
-  std::vector<std::unique_ptr<INodalBC>> nbc_disp_list {};
-  nbc_disp_list.reserve( dofMat );
-  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nFunc ) );
+  std::vector<std::unique_ptr<INodalBC>> nbc_disp_list( dofMat );
+  nbc_disp_list[0] = SYS_T::make_unique<NodalBC>( nFunc );
 
   std::vector<std::string> nbc_disp_file {};
   nbc_disp_file.reserve( sur_file_dir_x.size() );
@@ -174,7 +172,7 @@ int main( int argc, char * argv[] )
   {
     if( is_disp_driven_x[ii] ) nbc_disp_file.push_back( sur_file_dir_x[ii] );
   }
-  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc ) );
+  nbc_disp_list[1] = SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc );
 
   nbc_disp_file.clear();
   nbc_disp_file.reserve( sur_file_dir_y.size() );
@@ -182,7 +180,7 @@ int main( int argc, char * argv[] )
   {
     if( is_disp_driven_y[ii] ) nbc_disp_file.push_back( sur_file_dir_y[ii] );
   }
-  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc ) );
+  nbc_disp_list[2] = SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc );
 
   nbc_disp_file.clear();
   nbc_disp_file.reserve( sur_file_dir_z.size() );
@@ -190,7 +188,7 @@ int main( int argc, char * argv[] )
   {
     if( is_disp_driven_z[ii] ) nbc_disp_file.push_back( sur_file_dir_z[ii] );
   }
-  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc ) );
+  nbc_disp_list[3] = SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc );
 
   auto ebc = SYS_T::make_unique<ElemBC_3D>( sur_file_neu, elemType );
   ebc -> resetSurIEN_outwardnormal( IEN.get() ); // reset IEN for outward normal calculations
@@ -258,7 +256,6 @@ int main( int argc, char * argv[] )
   std::cout<<maxpart_nlocalnode<<"\t"<<minpart_nlocalnode<<std::endl;
   std::cout<<"The maximum / minimum of local node is: ";
   std::cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<std::endl;
-
 
   return EXIT_SUCCESS;
 }

--- a/examples/solids/preprocess.cpp
+++ b/examples/solids/preprocess.cpp
@@ -157,16 +157,16 @@ int main( int argc, char * argv[] )
   mnindex->write_hdf5("node_mapping");
 
   // Setup Nodal Boundary Conditions, grouped by matrix dof.
-  std::vector<INodalBC *> nbc_list {};
+  std::vector<std::unique_ptr<INodalBC>> nbc_list {};
   nbc_list.reserve( dofMat );
-  nbc_list.push_back( new NodalBC( nFunc ) );
-  nbc_list.push_back( new NodalBC( sur_file_dir_x, nFunc ) );
-  nbc_list.push_back( new NodalBC( sur_file_dir_y, nFunc ) );
-  nbc_list.push_back( new NodalBC( sur_file_dir_z, nFunc ) );
+  nbc_list.push_back( SYS_T::make_unique<NodalBC>( nFunc ) );
+  nbc_list.push_back( SYS_T::make_unique<NodalBC>( sur_file_dir_x, nFunc ) );
+  nbc_list.push_back( SYS_T::make_unique<NodalBC>( sur_file_dir_y, nFunc ) );
+  nbc_list.push_back( SYS_T::make_unique<NodalBC>( sur_file_dir_z, nFunc ) );
 
-  std::vector<INodalBC *> nbc_disp_list {};
+  std::vector<std::unique_ptr<INodalBC>> nbc_disp_list {};
   nbc_disp_list.reserve( dofMat );
-  nbc_disp_list.push_back( new NodalBC( nFunc ) );
+  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nFunc ) );
 
   std::vector<std::string> nbc_disp_file {};
   nbc_disp_file.reserve( sur_file_dir_x.size() );
@@ -174,7 +174,7 @@ int main( int argc, char * argv[] )
   {
     if( is_disp_driven_x[ii] ) nbc_disp_file.push_back( sur_file_dir_x[ii] );
   }
-  nbc_disp_list.push_back( new NodalBC( nbc_disp_file, nFunc ) );
+  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc ) );
 
   nbc_disp_file.clear();
   nbc_disp_file.reserve( sur_file_dir_y.size() );
@@ -182,7 +182,7 @@ int main( int argc, char * argv[] )
   {
     if( is_disp_driven_y[ii] ) nbc_disp_file.push_back( sur_file_dir_y[ii] );
   }
-  nbc_disp_list.push_back( new NodalBC( nbc_disp_file, nFunc ) );
+  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc ) );
 
   nbc_disp_file.clear();
   nbc_disp_file.reserve( sur_file_dir_z.size() );
@@ -190,7 +190,7 @@ int main( int argc, char * argv[] )
   {
     if( is_disp_driven_z[ii] ) nbc_disp_file.push_back( sur_file_dir_z[ii] );
   }
-  nbc_disp_list.push_back( new NodalBC( nbc_disp_file, nFunc ) );
+  nbc_disp_list.push_back( SYS_T::make_unique<NodalBC>( nbc_disp_file, nFunc ) );
 
   auto ebc = SYS_T::make_unique<ElemBC_3D>( sur_file_neu, elemType );
   ebc -> resetSurIEN_outwardnormal( IEN.get() ); // reset IEN for outward normal calculations
@@ -259,8 +259,6 @@ int main( int argc, char * argv[] )
   std::cout<<"The maximum / minimum of local node is: ";
   std::cout<<(double) maxpart_nlocalnode / (double) minpart_nlocalnode<<std::endl;
 
-  for(auto &it_nbc : nbc_list ) delete it_nbc;
-  for(auto &it_nbc : nbc_disp_list ) delete it_nbc;
 
   return EXIT_SUCCESS;
 }

--- a/include/EBC_Partition_outflow.hpp
+++ b/include/EBC_Partition_outflow.hpp
@@ -15,7 +15,6 @@
 // Date: Mar. 18 2019
 // ==================================================================
 #include "EBC_Partition.hpp"
-#include <memory>
 #include "INodalBC.hpp"
 
 class EBC_Partition_outflow : public EBC_Partition

--- a/include/EBC_Partition_outflow.hpp
+++ b/include/EBC_Partition_outflow.hpp
@@ -15,6 +15,7 @@
 // Date: Mar. 18 2019
 // ==================================================================
 #include "EBC_Partition.hpp"
+#include <memory>
 #include "INodalBC.hpp"
 
 class EBC_Partition_outflow : public EBC_Partition
@@ -24,7 +25,7 @@ class EBC_Partition_outflow : public EBC_Partition
     EBC_Partition_outflow( const IPart * const &part,
         const Map_Node_Index * const &mnindex,
         const ElemBC * const &ebc,
-        const std::vector<INodalBC *> &nbc_list );
+        const std::vector<std::unique_ptr<INodalBC>> &nbc_list );
 
     ~EBC_Partition_outflow() override = default;
 

--- a/include/EBC_Partition_outflow_MF.hpp
+++ b/include/EBC_Partition_outflow_MF.hpp
@@ -13,6 +13,7 @@
 // Date: Dec. 19 2021
 // ============================================================================
 #include "EBC_Partition.hpp"
+#include <memory>
 #include "INodalBC.hpp"
 
 class EBC_Partition_outflow_MF : public EBC_Partition
@@ -22,7 +23,7 @@ class EBC_Partition_outflow_MF : public EBC_Partition
     EBC_Partition_outflow_MF( const IPart * const &part,
         const Map_Node_Index * const &mnindex,
         const ElemBC * const &ebc,
-        const std::vector<INodalBC *> &nbc_list,
+        const std::vector<std::unique_ptr<INodalBC>> &nbc_list,
         const std::vector< std::vector<int> > &grid2id );
 
     ~EBC_Partition_outflow_MF() override = default;

--- a/include/EBC_Partition_outflow_MF.hpp
+++ b/include/EBC_Partition_outflow_MF.hpp
@@ -13,7 +13,6 @@
 // Date: Dec. 19 2021
 // ============================================================================
 #include "EBC_Partition.hpp"
-#include <memory>
 #include "INodalBC.hpp"
 
 class EBC_Partition_outflow_MF : public EBC_Partition

--- a/include/NBC_Partition.hpp
+++ b/include/NBC_Partition.hpp
@@ -12,7 +12,6 @@
 #include "IPart.hpp"
 #include "INodalBC.hpp"
 #include "Map_Node_Index.hpp"
-#include <memory>
 
 class NBC_Partition
 {

--- a/include/NBC_Partition.hpp
+++ b/include/NBC_Partition.hpp
@@ -12,6 +12,7 @@
 #include "IPart.hpp"
 #include "INodalBC.hpp"
 #include "Map_Node_Index.hpp"
+#include <memory>
 
 class NBC_Partition
 {
@@ -25,7 +26,7 @@ class NBC_Partition
     // ------------------------------------------------------------------------
     NBC_Partition( const IPart * const &part,
        const Map_Node_Index * const &mnindex,
-       const std::vector<INodalBC *> &nbc_list );
+       const std::vector<std::unique_ptr<INodalBC>> &nbc_list );
 
     virtual ~NBC_Partition() = default;
 

--- a/include/NBC_Partition_MF.hpp
+++ b/include/NBC_Partition_MF.hpp
@@ -18,7 +18,7 @@ class NBC_Partition_MF : public NBC_Partition
   public:
     NBC_Partition_MF( const IPart * const &part,
         const Map_Node_Index * const &mnindex,
-        const std::vector<INodalBC *> &nbc_list,
+        const std::vector<std::unique_ptr<INodalBC>> &nbc_list,
         const std::vector< std::vector<int> > &grid2id );
 
     // If the grid2id mapper is not provided for the constructor, we assume that
@@ -26,7 +26,7 @@ class NBC_Partition_MF : public NBC_Partition
     // for 0 <= mm < dof
     NBC_Partition_MF( const IPart * const &part,
         const Map_Node_Index * const &mnindex,
-        const std::vector<INodalBC *> &nbc_list );
+        const std::vector<std::unique_ptr<INodalBC>> &nbc_list );
 
     ~NBC_Partition_MF() override;
 

--- a/src/Mesh/EBC_Partition_outflow.cpp
+++ b/src/Mesh/EBC_Partition_outflow.cpp
@@ -6,7 +6,7 @@ EBC_Partition_outflow::EBC_Partition_outflow(
     const IPart * const &part,
     const Map_Node_Index * const &mnindex,
     const ElemBC * const &ebc,
-    const std::vector<INodalBC *> &nbc_list )
+    const std::vector<std::unique_ptr<INodalBC>> &nbc_list )
 : EBC_Partition(part, mnindex, ebc)
 {
   face_int_NA.resize(num_ebc);

--- a/src/Mesh/EBC_Partition_outflow_MF.cpp
+++ b/src/Mesh/EBC_Partition_outflow_MF.cpp
@@ -6,7 +6,7 @@ EBC_Partition_outflow_MF::EBC_Partition_outflow_MF(
     const IPart * const &part,
     const Map_Node_Index * const &mnindex,
     const ElemBC * const &ebc,
-    const std::vector<INodalBC *> &nbc_list,
+    const std::vector<std::unique_ptr<INodalBC>> &nbc_list,
     const std::vector< std::vector<int> > &grid2id )
 : EBC_Partition(part, mnindex, ebc)
 {

--- a/src/Mesh/NBC_Partition.cpp
+++ b/src/Mesh/NBC_Partition.cpp
@@ -5,7 +5,7 @@
 
 NBC_Partition::NBC_Partition( const IPart * const &part,
     const Map_Node_Index * const &mnindex,
-    const std::vector<INodalBC *> &nbc_list ) : cpu_rank(part->get_cpu_rank())
+    const std::vector<std::unique_ptr<INodalBC>> &nbc_list ) : cpu_rank(part->get_cpu_rank())
 {
   const int dof = (int) nbc_list.size();
 

--- a/src/Mesh/NBC_Partition_MF.cpp
+++ b/src/Mesh/NBC_Partition_MF.cpp
@@ -5,7 +5,7 @@
 
 NBC_Partition_MF::NBC_Partition_MF( const IPart * const &part,
     const Map_Node_Index * const &mnindex,
-    const std::vector<INodalBC *> &nbc_list,
+    const std::vector<std::unique_ptr<INodalBC>> &nbc_list,
     const std::vector< std::vector<int> > &grid2id ) 
 : NBC_Partition(part, mnindex, nbc_list)
 { 
@@ -71,7 +71,7 @@ NBC_Partition_MF::NBC_Partition_MF( const IPart * const &part,
 
 NBC_Partition_MF::NBC_Partition_MF( const IPart * const &part,
     const Map_Node_Index * const &mnindex,
-    const std::vector<INodalBC *> &nbc_list ) 
+    const std::vector<std::unique_ptr<INodalBC>> &nbc_list ) 
 : NBC_Partition(part, mnindex, nbc_list)
 { 
   const int dof = (int) nbc_list.size();


### PR DESCRIPTION
### Motivation
- Replace ad-hoc ownership of `INodalBC*` arrays with RAII to prevent leaks and make ownership explicit when passing nodal boundary condition lists into partitioning routines.
- Modernize constructor interfaces for `NBC_Partition` and related consumers so they accept a vector of `std::unique_ptr<INodalBC>` to reflect unique ownership transfer semantics.

### Description
- Changed constructor signatures to accept `const std::vector<std::unique_ptr<INodalBC>> &nbc_list` for `NBC_Partition` and `NBC_Partition_MF` and updated their implementations accordingly (`include/NBC_Partition.hpp`, `src/Mesh/NBC_Partition.cpp`, `include/NBC_Partition_MF.hpp`, `src/Mesh/NBC_Partition_MF.cpp`).
- Updated outflow elemental partition interfaces that consume the same BC list pattern to use `std::unique_ptr` vectors (`include/EBC_Partition_outflow.hpp`, `include/EBC_Partition_outflow_MF.hpp`, `src/Mesh/EBC_Partition_outflow.cpp`, `src/Mesh/EBC_Partition_outflow_MF.cpp`).
- Migrated example call sites to construct and pass `std::vector<std::unique_ptr<INodalBC>>` and to create elements with `SYS_T::make_unique<...>()`, including `examples/solids/preprocess.cpp`, `examples/ns/preprocess.cpp`, `examples/linearPDE/preprocess.cpp`, `examples/fsi/preprocess.cpp`, and `examples/ale_ns_rotate/preprocess.cpp`.
- Removed manual `delete` loops for these BC vectors and added necessary `#include <memory>` where appropriate.

### Testing
- Ran repository searches with `rg` to verify updated signatures and call sites, which confirmed the constructors and example call sites were updated consistently (success).
- Verified the working tree and changed file list via `git status --short` and committed the changes locally (commit succeeded).
- Created PR metadata with the project tooling after the changes (PR metadata generation succeeded).
- No full build or unit-test run was performed in this pass, so compile-time verification remains to be executed in CI or a follow-up local build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41d3c4964832abbd6f6a72569869a)