### PR TITLE
Move IEN vectors into IEN_FEM to avoid copies (rvalue ctor + std::move)

### DIFF
--- a/examples/ale_ns_rotate/prepost.cpp
+++ b/examples/ale_ns_rotate/prepost.cpp
@@ -87,8 +87,7 @@ int main( int argc, char * argv[] )
   VEC_T::insert_end(vecIEN, rotated_vecIEN);
   VEC_T::insert_end(ctrlPts, rotated_ctrlPts);
 
-  IIEN * IEN = new IEN_FEM(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  IIEN * IEN = new IEN_FEM(nElem, std::move(vecIEN));
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
 

--- a/examples/ale_ns_rotate/preprocess.cpp
+++ b/examples/ale_ns_rotate/preprocess.cpp
@@ -235,8 +235,7 @@ int main( int argc, char * argv[] )
   VEC_T::insert_end(vecIEN, rotated_vecIEN);
   VEC_T::insert_end(ctrlPts, rotated_ctrlPts);
 
-  IIEN * IEN = new IEN_FEM(nElem, vecIEN);
-  VEC_T::clean( vecIEN );
+  IIEN * IEN = new IEN_FEM(nElem, std::move(vecIEN));
   VEC_T::clean( rotated_vecIEN );
   VEC_T::clean( rotated_ctrlPts );
 
@@ -277,11 +276,9 @@ int main( int argc, char * argv[] )
     VTK_T::read_grid(fixed_interface_file[ii], sur_fixed_nFunc, sur_fixed_nElem, sur_fixed_ctrlPts, sur_fixed_vecIEN);
     VTK_T::read_grid(rotated_interface_file[ii], sur_rotated_nFunc, sur_rotated_nElem, sur_rotated_ctrlPts, sur_rotated_vecIEN);
 
-    IIEN * sur_fixed_IEN = new IEN_FEM(sur_fixed_nElem, sur_fixed_vecIEN);
-    VEC_T::clean(sur_fixed_vecIEN);
+    IIEN * sur_fixed_IEN = new IEN_FEM(sur_fixed_nElem, std::move(sur_fixed_vecIEN));
 
-    IIEN * sur_rotated_IEN = new IEN_FEM(sur_rotated_nElem, sur_rotated_vecIEN);
-    VEC_T::clean(sur_rotated_vecIEN);
+    IIEN * sur_rotated_IEN = new IEN_FEM(sur_rotated_nElem, std::move(sur_rotated_vecIEN));
 
     // Assume sur_fixed_nLocBas = sur_rotated_nLocBas
     const int sur_nLocBas = sur_fixed_IEN->get_nLocBas();

--- a/examples/fsi/prepost.cpp
+++ b/examples/fsi/prepost.cpp
@@ -78,9 +78,6 @@ int main( int argc, char * argv[] )
   
   const std::vector<int> phy_tag = VTK_T::read_int_CellData( geo_file, "Physics_tag" );
 
-  // Generate IEN
-  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
-
   // --------------------------------------------------------------------------
   // The fluid-solid interface file will be read and the nodal index will be
   // mapped to a new value by the following rule. The ii-th node in the
@@ -95,6 +92,9 @@ int main( int argc, char * argv[] )
   // IEN for the solid element. If the solid element has node on the fluid-solid
   // interface, it will be mapped to the new index, that is nFunc + ii.
   std::vector<int> vecIEN_p ( vecIEN );
+
+  // Generate IEN
+  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
 
   for(int ee=0; ee<nElem; ++ee)
   {

--- a/examples/fsi/prepost.cpp
+++ b/examples/fsi/prepost.cpp
@@ -78,6 +78,14 @@ int main( int argc, char * argv[] )
   
   const std::vector<int> phy_tag = VTK_T::read_int_CellData( geo_file, "Physics_tag" );
 
+  // We will generate a new IEN array for the pressure variable by updating the
+  // IEN for the solid element. If the solid element has node on the fluid-solid
+  // interface, it will be mapped to the new index, that is nFunc + ii.
+  std::vector<int> vecIEN_p ( vecIEN );
+
+  // Generate IEN
+  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
+
   // --------------------------------------------------------------------------
   // The fluid-solid interface file will be read and the nodal index will be
   // mapped to a new value by the following rule. The ii-th node in the
@@ -87,14 +95,6 @@ int main( int argc, char * argv[] )
 
   const int nFunc_interface = static_cast<int>( wall_node_id.size() );
   const int nFunc_p = nFunc_v + nFunc_interface;
-
-  // We will generate a new IEN array for the pressure variable by updating the
-  // IEN for the solid element. If the solid element has node on the fluid-solid
-  // interface, it will be mapped to the new index, that is nFunc + ii.
-  std::vector<int> vecIEN_p ( vecIEN );
-
-  // Generate IEN
-  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
 
   for(int ee=0; ee<nElem; ++ee)
   {

--- a/examples/fsi/prepost.cpp
+++ b/examples/fsi/prepost.cpp
@@ -79,7 +79,7 @@ int main( int argc, char * argv[] )
   const std::vector<int> phy_tag = VTK_T::read_int_CellData( geo_file, "Physics_tag" );
 
   // Generate IEN
-  IIEN * IEN_v = new IEN_FEM( nElem, vecIEN );
+  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
 
   // --------------------------------------------------------------------------
   // The fluid-solid interface file will be read and the nodal index will be
@@ -123,9 +123,8 @@ int main( int argc, char * argv[] )
     }
   }
 
-  IIEN * IEN_p = new IEN_FEM( nElem, vecIEN_p );
-
-  VEC_T::clean( vecIEN ); VEC_T::clean( vecIEN_p );
+  IIEN * IEN_p = new IEN_FEM( nElem, std::move(vecIEN_p) );
+ 
   // --------------------------------------------------------------------------
 
   // Generate the list of nodes for fluid and solid

--- a/examples/fsi/preprocess.cpp
+++ b/examples/fsi/preprocess.cpp
@@ -205,7 +205,7 @@ int main( int argc, char * argv[] )
   }
 
   // Generate IEN
-  IIEN * IEN_v = new IEN_FEM( nElem, vecIEN );
+  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
 
   // --------------------------------------------------------------------------
   // The fluid-solid interface file will be read and the nodal index will be
@@ -249,9 +249,8 @@ int main( int argc, char * argv[] )
     }
   }
 
-  IIEN * IEN_p = new IEN_FEM( nElem, vecIEN_p );
-
-  VEC_T::clean( vecIEN ); VEC_T::clean( vecIEN_p );
+  IIEN * IEN_p = new IEN_FEM( nElem, std::move(vecIEN_p) );
+ 
   // --------------------------------------------------------------------------
 
   // Generate the list of nodes for fluid and solid

--- a/examples/fsi/preprocess.cpp
+++ b/examples/fsi/preprocess.cpp
@@ -204,9 +204,6 @@ int main( int argc, char * argv[] )
     if(phy_tag[ii] != 0 && phy_tag[ii] != 1) SYS_T::print_fatal("Error: FSI problem, the physical tag for element should be 0 (fluid domain) or 1 (solid domain).\n");
   }
 
-  // Generate IEN
-  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
-
   // --------------------------------------------------------------------------
   // The fluid-solid interface file will be read and the nodal index will be
   // mapped to a new value by the following rule. The ii-th node in the
@@ -221,6 +218,9 @@ int main( int argc, char * argv[] )
   // IEN for the solid element. If the solid element has node on the fluid-solid
   // interface, it will be mapped to the new index, that is nFunc + ii.
   std::vector<int> vecIEN_p ( vecIEN );
+
+  // Generate IEN
+  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
   PERIGEE_OMP_PARALLEL_FOR
   for(int ee=0; ee<nElem; ++ee)
   {

--- a/examples/fsi/preprocess.cpp
+++ b/examples/fsi/preprocess.cpp
@@ -204,6 +204,14 @@ int main( int argc, char * argv[] )
     if(phy_tag[ii] != 0 && phy_tag[ii] != 1) SYS_T::print_fatal("Error: FSI problem, the physical tag for element should be 0 (fluid domain) or 1 (solid domain).\n");
   }
 
+  // We will generate a new IEN array for the pressure variable by updating the
+  // IEN for the solid element. If the solid element has node on the fluid-solid
+  // interface, it will be mapped to the new index, that is nFunc + ii.
+  std::vector<int> vecIEN_p ( vecIEN );
+
+  // Generate IEN
+  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
+  
   // --------------------------------------------------------------------------
   // The fluid-solid interface file will be read and the nodal index will be
   // mapped to a new value by the following rule. The ii-th node in the
@@ -214,13 +222,6 @@ int main( int argc, char * argv[] )
   const int nFunc_interface = static_cast<int>( wall_node_id.size() );
   const int nFunc_p = nFunc_v + nFunc_interface;
 
-  // We will generate a new IEN array for the pressure variable by updating the
-  // IEN for the solid element. If the solid element has node on the fluid-solid
-  // interface, it will be mapped to the new index, that is nFunc + ii.
-  std::vector<int> vecIEN_p ( vecIEN );
-
-  // Generate IEN
-  IIEN * IEN_v = new IEN_FEM( nElem, std::move(vecIEN) );
   PERIGEE_OMP_PARALLEL_FOR
   for(int ee=0; ee<nElem; ++ee)
   {

--- a/examples/linearPDE/prepost.cpp
+++ b/examples/linearPDE/prepost.cpp
@@ -73,8 +73,8 @@ int main( int argc, char * argv[] )
 
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
 
-  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, std::move(vecIEN));
+  
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
   

--- a/examples/linearPDE/preprocess.cpp
+++ b/examples/linearPDE/preprocess.cpp
@@ -111,8 +111,8 @@ int main( int argc, char * argv[] )
 
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
   
-  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, std::move(vecIEN));
+  
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
 

--- a/examples/ns/prepost.cpp
+++ b/examples/ns/prepost.cpp
@@ -68,8 +68,8 @@ int main( int argc, char * argv[] )
 
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
   
-  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, std::move(vecIEN));
+  
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
   

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -148,8 +148,7 @@ int main( int argc, char * argv[] )
   
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
   
-  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, std::move(vecIEN));
   
   const int nLocBas = FE_T::to_nLocBas(elemType);
 

--- a/examples/solids/prepost.cpp
+++ b/examples/solids/prepost.cpp
@@ -69,8 +69,8 @@ int main( int argc, char * argv[] )
 
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
 
-  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, std::move(vecIEN));
+  
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
 

--- a/examples/solids/preprocess.cpp
+++ b/examples/solids/preprocess.cpp
@@ -136,8 +136,8 @@ int main( int argc, char * argv[] )
 
   VTK_T::read_vtu_grid(geo_file, nFunc, nElem, ctrlPts, vecIEN);
 
-  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, vecIEN);
-  VEC_T::clean( vecIEN ); // clean the vector
+  auto IEN = SYS_T::make_unique<IEN_FEM>(nElem, std::move(vecIEN));
+  
 
   const int nLocBas = FE_T::to_nLocBas(elemType);
 

--- a/include/IEN_FEM.hpp
+++ b/include/IEN_FEM.hpp
@@ -14,14 +14,15 @@
 #include "Sys_Tools.hpp"
 #include "Vec_Tools.hpp"
 #include "IIEN.hpp"
+#include <utility>
 
 class IEN_FEM final : public IIEN
 {
   public:
-    IEN_FEM( const int &in_nelem, const std::vector<int> &in_ien ) 
+    IEN_FEM( const int &in_nelem, std::vector<int> &&in_ien ) 
       : nElem( in_nelem ),
         nLocBas( VEC_T::get_size( in_ien )/nElem ),
-        IEN( in_ien )
+        IEN( std::move(in_ien) )
     {
       SYS_T::print_fatal_if( VEC_T::get_size( in_ien ) % nElem != 0,
           "Error: IEN_FEM input IEN vector size cannot do a perfect division by input number of elements. This suggests the mesh main contain different types of elements. \n" );


### PR DESCRIPTION
### Motivation

- Reduce unnecessary copies of large IEN vectors when constructing `IEN_FEM` to improve performance and memory usage.

### Description

- Changed `IEN_FEM` constructor signature to accept an rvalue `std::vector<int>&&` and initialize `IEN` with `std::move(in_ien)` and added `#include <utility>`.
- Updated call sites across examples to pass IEN arrays with `std::move(vecIEN)` (and other temporary IEN vectors) when creating `IEN_FEM` instances, replacing previous copy-based constructions.
- Removed redundant `VEC_T::clean(vecIEN)` calls where the vector is moved into `IEN_FEM` to avoid operating on moved-from containers.
- Kept existing smart-pointer and `make_unique` usage; integrated `std::move` invocations where appropriate to transfer ownership.

### Testing

- Built the project with CMake and `make` and the build completed successfully.
- Executed the example preprocess/prepost binaries for the modified examples (`linearPDE`, `ns`, `solids`, `fsi`, `ale_ns_rotate`) to verify no runtime errors after the change and they ran successfully.
- Ran the test suite via `ctest` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09392bd53c832a9e9cc9ecf5f29f9b)