### PR TITLE
Refactor solids time step ownership into PTime_Solver

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -245,12 +245,10 @@ int main(int argc, char *argv[])
 
   nsolver->print_info();
 
-  // ===== Time step info =====
-  auto timeinfo = SYS_T::make_unique<PDNTimeStep>(initial_index, initial_time, initial_step);
-
   // ===== Temporal solver context =====
   auto tsolver = SYS_T::make_unique<PTime_Solver>( std::move(nsolver), 
-      sol_bName, sol_record_freq, ttan_renew_freq, final_time );
+      sol_bName, sol_record_freq, ttan_renew_freq, final_time,
+      initial_index, initial_time, initial_step );
 
   tsolver->print_info();
 
@@ -258,8 +256,7 @@ int main(int argc, char *argv[])
 
   tsolver->TM_Solid_GenAlpha( is_restart,
       std::move(dot_disp), std::move(dot_velo), std::move(dot_pres),
-      std::move(disp), std::move(velo), std::move(pres),
-      std::move(timeinfo) );
+      std::move(disp), std::move(velo), std::move(pres) );
 
   // Ensure PETSc objects are destroyed before PetscFinalize
   tsolver.reset();

--- a/examples/solids/include/PTime_Solver.hpp
+++ b/examples/solids/include/PTime_Solver.hpp
@@ -18,7 +18,10 @@ class PTime_Solver
         const std::string &input_name,
         const int &input_record_freq,
         const int &input_renew_tang_freq,
-        const double &input_final_time );
+        const double &input_final_time,
+        const int &initial_index,
+        const double &initial_time,
+        const double &initial_step );
 
     ~PTime_Solver() = default;
 
@@ -33,8 +36,7 @@ class PTime_Solver
         std::unique_ptr<PDNSolution> init_dot_pres,
         std::unique_ptr<PDNSolution> init_disp,
         std::unique_ptr<PDNSolution> init_velo,
-        std::unique_ptr<PDNSolution> init_pres,
-        std::unique_ptr<PDNTimeStep> time_info ) const;
+        std::unique_ptr<PDNSolution> init_pres );
 
   private:
     const double final_time;
@@ -43,6 +45,7 @@ class PTime_Solver
     const std::string pb_name;
 
     const std::unique_ptr<PNonlinear_Solver> nsolver;
+    std::unique_ptr<PDNTimeStep> time_info;
 
     std::string Name_Generator( const std::string &middle_name,
         const int &counter ) const;

--- a/examples/solids/src/PTime_Solver.cpp
+++ b/examples/solids/src/PTime_Solver.cpp
@@ -5,10 +5,14 @@ PTime_Solver::PTime_Solver(
     const std::string &input_name,
     const int &input_record_freq,
     const int &input_renew_tang_freq,
-    const double &input_final_time )
+    const double &input_final_time,
+    const int &initial_index,
+    const double &initial_time,
+    const double &initial_step )
 : final_time(input_final_time), sol_record_freq(input_record_freq),
   renew_tang_freq(input_renew_tang_freq), pb_name(input_name),
-  nsolver(std::move(in_nsolver))
+  nsolver(std::move(in_nsolver)),
+  time_info(SYS_T::make_unique<PDNTimeStep>(initial_index, initial_time, initial_step))
 {}
 
 void PTime_Solver::print_info() const
@@ -47,8 +51,7 @@ void PTime_Solver::TM_Solid_GenAlpha(
     std::unique_ptr<PDNSolution> init_dot_pres,
     std::unique_ptr<PDNSolution> init_disp,
     std::unique_ptr<PDNSolution> init_velo,
-    std::unique_ptr<PDNSolution> init_pres,
-    std::unique_ptr<PDNTimeStep> time_info ) const
+    std::unique_ptr<PDNSolution> init_pres )
 {
   auto pre_dot_disp = SYS_T::make_unique<PDNSolution>(*init_dot_disp);
   auto pre_dot_velo = SYS_T::make_unique<PDNSolution>(*init_dot_velo);


### PR DESCRIPTION
### Motivation
- Consolidate `PDNTimeStep` ownership inside the temporal solver so the time-step state is owned and managed by `PTime_Solver` rather than created and passed from the driver.
- Simplify the solver API by removing the external `time_info` `unique_ptr` parameter from `TM_Solid_GenAlpha` and avoid moving ownership across call sites.
- Ensure clearer object lifetime and reduce boilerplate in `examples/solids` driver code.

### Description
- Extended `PTime_Solver` constructor to accept `initial_index`, `initial_time`, and `initial_step` and added a `std::unique_ptr<PDNTimeStep> time_info` member that is constructed in the initializer list using `SYS_T::make_unique`.
- Removed the `std::unique_ptr<PDNTimeStep> time_info` parameter from `TM_Solid_GenAlpha` and updated the implementation to use the solver-owned `time_info` member.
- Updated `examples/solids/driver.cpp` to stop constructing a local `PDNTimeStep` and instead pass the initial time-step values into the `PTime_Solver` constructor.

### Testing
- Verified updated call sites and signatures with `rg -n "PTime_Solver\(|TM_Solid_GenAlpha\(" examples/solids` and confirmed matches were updated successfully.
- Checked repository status with `git status --short` and committed the change with `git commit` which reported the files changed and the commit created successfully.
- Created the PR record via the internal `make_pr` flow and validated that the refactor summary matches the applied changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42789fec0832a985490966ba83fff)