### PR TITLE
Vectorize displacement loading API and apply component-wise BCs in solver

### DIFF
--- a/examples/solids/include/LoadData.hpp
+++ b/examples/solids/include/LoadData.hpp
@@ -47,42 +47,16 @@ namespace LoadData
   // --------------------------------------------------------------------------
   // disp_loading
   //   Prescribed displacement-driven loading for Dirichlet nodes.
-  //   field = 1, 2, 3 denotes x-, y-, z-direction displacement, respectively.
-  //   disp is the imposed displacement value; velo and acce are its first and
-  //   second time derivatives used to set dot_disp and dot_velo consistently.
+  //   disp, velo, and acce are returned for x-, y-, and z-directions together.
+  //   Their first and second time derivatives are used to set dot_disp and
+  //   dot_velo consistently.
   // --------------------------------------------------------------------------
-  inline void disp_loading( const int &field, const double &tt,
-      double &disp, double &velo, double &acce )
+  inline void disp_loading( const double &tt,
+      Vector_3 &disp, Vector_3 &velo, Vector_3 &acce )
   {
-    switch(field)
-    {
-      // x direction
-      case 1:
-        disp = 0.0;
-        velo = 0.0;
-        acce = 0.0;
-        break;
-
-      // y direction
-      case 2:
-        disp = 0.0;
-        velo = 0.0;
-        acce = 0.0;
-        break;
-
-      // z direction
-      case 3:
-        disp = tt;
-        velo = 1.0;
-        acce = 0.0;
-        break;
-
-      default:
-        disp = 0.0;
-        velo = 0.0;
-        acce = 0.0;
-        break;
-    }
+    disp = Vector_3(0.0, 0.0, tt);
+    velo = Vector_3(0.0, 0.0, 1.0);
+    acce = Vector_3(0.0, 0.0, 0.0);
   }
 }
 

--- a/examples/solids/src/PNonlinear_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solver.cpp
@@ -82,25 +82,45 @@ void PNonlinear_Solver::apply_disp_loading(
     PDNSolution * const &disp,
     PDNSolution * const &velo ) const
 {
-  for(int field=1; field<=3; ++field)
+  Vector_3 uval;
+  Vector_3 vval;
+  Vector_3 aval;
+  LoadData::disp_loading( time, uval, vval, aval );
+
+  const int num_disp_ld_x = nbc_disp->get_Num_LD(1);
+  for(int ii=0; ii<num_disp_ld_x; ++ii)
   {
-    double uval = 0.0;
-    double vval = 0.0;
-    double aval = 0.0;
+    const PetscInt gid = nbc_disp->get_LDN(1, ii);
+    const PetscInt idx = gid * 3;
 
-    LoadData::disp_loading( field, time, uval, vval, aval );
+    VecSetValue(disp->solution, idx, uval.x(), INSERT_VALUES);
+    VecSetValue(velo->solution, idx, vval.x(), INSERT_VALUES);
+    VecSetValue(dot_disp->solution, idx, vval.x(), INSERT_VALUES);
+    VecSetValue(dot_velo->solution, idx, aval.x(), INSERT_VALUES);
+  }
 
-    const int num_disp_ld = nbc_disp->get_Num_LD(field);
-    for(int ii=0; ii<num_disp_ld; ++ii)
-    {
-      const PetscInt gid = nbc_disp->get_LDN(field, ii);
-      const PetscInt idx = gid * 3 + (field - 1);
+  const int num_disp_ld_y = nbc_disp->get_Num_LD(2);
+  for(int ii=0; ii<num_disp_ld_y; ++ii)
+  {
+    const PetscInt gid = nbc_disp->get_LDN(2, ii);
+    const PetscInt idx = gid * 3 + 1;
 
-      VecSetValue(disp->solution, idx, uval, INSERT_VALUES);
-      VecSetValue(velo->solution, idx, vval, INSERT_VALUES);
-      VecSetValue(dot_disp->solution, idx, vval, INSERT_VALUES);
-      VecSetValue(dot_velo->solution, idx, aval, INSERT_VALUES);
-    }
+    VecSetValue(disp->solution, idx, uval.y(), INSERT_VALUES);
+    VecSetValue(velo->solution, idx, vval.y(), INSERT_VALUES);
+    VecSetValue(dot_disp->solution, idx, vval.y(), INSERT_VALUES);
+    VecSetValue(dot_velo->solution, idx, aval.y(), INSERT_VALUES);
+  }
+
+  const int num_disp_ld_z = nbc_disp->get_Num_LD(3);
+  for(int ii=0; ii<num_disp_ld_z; ++ii)
+  {
+    const PetscInt gid = nbc_disp->get_LDN(3, ii);
+    const PetscInt idx = gid * 3 + 2;
+
+    VecSetValue(disp->solution, idx, uval.z(), INSERT_VALUES);
+    VecSetValue(velo->solution, idx, vval.z(), INSERT_VALUES);
+    VecSetValue(dot_disp->solution, idx, vval.z(), INSERT_VALUES);
+    VecSetValue(dot_velo->solution, idx, aval.z(), INSERT_VALUES);
   }
 
   disp->Assembly_GhostUpdate();


### PR DESCRIPTION
### Motivation
- Simplify prescribed displacement loading by returning all three components together instead of calling per-field variants.
- Make it easier to set displacement and its time derivatives consistently across x/y/z components.
- Prepare solver code for clearer and less error-prone application of Dirichlet DOFs per component.

### Description
- Changed `LoadData::disp_loading` signature from `void disp_loading(const int &field, const double &tt, double &disp, double &velo, double &acce)` to `void disp_loading(const double &tt, Vector_3 &disp, Vector_3 &velo, Vector_3 &acce)` and updated comments accordingly in `examples/solids/include/LoadData.hpp`.
- Implemented a vectorized return in `LoadData::disp_loading` that sets `disp`, `velo`, and `acce` as `Vector_3` values (z-displacement driven by `tt` and z-velocity set to `1.0` in this example).
- Updated `PNonlinear_Solver::apply_disp_loading` in `examples/solids/src/PNonlinear_Solver.cpp` to call the new `disp_loading`, obtain `uval`, `vval`, and `aval`, and apply these component values to Dirichlet DOFs using `VecSetValue` for x, y, and z indices with correct indexing.
- Replaced the previous per-field switch/loop with three explicit per-component loops using `nbc_disp->get_Num_LD(1/2/3)` and `nbc_disp->get_LDN(...)`, and kept the assembly/ghost-update calls for the updated solutions.

### Testing
- Built the project with the default CMake/make workflow and the build completed successfully.
- Executed the `examples/solids` example to exercise Dirichlet boundary condition application and the run completed initialization without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f432da6024832a832c34c031efbfe2)