### PR TITLE
Simplify interface name string construction

### DIFF
--- a/examples/fsi/src/PTime_FSI_Solver.cpp
+++ b/examples/fsi/src/PTime_FSI_Solver.cpp
@@ -26,20 +26,13 @@ void PTime_FSI_Solver::print_info() const
 std::string PTime_FSI_Solver::Name_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 std::string PTime_FSI_Solver::Name_dot_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name("dot_");
-  out_name.append(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return "dot_" + pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 void PTime_FSI_Solver::Write_restart_file(const PDNTimeStep * const &timeinfo,

--- a/examples/linearPDE/src/PTime_LinearPDE_Solver.cpp
+++ b/examples/linearPDE/src/PTime_LinearPDE_Solver.cpp
@@ -24,20 +24,13 @@ void PTime_LinearPDE_Solver::print_info() const
 std::string PTime_LinearPDE_Solver::Name_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 std::string PTime_LinearPDE_Solver::Name_dot_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name("dot_");
-  out_name.append(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return "dot_" + pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 void PTime_LinearPDE_Solver::TM_GenAlpha_Transport(

--- a/src/Analysis_Tool/ALocal_Interface.cpp
+++ b/src/Analysis_Tool/ALocal_Interface.cpp
@@ -19,8 +19,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
   max_num_local_rotated_ele = h5r -> read_intVector( gname.c_str(), "max_num_local_rotated_cell" );
   num_tag = h5r -> read_intVector( gname.c_str(), "num_tag" );
 
-  std::string groupbase(gname);
-  groupbase.append("/interfaceid_");
+  const std::string groupbase = gname + "/interfaceid_";
 
   num_fixed_node.assign(num_itf, 0);
   num_rotated_node.assign(num_itf, 0);
@@ -50,8 +49,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
   for(int ii=0; ii<num_itf; ++ii)
   {
-    std::string subgroup_name(groupbase);
-    subgroup_name.append( std::to_string(ii) );
+    const std::string subgroup_name = groupbase + std::to_string(ii);
 
     // total info
     fixed_ele_face_id[ii] = h5r -> read_intVector( subgroup_name.c_str(), "fixed_cell_face_id" );
@@ -82,8 +80,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
     rotated_LID[ii] = h5r -> read_intVector(  subgroup_name.c_str(), "rotated_LID" );
 
-    std::string subsubgroupbase(subgroup_name);
-    subsubgroupbase.append("/tag_");
+    const std::string subsubgroupbase = subgroup_name + "/tag_";
     
     // access for element search
     if(num_local_fixed_ele[ii] > 0)
@@ -94,8 +91,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_rotated_ele[ii][jj] > 0)
           tagged_rotated_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_rotated_cell" );
         else
@@ -116,8 +112,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_fixed_ele[ii][jj] > 0)
           tagged_fixed_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_fixed_cell" );
         else
@@ -146,8 +141,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
   max_num_local_rotated_ele = h5r -> read_intVector( gname.c_str(), "max_num_local_rotated_cell" );
   num_tag = h5r -> read_intVector( gname.c_str(), "num_tag" );
 
-  std::string groupbase(gname);
-  groupbase.append("/interfaceid_");
+  const std::string groupbase = gname + "/interfaceid_";
 
   num_fixed_node.assign(num_itf, 0);
   num_rotated_node.assign(num_itf, 0);
@@ -177,8 +171,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
   for(int ii=0; ii<num_itf; ++ii)
   {
-    std::string subgroup_name(groupbase);
-    subgroup_name.append( std::to_string(ii) );
+    const std::string subgroup_name = groupbase + std::to_string(ii);
 
     // total info
     fixed_ele_face_id[ii] = h5r -> read_intVector( subgroup_name.c_str(), "fixed_cell_face_id" );
@@ -209,8 +202,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
     rotated_LID[ii] = h5r -> read_intVector(  subgroup_name.c_str(), "rotated_LID" );
 
-    std::string subsubgroupbase(subgroup_name);
-    subsubgroupbase.append("/tag_");
+    const std::string subsubgroupbase = subgroup_name + "/tag_";
 
     // access for element search
     if(num_local_fixed_ele[ii] > 0)
@@ -221,8 +213,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_rotated_ele[ii][jj] > 0)
           tagged_rotated_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_rotated_cell" );
         else
@@ -243,8 +234,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_fixed_ele[ii][jj] > 0)
           tagged_fixed_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_fixed_cell" );
         else

--- a/src/Mesh/Interface_Partition.cpp
+++ b/src/Mesh/Interface_Partition.cpp
@@ -188,8 +188,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 
   for(int ii=0; ii<num_pair; ++ii)
   {
-    std::string subgroup_name(groupbase);
-    subgroup_name.append( std::to_string(ii) );
+    const std::string subgroup_name = groupbase + std::to_string(ii);
 
     hid_t group_id = H5Gcreate(g_id, subgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -233,8 +232,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 
     for(int jj=0; jj<num_tag[ii]; ++jj)
     {
-      std::string subsubgroup_name(subgroupbase);
-      subsubgroup_name.append( std::to_string(jj) );
+      const std::string subsubgroup_name = subgroupbase + std::to_string(jj);
 
       hid_t subgroup_id = H5Gcreate(group_id, subsubgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/src/Mesh/Sliding_Interface_Tools.cpp
+++ b/src/Mesh/Sliding_Interface_Tools.cpp
@@ -31,13 +31,11 @@ namespace SI_T
     nLocBas = h5r -> read_intScalar(mesh_info.c_str(), "nLocBas");
     dof_sol = h5r -> read_intScalar(mesh_info.c_str(), "dofNum");
 
-    std::string groupbase(gname);
-    groupbase.append("/interfaceid_");
+    const std::string groupbase = gname + "/interfaceid_";
 
     for(int ii=0; ii<num_itf; ++ii)
     {
-      std::string subgroup_name(groupbase);
-      subgroup_name.append( std::to_string(ii) );
+      const std::string subgroup_name = groupbase + std::to_string(ii);
       
       num_fixed_node[ii] = VEC_T::get_size(h5r -> read_intVector( subgroup_name.c_str(), "fixed_node_map" ));
 


### PR DESCRIPTION
### Motivation
- Remove local `std::string` variables that are immediately and only used to append a few fixed segments, replacing them with shorter `operator+` expressions for improved readability.
- Focus the change on simple "initialize then append a couple of fixed fragments or an index" patterns and avoid touching looped, conditional, or incremental append logic.

### Description
- Replace `out_name`-style sequences in `Name_Generator()` and `Name_dot_Generator()` with direct `return` expressions using `operator+` in `examples/linearPDE/src/PTime_LinearPDE_Solver.cpp` and `examples/fsi/src/PTime_FSI_Solver.cpp`.
- Replace `groupbase`/`subgroup_name`/`subsubgroup_name` constructions that were created by `std::string` followed by `.append()` with `const std::string` initialized via `+` in `src/Mesh/Sliding_Interface_Tools.cpp`, `src/Mesh/Interface_Partition.cpp`, and `src/Analysis_Tool/ALocal_Interface.cpp`.
- Preserve control flow, loops, conditional zero-padding and all other multi-step string constructions elsewhere in the repository.

### Testing
- Ran `git diff --check` to ensure no trivial whitespace/format issues were introduced and it passed.
- Verified the five targeted files no longer contain `.append(` calls using `rg` and the search succeeded.
- Performed a C++11 syntax-only compilation of representative string-expression snippets with `g++ -std=c++11 -x c++ -fsyntax-only -` and it passed.
- Confirmed the working tree is clean after committing the focused changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7b553c68832aa350cae6c097ef83)