### PR TITLE
Add explicit Timer.hpp includes for SYS_T::Timer call sites

### DIFF
--- a/examples/ale_ns_rotate/prepost.cpp
+++ b/examples/ale_ns_rotate/prepost.cpp
@@ -5,6 +5,7 @@
 //
 // Date: Jan. 24 2017
 // ==================================================================
+#include "Timer.hpp"
 #include "HDF5_Reader.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/ale_ns_rotate/preprocess.cpp
+++ b/examples/ale_ns_rotate/preprocess.cpp
@@ -6,6 +6,7 @@
 //
 // Date Created: Jan 01 2020
 // ==================================================================
+#include "Timer.hpp"
 #include "Math_Tools.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/fsi/prepost.cpp
+++ b/examples/fsi/prepost.cpp
@@ -5,6 +5,7 @@
 //
 // Date: Jan 16 2022
 // ==================================================================
+#include "Timer.hpp"
 #include "HDF5_Reader.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/fsi/preprocess.cpp
+++ b/examples/fsi/preprocess.cpp
@@ -7,6 +7,7 @@
 // Author: Ju Liu
 // Date: Dec. 13 2021
 // ============================================================================
+#include "Timer.hpp"
 #include "Math_Tools.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/linearPDE/prepost.cpp
+++ b/examples/linearPDE/prepost.cpp
@@ -6,6 +6,7 @@
 // Author: Chi Ding
 // Email:  am-dight@outlook.com 
 // ============================================================================
+#include "Timer.hpp"
 #include "HDF5_Reader.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/linearPDE/preprocess.cpp
+++ b/examples/linearPDE/preprocess.cpp
@@ -5,6 +5,7 @@
 //
 // Author: Xinhai Yue
 // ============================================================================
+#include "Timer.hpp"
 #include "IEN_FEM.hpp"
 #include "VTK_Tools.hpp"
 #include "Global_Part_METIS.hpp"

--- a/examples/ns/prepost.cpp
+++ b/examples/ns/prepost.cpp
@@ -5,6 +5,7 @@
 //
 // Date: Jan. 24 2017
 // ============================================================================
+#include "Timer.hpp"
 #include "HDF5_Reader.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/ns/preprocess.cpp
+++ b/examples/ns/preprocess.cpp
@@ -6,6 +6,7 @@
 //
 // Date Created: Jan 01 2020
 // ============================================================================
+#include "Timer.hpp"
 #include "Math_Tools.hpp"
 #include "VTK_Tools.hpp"
 #include "IEN_FEM.hpp"

--- a/examples/solids/prepost.cpp
+++ b/examples/solids/prepost.cpp
@@ -6,6 +6,7 @@
 //
 // Date Created: Jan 06 2026
 // ============================================================================
+ #include "Timer.hpp"
  #include "HDF5_Reader.hpp"
  #include "VTK_Tools.hpp"
  #include "IEN_FEM.hpp"

--- a/examples/solids/preprocess.cpp
+++ b/examples/solids/preprocess.cpp
@@ -6,6 +6,7 @@
 //
 // Date Created: Jan 04 2026
 // ============================================================================
+#include "Timer.hpp"
 #include "IEN_FEM.hpp"
 #include "VTK_Tools.hpp"
 #include "Global_Part_METIS.hpp"

--- a/src/Mesh/Gmsh_FileIO.cpp
+++ b/src/Mesh/Gmsh_FileIO.cpp
@@ -1,3 +1,4 @@
+#include "Timer.hpp"
 #include "Gmsh_FileIO.hpp"
 #include "Vec_Tools.hpp"
 #include "Tet_Tools.hpp"


### PR DESCRIPTION
### Motivation

- Ensure each translation unit that constructs or references `SYS_T::Timer` directly includes its declaration so builds do not rely on transitive includes.

### Description

- Add `#include "Timer.hpp"` (declared at `include/Timer.hpp`) to 11 `.cpp` files that use `SYS_T::Timer` so the header is present in each translation unit. 
- Modified files: `src/Mesh/Gmsh_FileIO.cpp` and the preprocess/prepost drivers under `examples/ns`, `examples/solids`, `examples/fsi`, `examples/linearPDE`, and `examples/ale_ns_rotate` (11 files total). 
- Commit created with message `Add explicit Timer includes for Timer users` containing the above changes. 

### Testing

- Ran `rg -n 'SYS_T::Timer' src examples` to enumerate call sites and confirmed the list matched the updated files. 
- Verified each `.cpp` returned by the scan contains an explicit `#include "Timer.hpp"` using `rg -q '^\s*#include "Timer\.hpp"'` and all checks passed. 
- Ran `git diff --check` and `git status --short --branch` to ensure no whitespace/errors and a clean working tree after commit, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cef6a8ac0832ab7e2982fecd9448e)