### PR TITLE
Use shared zero-padded index for HERK pressure filenames

### DIFF
--- a/examples/ns/pres_cal_herk.cpp
+++ b/examples/ns/pres_cal_herk.cpp
@@ -103,7 +103,6 @@ int main(int argc, char *argv[])
   SYS_T::GetOptionString("-part_file", part_file);
 
   // time stepping parameters
-  // Assuming SOL_900000000 corresponds to a time of 0.0s
   double initial_time = time_start * initial_step;
   int initial_index = time_start;
   double final_time = initial_time + time_end * initial_step;
@@ -293,15 +292,11 @@ int main(int argc, char *argv[])
   SYS_T::commPrint("===> Start Finite Element Analysis:\n");
   
   // Read the sol
-  std::ostringstream time_index;
   for (int time = time_start; time<=time_end; time += time_step)
   {
-    std::string name_to_read(read_sol_bname);
-    std::string name_to_write(sol_bname);
-    time_index.str("");
-    time_index<< 900000000 + time;
-    name_to_read.append(time_index.str());
-    name_to_write.append(time_index.str());
+    const std::string time_index = SYS_T::fixed_length_index(time);
+    const std::string name_to_read = read_sol_bname + time_index;
+    const std::string name_to_write = sol_bname + time_index;
 
     SYS_T::commPrint("Time %f: Read %s, Write %s.\n", 
       time*initial_step, name_to_read.c_str(), name_to_write.c_str() );


### PR DESCRIPTION
### Motivation
- Ensure pressure postprocessing reads the same zero-padded solution filenames produced by the HERK time solver instead of using the legacy `900000000 + time` offset that produced indices starting with `9` followed by 8 digits.

### Description
- Replace the manual `900000000 + time` string construction in `examples/ns/pres_cal_herk.cpp` with the shared formatter `SYS_T::fixed_length_index(time)` so both read and write names use the same zero-padded suffix.
- Remove the obsolete comment that assumed the `SOL_900000000` convention.
- Only `examples/ns/pres_cal_herk.cpp` was modified to align with the `PTime_NS_HERK_Solver` naming behavior (which uses `SYS_T::fixed_length_index`).

### Testing
- Ran `git diff --check` with no issues reported (success).
- Executed a small assertion script that verified `SYS_T::fixed_length_index(time)` is used and that `900000000` is no longer present in the file (success).
- Attempted to configure/build `examples/ns` (`cmake -S examples/ns -B /tmp/perigee-ns-build && cmake --build /tmp/perigee-ns-build --target ns3dcalP`), but configuration failed because `conf/system_lib_loading.cmake` is not available in this environment (configuration blocked; not a regression in the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a269eb27a40832a8a69e034eb1396ee)