### PR TITLE
Refactor string construction and const correctness across visualization and mesh modules

### DIFF
--- a/examples/ale_ns_rotate/vis.cpp
+++ b/examples/ale_ns_rotate/vis.cpp
@@ -148,15 +148,11 @@ int main( int argc, char * argv[] )
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
-    std::string name_to_read_disp(disp_bname);
-    std::string name_to_read_mvelo(mvelo_bname);    
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
-    name_to_read_disp.append(time_suffix);
-    name_to_read_mvelo.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
+    const std::string name_to_read_disp = disp_bname + time_suffix;
+    const std::string name_to_read_mvelo = mvelo_bname + time_suffix;
 
     const std::vector<std::string> name_to_read_list {name_to_read, name_to_read_disp, name_to_read_mvelo};
 

--- a/examples/ale_ns_rotate/vis_wss_hex27.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex27.cpp
@@ -83,8 +83,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the command line argument on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -213,11 +212,9 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ale_ns_rotate/vis_wss_hex8.cpp
+++ b/examples/ale_ns_rotate/vis_wss_hex8.cpp
@@ -84,8 +84,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the command line argument on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -214,11 +213,9 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ale_ns_rotate/vis_wss_tet10.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet10.cpp
@@ -83,8 +83,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the command line argument on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -208,11 +207,9 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n", time, name_to_read.c_str(), name_to_write.c_str());
 

--- a/examples/ale_ns_rotate/vis_wss_tet4.cpp
+++ b/examples/ale_ns_rotate/vis_wss_tet4.cpp
@@ -75,8 +75,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);  
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   // Print the key data on screen
   cout<<"==== Command Line Arguments ===="<<endl;
@@ -207,11 +206,9 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Generate the file name
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     std::cout<<"Time "<<time<<": Read "<<name_to_read<<" and Write "<<name_to_write<<std::endl;
 

--- a/examples/fsi/src/PTime_FSI_Solver.cpp
+++ b/examples/fsi/src/PTime_FSI_Solver.cpp
@@ -26,20 +26,13 @@ void PTime_FSI_Solver::print_info() const
 std::string PTime_FSI_Solver::Name_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 std::string PTime_FSI_Solver::Name_dot_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name("dot_");
-  out_name.append(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return "dot_" + pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 void PTime_FSI_Solver::Write_restart_file(const PDNTimeStep * const &timeinfo,

--- a/examples/fsi/vis.cpp
+++ b/examples/fsi/vis.cpp
@@ -135,15 +135,11 @@ int main( int argc, char * argv[] )
 
   for(int time = time_start; time<=time_end; time += time_step)
   {
-    std::string disp_name_to_read(disp_sol_bname);
-    std::string velo_name_to_read(velo_sol_bname);
-    std::string pres_name_to_read(pres_sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    disp_name_to_read.append(time_suffix);
-    velo_name_to_read.append(time_suffix);
-    pres_name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string disp_name_to_read = disp_sol_bname + time_suffix;
+    const std::string velo_name_to_read = velo_sol_bname + time_suffix;
+    const std::string pres_name_to_read = pres_sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s %s %s and Write %s \n",
         time, disp_name_to_read.c_str(), pres_name_to_read.c_str(), 

--- a/examples/fsi/vis_fluid.cpp
+++ b/examples/fsi/vis_fluid.cpp
@@ -154,15 +154,11 @@ int main( int argc, char * argv[] )
 
   for(int time = time_start; time<=time_end; time += time_step)
   {
-    std::string disp_name_to_read(disp_sol_bname);
-    std::string velo_name_to_read(velo_sol_bname);
-    std::string pres_name_to_read(pres_sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    disp_name_to_read.append(time_suffix);
-    velo_name_to_read.append(time_suffix);
-    pres_name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string disp_name_to_read = disp_sol_bname + time_suffix;
+    const std::string velo_name_to_read = velo_sol_bname + time_suffix;
+    const std::string pres_name_to_read = pres_sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s %s %s and Write %s \n",
         time, disp_name_to_read.c_str(), pres_name_to_read.c_str(),

--- a/examples/fsi/vis_fsi_wss.cpp
+++ b/examples/fsi/vis_fsi_wss.cpp
@@ -53,8 +53,7 @@ int main( int argc, char * argv[] )
 
   SYS_T::GetOptionInt("-time_index", time_index);
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   cout<<"==== Command Line Arguments ===="<<endl;
   cout<<" -time_index: "<<time_index<<endl;
@@ -97,16 +96,10 @@ int main( int argc, char * argv[] )
   const auto analysis_new2old = HDF5_T::read_intVector( "node_mapping_v.h5", "/", "new_2_old" );
 
   // Read solution files
-  std::string disp_sol_name(sol_bname), velo_sol_name(sol_bname);
-  disp_sol_name.append("disp_");
-  velo_sol_name.append("velo_");
-  std::string name_to_write(out_bname);
-
   const std::string time_suffix = SYS_T::fixed_length_index(time_index);
-  
-  disp_sol_name.append(time_suffix);
-  velo_sol_name.append(time_suffix);
-  name_to_write.append(time_suffix);
+  const std::string disp_sol_name = sol_bname + "disp_" + time_suffix;
+  const std::string velo_sol_name = sol_bname + "velo_" + time_suffix;
+  const std::string name_to_write = out_bname + time_suffix;
   
   SYS_T::commPrint("Read %s and %s, and write %s. \n", disp_sol_name.c_str(),
       velo_sol_name.c_str(), name_to_write.c_str() );

--- a/examples/fsi/vis_fsi_wss_hex8.cpp
+++ b/examples/fsi/vis_fsi_wss_hex8.cpp
@@ -85,8 +85,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);  
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   cout<<"==== Command Line Arguments ===="<<endl;
   cout<<" -time_start: "<<time_start<<endl;
@@ -206,16 +205,10 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Read solution files
-    std::string disp_sol_name(sol_bname), velo_sol_name(sol_bname);
-    disp_sol_name.append("disp_");
-    velo_sol_name.append("velo_");
-    std::string name_to_write(out_bname);
-
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    
-    disp_sol_name.append(time_suffix);
-    velo_sol_name.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string disp_sol_name = sol_bname + "disp_" + time_suffix;
+    const std::string velo_sol_name = sol_bname + "velo_" + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Read %s and %s, and write %s. \n", disp_sol_name.c_str(),
         velo_sol_name.c_str(), name_to_write.c_str() );

--- a/examples/fsi/vis_fsi_wss_tet4.cpp
+++ b/examples/fsi/vis_fsi_wss_tet4.cpp
@@ -65,8 +65,7 @@ int main( int argc, char * argv[] )
   SYS_T::GetOptionInt("-time_step", time_step);
   SYS_T::GetOptionInt("-time_end", time_end);  
 
-  std::string out_bname = sol_bname;
-  out_bname.append("WSS_");
+  const std::string out_bname = sol_bname + "WSS_";
 
   cout<<"==== Command Line Arguments ===="<<endl;
   cout<<" -time_start: "<<time_start<<endl;
@@ -159,16 +158,10 @@ int main( int argc, char * argv[] )
   for(int time = time_start; time <= time_end; time += time_step)
   {
     // Read solution files
-    std::string disp_sol_name(sol_bname), velo_sol_name(sol_bname);
-    disp_sol_name.append("disp_");
-    velo_sol_name.append("velo_");
-    std::string name_to_write(out_bname);
-
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    
-    disp_sol_name.append(time_suffix);
-    velo_sol_name.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string disp_sol_name = sol_bname + "disp_" + time_suffix;
+    const std::string velo_sol_name = sol_bname + "velo_" + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Read %s and %s, and write %s. \n", disp_sol_name.c_str(),
         velo_sol_name.c_str(), name_to_write.c_str() );

--- a/examples/fsi/vis_solid.cpp
+++ b/examples/fsi/vis_solid.cpp
@@ -159,15 +159,11 @@ int main ( int argc , char * argv[] )
 
   for(int time = time_start; time<=time_end; time += time_step)
   {
-    std::string disp_name_to_read(disp_sol_bname);
-    std::string velo_name_to_read(velo_sol_bname);
-    std::string pres_name_to_read(pres_sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    disp_name_to_read.append(time_suffix);
-    velo_name_to_read.append(time_suffix);
-    pres_name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string disp_name_to_read = disp_sol_bname + time_suffix;
+    const std::string velo_name_to_read = velo_sol_bname + time_suffix;
+    const std::string pres_name_to_read = pres_sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s %s %s and Write %s \n",
         time, disp_name_to_read.c_str(), pres_name_to_read.c_str(),

--- a/examples/linearPDE/elastodynamics/vis.cpp
+++ b/examples/linearPDE/elastodynamics/vis.cpp
@@ -117,11 +117,9 @@ int main( int argc, char * argv[] )
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n",
         time, name_to_read.c_str(), name_to_write.c_str() );

--- a/examples/linearPDE/src/PTime_LinearPDE_Solver.cpp
+++ b/examples/linearPDE/src/PTime_LinearPDE_Solver.cpp
@@ -24,20 +24,13 @@ void PTime_LinearPDE_Solver::print_info() const
 std::string PTime_LinearPDE_Solver::Name_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 std::string PTime_LinearPDE_Solver::Name_dot_Generator( const std::string &middle_name,
     const int &counter ) const
 {
-  std::string out_name("dot_");
-  out_name.append(pb_name);
-  out_name.append(middle_name);
-  out_name.append(SYS_T::fixed_length_index(counter));
-  return out_name;
+  return "dot_" + pb_name + middle_name + SYS_T::fixed_length_index(counter);
 }
 
 void PTime_LinearPDE_Solver::TM_GenAlpha_Transport(

--- a/examples/linearPDE/transport/vis.cpp
+++ b/examples/linearPDE/transport/vis.cpp
@@ -111,11 +111,9 @@ int main( int argc, char * argv[] )
 
   for(int time = time_start; time<=time_end; time+= time_step)
   {
-    std::string name_to_read(sol_bname);
-    std::string name_to_write(out_bname);
     const std::string time_suffix = SYS_T::fixed_length_index(time);
-    name_to_read.append(time_suffix);
-    name_to_write.append(time_suffix);
+    const std::string name_to_read = sol_bname + time_suffix;
+    const std::string name_to_write = out_bname + time_suffix;
 
     SYS_T::commPrint("Time %d: Read %s and Write %s \n",
         time, name_to_read.c_str(), name_to_write.c_str() );

--- a/src/Analysis_Tool/ALocal_Interface.cpp
+++ b/src/Analysis_Tool/ALocal_Interface.cpp
@@ -19,8 +19,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
   max_num_local_rotated_ele = h5r -> read_intVector( gname.c_str(), "max_num_local_rotated_cell" );
   num_tag = h5r -> read_intVector( gname.c_str(), "num_tag" );
 
-  std::string groupbase(gname);
-  groupbase.append("/interfaceid_");
+  const std::string groupbase = gname + "/interfaceid_";
 
   num_fixed_node.assign(num_itf, 0);
   num_rotated_node.assign(num_itf, 0);
@@ -50,8 +49,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
   for(int ii=0; ii<num_itf; ++ii)
   {
-    std::string subgroup_name(groupbase);
-    subgroup_name.append( std::to_string(ii) );
+    const std::string subgroup_name = groupbase + std::to_string(ii);
 
     // total info
     fixed_ele_face_id[ii] = h5r -> read_intVector( subgroup_name.c_str(), "fixed_cell_face_id" );
@@ -82,8 +80,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
     rotated_LID[ii] = h5r -> read_intVector(  subgroup_name.c_str(), "rotated_LID" );
 
-    std::string subsubgroupbase(subgroup_name);
-    subsubgroupbase.append("/tag_");
+    const std::string subsubgroupbase = subgroup_name + "/tag_";
     
     // access for element search
     if(num_local_fixed_ele[ii] > 0)
@@ -94,8 +91,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_rotated_ele[ii][jj] > 0)
           tagged_rotated_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_rotated_cell" );
         else
@@ -116,8 +112,7 @@ ALocal_Interface::ALocal_Interface( const std::string &fileBaseName, int cpu_ran
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_fixed_ele[ii][jj] > 0)
           tagged_fixed_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_fixed_cell" );
         else
@@ -146,8 +141,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
   max_num_local_rotated_ele = h5r -> read_intVector( gname.c_str(), "max_num_local_rotated_cell" );
   num_tag = h5r -> read_intVector( gname.c_str(), "num_tag" );
 
-  std::string groupbase(gname);
-  groupbase.append("/interfaceid_");
+  const std::string groupbase = gname + "/interfaceid_";
 
   num_fixed_node.assign(num_itf, 0);
   num_rotated_node.assign(num_itf, 0);
@@ -177,8 +171,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
   for(int ii=0; ii<num_itf; ++ii)
   {
-    std::string subgroup_name(groupbase);
-    subgroup_name.append( std::to_string(ii) );
+    const std::string subgroup_name = groupbase + std::to_string(ii);
 
     // total info
     fixed_ele_face_id[ii] = h5r -> read_intVector( subgroup_name.c_str(), "fixed_cell_face_id" );
@@ -209,8 +202,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
     rotated_LID[ii] = h5r -> read_intVector(  subgroup_name.c_str(), "rotated_LID" );
 
-    std::string subsubgroupbase(subgroup_name);
-    subsubgroupbase.append("/tag_");
+    const std::string subsubgroupbase = subgroup_name + "/tag_";
 
     // access for element search
     if(num_local_fixed_ele[ii] > 0)
@@ -221,8 +213,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_rotated_ele[ii][jj] > 0)
           tagged_rotated_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_rotated_cell" );
         else
@@ -243,8 +234,7 @@ ALocal_Interface::ALocal_Interface( const HDF5_Reader * const &h5r )
 
       for(int jj=0; jj<num_tag[ii]; ++jj)
       {
-        std::string subsubgroup_name(subsubgroupbase);
-        subsubgroup_name.append( std::to_string(jj) );
+        const std::string subsubgroup_name = subsubgroupbase + std::to_string(jj);
         if(num_tagged_fixed_ele[ii][jj] > 0)
           tagged_fixed_ele[ii][jj] = h5r -> read_intVector( subsubgroup_name.c_str(), "tagged_fixed_cell" );
         else

--- a/src/Mesh/Interface_Partition.cpp
+++ b/src/Mesh/Interface_Partition.cpp
@@ -188,8 +188,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 
   for(int ii=0; ii<num_pair; ++ii)
   {
-    std::string subgroup_name(groupbase);
-    subgroup_name.append( std::to_string(ii) );
+    const std::string subgroup_name = groupbase + std::to_string(ii);
 
     hid_t group_id = H5Gcreate(g_id, subgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -233,8 +232,7 @@ void Interface_Partition::write_hdf5(const std::string &FileName) const
 
     for(int jj=0; jj<num_tag[ii]; ++jj)
     {
-      std::string subsubgroup_name(subgroupbase);
-      subsubgroup_name.append( std::to_string(jj) );
+      const std::string subsubgroup_name = subgroupbase + std::to_string(jj);
 
       hid_t subgroup_id = H5Gcreate(group_id, subsubgroup_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/src/Mesh/Sliding_Interface_Tools.cpp
+++ b/src/Mesh/Sliding_Interface_Tools.cpp
@@ -31,13 +31,11 @@ namespace SI_T
     nLocBas = h5r -> read_intScalar(mesh_info.c_str(), "nLocBas");
     dof_sol = h5r -> read_intScalar(mesh_info.c_str(), "dofNum");
 
-    std::string groupbase(gname);
-    groupbase.append("/interfaceid_");
+    const std::string groupbase = gname + "/interfaceid_";
 
     for(int ii=0; ii<num_itf; ++ii)
     {
-      std::string subgroup_name(groupbase);
-      subgroup_name.append( std::to_string(ii) );
+      const std::string subgroup_name = groupbase + std::to_string(ii);
       
       num_fixed_node[ii] = VEC_T::get_size(h5r -> read_intVector( subgroup_name.c_str(), "fixed_node_map" ));
 


### PR DESCRIPTION
### Motivation
- Simplify and standardize how file and group names are constructed to reduce repeated `append` calls and improve readability.
- Improve const correctness for temporary strings used in name generation to make intent clearer and enable potential compiler optimizations.
- Make `Name_Generator` and `Name_dot_Generator` implementations more concise by returning direct concatenations.

### Description
- Replaced multi-step `std::string` construction using `append` with single-expression concatenation (e.g. `sol_bname + time_suffix`) and marked them `const` in many `examples/*/vis*.cpp` and `examples/*/vis_*_wss.cpp` files.
- Simplified `PTime_*_Solver::Name_Generator` and `Name_dot_Generator` functions to return concatenated strings directly (e.g. `return pb_name + middle_name + SYS_T::fixed_length_index(counter);`).
- Standardized HDF5 group and subgroup name composition to use `const std::string` + `std::to_string()` instead of building strings via `append` in `ALocal_Interface.cpp`, `Interface_Partition.cpp`, `Sliding_Interface_Tools.cpp`, and related files.
- Minor refactor of local variables to `const` where appropriate and consistent use of direct initialization to improve clarity and maintainability.

### Testing
- Performed a full project build with the project's CMake/make workflow using the default build configuration, and the build completed successfully without compilation errors.
- Compiled the modified example targets (visualization and WSS examples) as a smoke test, and they linked successfully during the build process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7b553c68832aa350cae6c097ef83)