### PR TITLE
Use SYS_T::fixed_length_index for IFlowRate filenames

### DIFF
--- a/include/IFlowRate.hpp
+++ b/include/IFlowRate.hpp
@@ -10,7 +10,8 @@
 // Author: Ju Liu
 // Date created: Aug. 6 2017
 // ============================================================================
-#include <sstream>
+#include "Sys_Tools.hpp"
+
 #include <string>
 
 class IFlowRate
@@ -43,14 +44,8 @@ class IFlowRate
     // ------------------------------------------------------------------------
     virtual std::string gen_flowfile_name(int nbc_id) const
     {
-      std::ostringstream ss;
-      ss << "Inlet_";
-      if( nbc_id/10 == 0 ) ss << "00";
-      else if( nbc_id/100 == 0 ) ss << "0";
-
-      ss << nbc_id << "_precalculated_flowrate.txt";
-
-      return ss.str();
+      return "Inlet_" + SYS_T::fixed_length_index(nbc_id, 3)
+        + "_precalculated_flowrate.txt";
     }
 };
 


### PR DESCRIPTION
### Motivation
- Replace ad-hoc zero-padding logic in `IFlowRate::gen_flowfile_name` with the shared `SYS_T::fixed_length_index` helper for consistent, centralized filename formatting.

### Description
- Include `Sys_Tools.hpp` in `include/IFlowRate.hpp` and refactor `gen_flowfile_name` to return `"Inlet_" + SYS_T::fixed_length_index(nbc_id, 3) + "_precalculated_flowrate.txt"`, removing the previous `std::ostringstream` zero-padding code.

### Testing
- Ran `git diff --check` which produced no issues, and attempted `cmake -S examples/test -B /tmp/perigee-test-build` which failed to configure because the environment-specific `conf/system_lib_loading.cmake` is not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2600092b40832aac13229e2b087819)