### PR TITLE
Use smart pointers for Gmsh file timers

### DIFF
--- a/src/Mesh/Gmsh_FileIO.cpp
+++ b/src/Mesh/Gmsh_FileIO.cpp
@@ -173,7 +173,7 @@ void Gmsh_FileIO::write_interior_vtp( const std::string &vtp_filename,
     <<" associated with "<<phy_3d_name[index_vol1]
     <<" and "<<phy_3d_name[index_vol2]<<std::endl;
 
-  SYS_T::Timer * mytimer = new SYS_T::Timer();
+  auto mytimer = SYS_T::make_unique<SYS_T::Timer>();
 
   std::cout<<"-----> write "<<vtp_filename<<".vtp \n";
   mytimer->Reset();
@@ -365,7 +365,6 @@ void Gmsh_FileIO::write_interior_vtp( const std::string &vtp_filename,
   
   mytimer->Stop();
   std::cout<<"      Time taken "<<mytimer->get_sec()<<" sec. \n";
-  delete mytimer;
 }
 
 void Gmsh_FileIO::write_interior_vtp( int index_sur, 
@@ -398,7 +397,7 @@ void Gmsh_FileIO::write_vtp( const std::string &vtp_filename,
   else
     std::cout<<" without face-to-volume element index. \n";
 
-  SYS_T::Timer * mytimer = new SYS_T::Timer();
+  auto mytimer = SYS_T::make_unique<SYS_T::Timer>();
 
   std::cout<<"-----> write "<<vtp_filename<<".vtp \n";
 
@@ -572,7 +571,6 @@ void Gmsh_FileIO::write_vtp( const std::string &vtp_filename,
 
   mytimer->Stop();
   std::cout<<"      Time taken "<<mytimer->get_sec()<<" sec. \n";
-  delete mytimer;
 }
 
 void Gmsh_FileIO::write_vtp(const std::string &vtp_filename,
@@ -598,7 +596,7 @@ void Gmsh_FileIO::write_each_vtu( const std::vector<std::string> name_list) cons
   SYS_T::print_fatal_if(VEC_T::get_size(name_list) != num_phy_domain_3d,
     "Error: Gmsh_FileIO::write_each_vtu, the number of files should match the number of 3d domains");
 
-  SYS_T::Timer * mytimer = new SYS_T::Timer();
+  auto mytimer = SYS_T::make_unique<SYS_T::Timer>();
 
   for(int ii=0; ii<num_phy_domain_3d; ++ii)
   {
@@ -682,7 +680,6 @@ void Gmsh_FileIO::write_each_vtu( const std::vector<std::string> name_list) cons
     std::cout<<mytimer->get_sec()<<" sec. \n";
   }
 
-  delete mytimer;
 }
 
 void Gmsh_FileIO::write_each_vtu() const
@@ -697,7 +694,7 @@ void Gmsh_FileIO::write_vtu( const std::string &in_fname,
   std::cout<<"    There are "<<num_phy_domain_3d
     <<" 3D physical domains, with indices: \n";
 
-  SYS_T::Timer * mytimer = new SYS_T::Timer();
+  auto mytimer = SYS_T::make_unique<SYS_T::Timer>();
   mytimer->Reset();
   mytimer->Start();
 
@@ -759,7 +756,6 @@ void Gmsh_FileIO::write_vtu( const std::string &in_fname,
 
   mytimer->Stop();
   std::cout<<"    Time taken "<<mytimer->get_sec()<<" sec. \n";
-  delete mytimer;
 }
 
 void Gmsh_FileIO::check_FSI_ordering( const std::string &phy1,
@@ -1414,7 +1410,7 @@ void Gmsh_FileIO::write_quadratic_sur_vtu( const std::string &vtu_filename,
   else
     std::cout<<" without face-to-volume element index. \n";
 
-  SYS_T::Timer * mytimer = new SYS_T::Timer();
+  auto mytimer = SYS_T::make_unique<SYS_T::Timer>();
 
   std::cout<<"-----> write "<<vtu_filename<<".vtu \n";
 
@@ -1586,7 +1582,6 @@ void Gmsh_FileIO::write_quadratic_sur_vtu( const std::string &vtu_filename,
 
   mytimer->Stop();
   std::cout<<"      Time taken "<<mytimer->get_sec()<<" sec. \n";
-  delete mytimer;
 }
 
 void Gmsh_FileIO::write_quadratic_sur_vtu(const std::string &vtu_filename,


### PR DESCRIPTION
### Motivation
- Improve ownership and exception-safety of `SYS_T::Timer` instances used during Gmsh I/O routines to avoid manual memory management.
- Make timer lifetime automatic and eliminate explicit `delete` calls for clarity and reliability.

### Description
- Replaced occurrences of `SYS_T::Timer * mytimer = new SYS_T::Timer();` with `auto mytimer = SYS_T::make_unique<SYS_T::Timer>();` in `src/Mesh/Gmsh_FileIO.cpp` across the various VTK/HDF5 write routines.
- Removed the corresponding manual `delete mytimer;` calls so timers are cleaned up automatically when going out of scope.
- No changes to timer API usage (`Reset()`, `Start()`, `Stop()`, `get_sec()`), only ownership change to `std::unique_ptr` via the project `SYS_T::make_unique` helper.

### Testing
- Verified no remaining manual allocations/deletions for these timers using a code search for `new SYS_T::Timer` / `delete mytimer` and confirmed `make_unique<SYS_T::Timer>` occurrences in the modified file.
- Ran `git diff --check` to ensure no whitespace or diff errors, which passed.
- Attempted to configure an example with `cmake -S examples/test -B /tmp/perigee-test-build`, but CMake configuration could not complete in this environment because `conf/system_lib_loading.cmake` is not present (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc7c01398832ab0e28236e1377584)