### PR TITLE
Use fixed-length index helper for flow filenames

### DIFF
--- a/examples/ale_ns_rotate/include/PTime_NS_Solver.hpp
+++ b/examples/ale_ns_rotate/include/PTime_NS_Solver.hpp
@@ -35,14 +35,7 @@ class PTime_NS_Solver
     // ------------------------------------------------------------------------
     std::string gen_flowfile_name(const std::string &prefix, const int &id) const
     {
-      std::ostringstream ss;
-      ss << prefix;
-
-      if(id < 10) ss << "00";
-      else if(id < 100) ss << "0";
-
-      ss << id << "_data.txt";
-      return ss.str();
+      return prefix + SYS_T::fixed_length_index(id, 3) + "_data.txt";
     }
     
     void TM_NS_GenAlpha(

--- a/examples/fsi/include/PTime_FSI_Solver.hpp
+++ b/examples/fsi/include/PTime_FSI_Solver.hpp
@@ -37,14 +37,7 @@ class PTime_FSI_Solver
     // ------------------------------------------------------------------------
     std::string gen_flowfile_name(const std::string &prefix, const int &id) const
     {
-      std::ostringstream ss;
-      ss << prefix;
-
-      if(id < 10) ss << "00";
-      else if(id < 100) ss << "0";
-
-      ss << id << "_data.txt";
-      return ss.str();
+      return prefix + SYS_T::fixed_length_index(id, 3) + "_data.txt";
     }
 
     // ------------------------------------------------------------------------

--- a/examples/ns/include/PTime_NS_Solver.hpp
+++ b/examples/ns/include/PTime_NS_Solver.hpp
@@ -31,14 +31,7 @@ class PTime_NS_Solver
     // ------------------------------------------------------------------------
     std::string gen_flowfile_name(const std::string &prefix, const int &id) const
     {
-      std::ostringstream ss;
-      ss << prefix;
-
-      if(id < 10) ss << "00";
-      else if(id < 100) ss << "0";
-
-      ss << id << "_data.txt";
-      return ss.str();
+      return prefix + SYS_T::fixed_length_index(id, 3) + "_data.txt";
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Replace ad-hoc three-digit zero-padding logic in flow filename generation with the shared `SYS_T::fixed_length_index` helper to reduce duplication and ensure consistent formatting across examples.
- Apply the change to the NS, ALE-NS-rotate, and FSI example time solvers that generate inlet/outlet data filenames.

### Description
- Replaced the manual `ostringstream` + conditional padding logic inside `gen_flowfile_name` with `return prefix + SYS_T::fixed_length_index(id, 3) + "_data.txt";` in the following files: `examples/ns/include/PTime_NS_Solver.hpp`, `examples/ale_ns_rotate/include/PTime_NS_Solver.hpp`, and `examples/fsi/include/PTime_FSI_Solver.hpp`.
- Removed duplicated padding code blocks and kept the original `prefix_xxx_data.txt` filename format.
- Changes were committed with message "Use fixed length helper for flow filenames".

### Testing
- Ran `git diff --check` to validate there are no whitespace/merge issues, which passed.
- Confirmed the modified files are staged and committed (`git commit`) successfully.
- Attempted to configure the `examples/test` CMake project with `cmake -S examples/test -B /tmp/perigee-test-build`, which failed to configure because `conf/system_lib_loading.cmake` is not present in the environment (external configuration required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff2e0362c832aad4139fb0888338f)