### PR TITLE
Refine SV_Tools header dependencies

### DIFF
--- a/include/SV_Tools.hpp
+++ b/include/SV_Tools.hpp
@@ -9,7 +9,8 @@
 // Author: Ju Liu
 // Date Created: Aug. 6 2017
 // ==================================================================
-#include "Tet_Tools.hpp"
+#include <string>
+#include <vector>
 
 namespace SV_T
 {

--- a/src/System/SV_Tools.cpp
+++ b/src/System/SV_Tools.cpp
@@ -1,5 +1,24 @@
 #include "SV_Tools.hpp"
 
+#include "DataVecStr.hpp"
+#include "Math_Tools.hpp"
+#include "Sys_Tools.hpp"
+#include "Tet_Tools.hpp"
+#include "Vec_Tools.hpp"
+#include "VTK_Tools.hpp"
+
+#include "vtkCell.h"
+#include "vtkCellData.h"
+#include "vtkDataArray.h"
+#include "vtkPointData.h"
+#include "vtkPolyData.h"
+#include "vtkUnstructuredGrid.h"
+#include "vtkXMLPolyDataReader.h"
+#include "vtkXMLUnstructuredGridReader.h"
+
+#include <algorithm>
+#include <iostream>
+
 void SV_T::update_sv_vtu( const std::string &filename,
     const std::string &write_name,
     int &sv_node_start, int &sv_elem_start )

--- a/tools/sv_file_converter/convert_quad_sv_files.cpp
+++ b/tools/sv_file_converter/convert_quad_sv_files.cpp
@@ -7,6 +7,7 @@
 // Date: Jan 20 2020
 // ==================================================================
 #include "SV_Tools.hpp"
+#include "Sys_Tools.hpp"
 
 int main( int argc, char * argv[] )
 {

--- a/tools/sv_file_converter/convert_sv_files.cpp
+++ b/tools/sv_file_converter/convert_sv_files.cpp
@@ -7,6 +7,7 @@
 // Date: Mar. 14 2019
 // ==================================================================
 #include "SV_Tools.hpp"
+#include "Sys_Tools.hpp"
 
 int main( int argc, char * argv[] )
 {

--- a/tools/sv_file_converter/convert_svpre_files.cpp
+++ b/tools/sv_file_converter/convert_svpre_files.cpp
@@ -17,6 +17,7 @@
 // Date: Sept 11 2019
 // ==================================================================
 #include "SV_Tools.hpp"
+#include "Sys_Tools.hpp"
 
 int main( int argc, char * argv[] )
 {

--- a/tools/sv_fsi_file_converter/convert_sv_fsi_files.cpp
+++ b/tools/sv_fsi_file_converter/convert_sv_fsi_files.cpp
@@ -10,6 +10,7 @@
 // Date: April 03 2019
 // ==================================================================
 #include "SV_Tools.hpp"
+#include "Sys_Tools.hpp"
 
 int main( int argc, char * argv[] )
 {


### PR DESCRIPTION
### Motivation
- Reduce transitive includes by removing the broad `Tet_Tools.hpp` dependency from the public `SV_Tools.hpp` header and only expose the standard types used in the API.
- Prevent implementation-only and VTK/PERIGEE headers from leaking into every translation unit that includes `SV_Tools.hpp`.
- Make converter drivers' dependencies explicit so they do not rely on transitive includes for `SYS_T`/PETSc/MPI declarations.

### Description
- Replace `#include "Tet_Tools.hpp"` in `include/SV_Tools.hpp` with `#include <string>` and `#include <vector>` so the header only exposes what its declarations require.
- Move implementation-only includes into `src/System/SV_Tools.cpp`, adding `DataVecStr.hpp`, `Math_Tools.hpp`, `Sys_Tools.hpp`, `Tet_Tools.hpp`, `Vec_Tools.hpp`, `VTK_Tools.hpp`, the necessary VTK headers, and `<algorithm>`/`<iostream>` for implementation use.
- Add explicit `#include "Sys_Tools.hpp"` to the SV converter driver sources under `tools/sv_file_converter/` and `tools/sv_fsi_file_converter/` to ensure `SYS_T`/PETSc symbols are available without relying on transitive includes.
- No public API signatures in the `SV_T` namespace were changed.

### Testing
- Performed a header-only syntax check with `printf '#include "SV_Tools.hpp"\nint main() { return 0; }\n' | c++ -std=c++11 -Iinclude -x c++ -fsyntax-only -` which succeeded.
- Ran `git diff --check` to validate there are no diff/whitespace issues and it reported no problems.
- Attempted to configure the converter CMake project with `cmake -S tools/sv_file_converter -B /tmp/perigee-sv-file-converter-build`, which failed due to a missing repository-local include `conf/system_lib_loading.cmake` and therefore did not complete configuration (this is not a regression from the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc3ea51a8832ab5f381f997fb9620)