### PR TITLE
Pass SYS_Tools scalar/pointer parameters by value

### DIFF
--- a/include/Sys_Tools.hpp
+++ b/include/Sys_Tools.hpp
@@ -93,7 +93,7 @@ namespace SYS_T
   // ! fixed_length_index( index, length )
   //   Format an index as a fixed minimum-length string with leading zeros.
   // --------------------------------------------------------------------------
-  inline std::string fixed_length_index( const int index, const int length = 9 )
+  inline std::string fixed_length_index( int index, int length = 9 )
   {
     std::ostringstream ss;
     ss << std::setfill('0') << std::setw(length) << index;
@@ -184,11 +184,11 @@ namespace SYS_T
   // 2. Print the data name and its value on screen using PetscPrintf
   //    and PETSC_COMM_WORLD. This is particularly designed to print
   //    command line arguments.
-  inline void cmdPrint(const char * const &dataname, int datavalue)
+  inline void cmdPrint(const char * dataname, int datavalue)
   {std::ostringstream ss; ss<<dataname<<" "<<datavalue<<"\n"; PetscPrintf(PETSC_COMM_WORLD, "%s", ss.str().c_str());}
-  inline void cmdPrint(const char * const &dataname, double datavalue)
+  inline void cmdPrint(const char * dataname, double datavalue)
   {std::ostringstream ss; ss<<dataname<<" "<<datavalue<<"\n"; PetscPrintf(PETSC_COMM_WORLD, "%s", ss.str().c_str());}
-  inline void cmdPrint(const char * const &dataname, const std::string &datavalue)
+  inline void cmdPrint(const char * dataname, const std::string &datavalue)
   {std::ostringstream ss; ss<<dataname<<" "<<datavalue<<"\n"; PetscPrintf(PETSC_COMM_WORLD, "%s", ss.str().c_str());}
 
   // 3. Print fatal error message and terminate the MPI process
@@ -458,7 +458,7 @@ namespace SYS_T
   // --------------------------------------------------------------------------
   // Execute a system call
   // --------------------------------------------------------------------------
-  inline void execute( const char * const &command )
+  inline void execute( const char * command )
   {
     int sysret = system( command );
     print_fatal_if(sysret != 0, "Error: system call %s failed. \n", command);
@@ -469,7 +469,7 @@ namespace SYS_T
   // argument. They are really wrappers of the PetscOptionsGetXXXXX
   // functions.
   // ================================================================
-  inline void GetOptionReal( const char * const &name, double &outdata )
+  inline void GetOptionReal( const char * name, double &outdata )
   {
 #if PETSC_VERSION_LT(3,7,0)
     PetscOptionsGetReal(PETSC_NULL, name, &outdata, PETSC_NULL);
@@ -480,7 +480,7 @@ namespace SYS_T
 #endif
   }
 
-  inline void GetOptionInt( const char * const &name, int &outdata )
+  inline void GetOptionInt( const char * name, int &outdata )
   {
 #if PETSC_VERSION_LT(3,7,0)
     PetscOptionsGetInt(PETSC_NULL, name, &outdata, PETSC_NULL);
@@ -491,7 +491,7 @@ namespace SYS_T
 #endif
   }
 
-  inline void GetOptionBool( const char * const &name, bool &outdata )
+  inline void GetOptionBool( const char * name, bool &outdata )
   {
     PetscBool pdata = PETSC_FALSE;
     PetscBool flg;
@@ -511,7 +511,7 @@ namespace SYS_T
     }
   }
 
-  inline void GetOptionString( const char * const &name, std::string &outdata )
+  inline void GetOptionString( const char * name, std::string &outdata )
   {
     PetscBool flg;
     char char_outdata[PETSC_MAX_PATH_LEN];


### PR DESCRIPTION
### Motivation
- Reduce unnecessary reference-to-scalar/pointer usage and make small parameter passing in `SYS_T` more idiomatic and efficient by taking ints and C-style string pointers by value.

### Description
- Updated `include/Sys_Tools.hpp` to change `fixed_length_index` signature from `const int index, const int length` to `int index, int length`, and to take `const char *` parameters by value for `cmdPrint`, `execute` and the PETSc option helpers (`GetOptionReal`, `GetOptionInt`, `GetOptionBool`, `GetOptionString`).

### Testing
- Ran `git diff --check` and `rg` to verify the targeted reference types were replaced (passed), and attempted to configure/build the `sys_test` target via `cmake -S examples/test -B /tmp/perigee-sys-tools-build -DCMAKE_BUILD_TYPE=Debug && cmake --build /tmp/perigee-sys-tools-build --target sys_test -j2`, which could not complete because the local checkout in this environment is missing `conf/system_lib_loading.cmake` (configuration failed due to missing project helper file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201c8fc450832abf48dd606ef2c8c8)