### PR TITLE
Inline solid solution name generation

### DIFF
--- a/examples/solids/include/PTime_Solver.hpp
+++ b/examples/solids/include/PTime_Solver.hpp
@@ -47,12 +47,6 @@ class PTime_Solver
     const std::unique_ptr<PNonlinear_Solver> nsolver;
     std::unique_ptr<PDNTimeStep> time_info;
 
-    std::string Name_Generator( const std::string &middle_name,
-        const int &counter ) const;
-
-    std::string Name_dot_Generator( const std::string &middle_name,
-        const int &counter ) const;
-
     PTime_Solver() = delete;
 };
 

--- a/examples/solids/src/PTime_Solver.cpp
+++ b/examples/solids/src/PTime_Solver.cpp
@@ -26,19 +26,6 @@ void PTime_Solver::print_info() const
   SYS_T::commPrint("----------------------------------------------------------- \n");
 }
 
-std::string PTime_Solver::Name_Generator( const std::string &middle_name,
-    const int &counter ) const
-{
-  return pb_name + middle_name + SYS_T::fixed_length_index(counter);
-}
-
-std::string PTime_Solver::Name_dot_Generator( const std::string &middle_name,
-    const int &counter ) const
-{
-  return std::string("dot_") + pb_name + middle_name
-      + SYS_T::fixed_length_index(counter);
-}
-
 void PTime_Solver::TM_Solid_GenAlpha(
     const bool &restart_init_assembly_flag,
     std::unique_ptr<PDNSolution> init_dot_disp,
@@ -66,22 +53,24 @@ void PTime_Solver::TM_Solid_GenAlpha(
 
   if( restart_init_assembly_flag == false )
   {
-    std::string sol_name = Name_Generator("disp_", time_info->get_index());
+    const std::string index_name =
+        SYS_T::fixed_length_index(time_info->get_index());
+    std::string sol_name = pb_name + "disp_" + index_name;
     cur_disp->WriteBinary(sol_name.c_str());
 
-    sol_name = Name_Generator("velo_", time_info->get_index());
+    sol_name = pb_name + "velo_" + index_name;
     cur_velo->WriteBinary(sol_name.c_str());
 
-    sol_name = Name_Generator("pres_", time_info->get_index());
+    sol_name = pb_name + "pres_" + index_name;
     cur_pres->WriteBinary(sol_name.c_str());
 
-    std::string sol_dot_name = Name_dot_Generator("disp_", time_info->get_index());
+    std::string sol_dot_name = "dot_" + pb_name + "disp_" + index_name;
     cur_dot_disp->WriteBinary(sol_dot_name.c_str());
 
-    sol_dot_name = Name_dot_Generator("velo_", time_info->get_index());
+    sol_dot_name = "dot_" + pb_name + "velo_" + index_name;
     cur_dot_velo->WriteBinary(sol_dot_name.c_str());
 
-    sol_dot_name = Name_dot_Generator("pres_", time_info->get_index());
+    sol_dot_name = "dot_" + pb_name + "pres_" + index_name;
     cur_dot_pres->WriteBinary(sol_dot_name.c_str());
   }
 
@@ -121,22 +110,24 @@ void PTime_Solver::TM_Solid_GenAlpha(
 
     if( time_info->get_index() % sol_record_freq == 0 )
     {
-      std::string sol_name = Name_Generator("disp_", time_info->get_index());
+      const std::string index_name =
+          SYS_T::fixed_length_index(time_info->get_index());
+      std::string sol_name = pb_name + "disp_" + index_name;
       cur_disp->WriteBinary(sol_name.c_str());
 
-      sol_name = Name_Generator("velo_", time_info->get_index());
+      sol_name = pb_name + "velo_" + index_name;
       cur_velo->WriteBinary(sol_name.c_str());
 
-      sol_name = Name_Generator("pres_", time_info->get_index());
+      sol_name = pb_name + "pres_" + index_name;
       cur_pres->WriteBinary(sol_name.c_str());
 
-      std::string sol_dot_name = Name_dot_Generator("disp_", time_info->get_index());
+      std::string sol_dot_name = "dot_" + pb_name + "disp_" + index_name;
       cur_dot_disp->WriteBinary(sol_dot_name.c_str());
 
-      sol_dot_name = Name_dot_Generator("velo_", time_info->get_index());
+      sol_dot_name = "dot_" + pb_name + "velo_" + index_name;
       cur_dot_velo->WriteBinary(sol_dot_name.c_str());
 
-      sol_dot_name = Name_dot_Generator("pres_", time_info->get_index());
+      sol_dot_name = "dot_" + pb_name + "pres_" + index_name;
       cur_dot_pres->WriteBinary(sol_dot_name.c_str());
     }
 


### PR DESCRIPTION
### Motivation

- Remove two trivial one-line helpers that only assembled filenames to reduce indirection and simplify the solver code.
- Construct filenames directly where they are used and avoid repeated calls to the index formatting routine by reusing a local formatted index.

### Description

- Removed `Name_Generator` and `Name_dot_Generator` declarations from `examples/solids/include/PTime_Solver.hpp`.
- Removed the corresponding definitions from `examples/solids/src/PTime_Solver.cpp`.
- Inlined filename construction at the initial output block and the periodic output block inside `PTime_Solver::TM_Solid_GenAlpha` by building strings like ``pb_name + "disp_" + index_name`` and ``"dot_" + pb_name + "disp_" + index_name``.
- Introduced a local ``const std::string index_name = SYS_T::fixed_length_index(time_info->get_index());`` in each output block to reuse the formatted index.

### Testing

- Ran ``git diff --check`` with no issues.
- Searched with ``rg -n "Name(_dot)?_Generator" examples/solids`` and confirmed no remaining references.
- Attempted configure with ``cmake -S examples/solids -B /tmp/perigee-solids-build -DCMAKE_BUILD_TYPE=Debug``; configuration failed because ``conf/system_lib_loading.cmake`` is not present in this checkout, so a full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a275fb29e48832a8bf94e1a5a0aacfe)