### PR TITLE
Reduce header coupling: include FEAElement.hpp in element headers and move FE_Tools.hpp to sources

### DIFF
--- a/include/FEAElement_Hex27.hpp
+++ b/include/FEAElement_Hex27.hpp
@@ -78,8 +78,8 @@
 //
 // Date Created: Sep 6 2023
 // ==================================================================
+#include "FEAElement.hpp"
 #include "FEAElement_Quad9_3D_der0.hpp"
-#include "FE_Tools.hpp"
 
 class FEAElement_Hex27 final : public FEAElement
 {

--- a/include/FEAElement_Hex8.hpp
+++ b/include/FEAElement_Hex8.hpp
@@ -32,8 +32,8 @@
 //
 // Date Created: Sep 6 2023
 // ==================================================================
+#include "FEAElement.hpp"
 #include "FEAElement_Quad4_3D_der0.hpp"
-#include "FE_Tools.hpp"
 
 class FEAElement_Hex8 final : public FEAElement
 {

--- a/include/FEAElement_Quad4.hpp
+++ b/include/FEAElement_Quad4.hpp
@@ -9,7 +9,7 @@
 //
 // Date created: Sep. 2023
 // ==================================================================
-#include "FE_Tools.hpp"
+#include "FEAElement.hpp"
 
 class FEAElement_Quad4 final : public FEAElement
 {
@@ -74,3 +74,4 @@ class FEAElement_Quad4 final : public FEAElement
 };
 
 #endif
+

--- a/include/FEAElement_Quad9.hpp
+++ b/include/FEAElement_Quad9.hpp
@@ -9,7 +9,7 @@
 //
 // Date created: Sep. 2023
 // ==================================================================
-#include "FE_Tools.hpp"
+#include "FEAElement.hpp"
 
 class FEAElement_Quad9 final : public FEAElement
 {
@@ -74,3 +74,4 @@ class FEAElement_Quad9 final : public FEAElement
 };
 
 #endif
+

--- a/include/FEAElement_Tet10.hpp
+++ b/include/FEAElement_Tet10.hpp
@@ -35,8 +35,8 @@
 //
 // Date created: Nov. 3 2019
 // ==================================================================
+#include "FEAElement.hpp"
 #include "FEAElement_Triangle6_3D_der0.hpp"
-#include "FE_Tools.hpp"
 
 class FEAElement_Tet10 final : public FEAElement
 {

--- a/include/FEAElement_Tet4.hpp
+++ b/include/FEAElement_Tet4.hpp
@@ -9,8 +9,8 @@
 //
 // Date Created: Jan 19 2017
 // ============================================================================
+#include "FEAElement.hpp"
 #include "FEAElement_Triangle3_3D_der0.hpp"
-#include "FE_Tools.hpp"
 
 class FEAElement_Tet4 final : public FEAElement
 {

--- a/include/FEAElement_Triangle6.hpp
+++ b/include/FEAElement_Triangle6.hpp
@@ -10,7 +10,6 @@
 // Date created: Nov. 28 2017
 // ==================================================================
 #include "FEAElement.hpp"
-#include "FE_Tools.hpp"
 
 class FEAElement_Triangle6 final : public FEAElement
 {

--- a/src/Element/FEAElement_Hex27.cpp
+++ b/src/Element/FEAElement_Hex27.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Hex27.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Hex27::FEAElement_Hex27( int in_nqua ) : numQuapts( in_nqua ) ,
   quadrilateral_face( SYS_T::make_unique<FEAElement_Quad9_3D_der0>(numQuapts) )

--- a/src/Element/FEAElement_Hex8.cpp
+++ b/src/Element/FEAElement_Hex8.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Hex8.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Hex8::FEAElement_Hex8( int in_nqua ) : numQuapts( in_nqua ) ,
   quadrilateral_face( SYS_T::make_unique<FEAElement_Quad4_3D_der0>(numQuapts) )

--- a/src/Element/FEAElement_Quad4.cpp
+++ b/src/Element/FEAElement_Quad4.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Quad4.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Quad4::FEAElement_Quad4( int in_nqua )
 : numQuapts( in_nqua )

--- a/src/Element/FEAElement_Quad9.cpp
+++ b/src/Element/FEAElement_Quad9.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Quad9.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Quad9::FEAElement_Quad9( int in_nqua ) : numQuapts( in_nqua )
 {

--- a/src/Element/FEAElement_Tet10.cpp
+++ b/src/Element/FEAElement_Tet10.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Tet10.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Tet10::FEAElement_Tet10( int in_nqua ) : numQuapts( in_nqua ) ,
   triangle_face( SYS_T::make_unique<FEAElement_Triangle6_3D_der0>(numQuapts) )

--- a/src/Element/FEAElement_Tet4.cpp
+++ b/src/Element/FEAElement_Tet4.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Tet4.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Tet4::FEAElement_Tet4( int in_nqua ) : numQuapts( in_nqua ),
   triangle_face( SYS_T::make_unique<FEAElement_Triangle3_3D_der0>(numQuapts) )

--- a/src/Element/FEAElement_Triangle6.cpp
+++ b/src/Element/FEAElement_Triangle6.cpp
@@ -1,4 +1,5 @@
 #include "FEAElement_Triangle6.hpp"
+#include "FE_Tools.hpp"
 
 FEAElement_Triangle6::FEAElement_Triangle6( int in_nqua )
 : numQuapts( in_nqua )


### PR DESCRIPTION
### Motivation

- Reduce header-level dependency on `FE_Tools.hpp` to minimize coupling and potential circular includes.
- Ensure element header files include the base `FEAElement.hpp` interface directly for clarity and correctness.
- Improve compile stability and incremental build performance by moving implementation-only includes to source files.

### Description

- Replaced `#include "FE_Tools.hpp"` in multiple element header files with `#include "FEAElement.hpp"` for the element interface (applied to `FEAElement_Quad4.hpp`, `FEAElement_Quad9.hpp`, `FEAElement_Triangle6.hpp`, `FEAElement_Tet4.hpp`, `FEAElement_Tet10.hpp`, `FEAElement_Hex8.hpp`, and `FEAElement_Hex27.hpp`).
- Added `#include "FE_Tools.hpp"` into the corresponding implementation files so `FE_Tools` is included only where needed (added to the .cpp files for the same element classes).
- Minor header formatting/EOF cleanup in a couple of header files.

### Testing

- Built the project with the usual build system (`cmake --build .`) which completed successfully.
- Ran the project's automated test suite with `ctest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0550ab45d8832a96f35f7fd2c42af7)