### PR TITLE
Refactor cap filename formatting with stream manipulators

### DIFF
--- a/include/Sys_Tools.hpp
+++ b/include/Sys_Tools.hpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <ctime>
@@ -108,13 +109,7 @@ namespace SYS_T
       int index, const std::string &filename )
   {
     std::ostringstream ss;
-    ss<<baseName;
-
-    if( index/10 == 0 ) ss<<"00";
-    else if( index/100 == 0 ) ss<<"0";
-
-    ss<<index<<filename;
-
+    ss << baseName << std::setfill('0') << std::setw(3) << index << filename;
     return ss.str();
   }
 


### PR DESCRIPTION
### Motivation
- Use standard stream manipulators to produce consistent three-digit, zero-padded cap filenames and remove manual padding logic in `SYS_T::gen_capfile_name`.

### Description
- Add `#include <iomanip>` and replace the hand-written zero-padding branch in `include/Sys_Tools.hpp` with `std::setfill('0')` and `std::setw(3)` in `SYS_T::gen_capfile_name` to emit `baseNameXXX<ext>`.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and a focused C++11 assertion harness compiled with `g++` that verifies outputs for indices `0`, `9`, `10`, `99`, `100`, and `1000`, all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d50470eb0832a817abe5f41fc2a93)