### PR TITLE
Share solid velocity-pressure PETSc index sets and remove GetSubVecIndex_vp

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -219,6 +219,9 @@ int main(int argc, char *argv[])
       disp, velo, pres, dot_disp, dot_velo, dot_pres,
       initial_index, initial_time, initial_step );
 
+  IS is_velo, is_pres;
+  SOLID_INIT::create_vp_index_sets(*pNode, is_velo, is_pres);
+
   // ===== Global Assembly Routine =====
   std::unique_ptr<PGAssem_Solid_FEM> gloAssem_ptr =
     SYS_T::make_unique<PGAssem_Solid_FEM>(
@@ -232,7 +235,7 @@ int main(int argc, char *argv[])
 
   // ===== Initialize the dot_sol vectors by solving mass matrix =====
   SOLID_INIT::initialize_dot_solution( is_restart, gloAssem_ptr.get(),
-      dot_disp.get(), dot_velo.get(), dot_pres.get(),
+      is_velo, is_pres, dot_disp.get(), dot_velo.get(), dot_pres.get(),
       disp.get(), velo.get(), pres.get() );
 
   // ===== Linear and nonlinear solver context =====
@@ -240,8 +243,11 @@ int main(int argc, char *argv[])
 
   auto nsolver = SYS_T::make_unique<PNonlinear_Solver>(
       std::move(gloAssem_ptr), std::move(lsolver), std::move(pmat),
-      std::move(tm_galpha), std::move(locnbc_disp),
+      std::move(tm_galpha), std::move(locnbc_disp), is_velo, is_pres,
       nl_rtol, nl_atol, nl_dtol, nl_maxits, nl_refreq, nl_threshold );
+
+  ISDestroy(&is_velo);
+  ISDestroy(&is_pres);
 
   nsolver->print_info();
 

--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -11,6 +11,27 @@
 
 namespace SOLID_INIT
 {
+  inline void create_vp_index_sets( const APart_Node &pnode,
+      IS &is_velo, IS &is_pres )
+  {
+    const int nlocal = pnode.get_nlocalnode();
+    std::vector<PetscInt> idx_v(3 * nlocal), idx_p(nlocal);
+
+    for(int ii=0; ii<nlocal; ++ii)
+    {
+      const PetscInt gid = pnode.get_node_loc(ii);
+      idx_p[ii] = 4 * gid;
+      idx_v[3*ii  ] = 4 * gid + 1;
+      idx_v[3*ii+1] = 4 * gid + 2;
+      idx_v[3*ii+2] = 4 * gid + 3;
+    }
+
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()),
+        idx_v.data(), PETSC_COPY_VALUES, &is_velo);
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()),
+        idx_p.data(), PETSC_COPY_VALUES, &is_pres);
+  }
+
   inline void initialize_solution_state( bool is_restart,
       int restart_index, double restart_time, double restart_step,
       const std::string &restart_disp_name,
@@ -69,8 +90,9 @@ namespace SOLID_INIT
     }
   }
 
-  inline void initialize_dot_solution( bool is_restart, 
+  inline void initialize_dot_solution( bool is_restart,
       PGAssem_Solid_FEM * const gloAssem,
+      IS is_velo, IS is_pres,
       PDNSolution * const &dot_disp,
       PDNSolution * const &dot_velo,
       PDNSolution * const &dot_pres,
@@ -101,13 +123,6 @@ namespace SOLID_INIT
     lsolver_acce->Solve( gloAssem->K, gloAssem->G, dot_vp );
     VecScale(dot_vp, -1.0);
 
-    std::vector<PetscInt> idx_v, idx_p;
-    gloAssem->GetSubVecIndex_vp(idx_v, idx_p);
-
-    IS is_velo, is_pres;
-    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);
-    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()), idx_p.data(), PETSC_COPY_VALUES, &is_pres);
-
     Vec sol_v, sol_p;
     VecGetSubVector(dot_vp, is_velo, &sol_v);
     VecGetSubVector(dot_vp, is_pres, &sol_p);
@@ -120,8 +135,6 @@ namespace SOLID_INIT
 
     VecRestoreSubVector(dot_vp, is_velo, &sol_v);
     VecRestoreSubVector(dot_vp, is_pres, &sol_p);
-    ISDestroy(&is_velo);
-    ISDestroy(&is_pres);
     VecDestroy(&dot_vp);
 
     dot_disp->Copy( velo );

--- a/examples/solids/include/PGAssem_Solid_FEM.hpp
+++ b/examples/solids/include/PGAssem_Solid_FEM.hpp
@@ -55,10 +55,6 @@ class PGAssem_Solid_FEM : public IPGAssem
         const PDNSolution * const &velo,
         const PDNSolution * const &pres ) override;
 
-    void GetSubVecIndex_vp(
-        std::vector<PetscInt> &idx_v,
-        std::vector<PetscInt> &idx_p ) const;
-
   private:
     const std::unique_ptr<const ALocal_IEN> locien;
     const std::unique_ptr<const ALocal_Elem> locelem;

--- a/examples/solids/include/PNonlinear_Solver.hpp
+++ b/examples/solids/include/PNonlinear_Solver.hpp
@@ -23,6 +23,7 @@ class PNonlinear_Solver
         std::unique_ptr<Matrix_PETSc> in_bc_mat,
         std::unique_ptr<TimeMethod_GenAlpha> in_tmga,
         std::unique_ptr<ALocal_NBC> in_nbc_disp,
+        IS in_is_velo, IS in_is_pres,
         const double &input_nrtol, const double &input_natol,
         const double &input_ndtol, const int &input_max_iteration,
         const int &input_renew_freq, const int &input_renew_threshold );

--- a/examples/solids/src/PGAssem_Solid_FEM.cpp
+++ b/examples/solids/src/PGAssem_Solid_FEM.cpp
@@ -75,25 +75,6 @@ PGAssem_Solid_FEM::~PGAssem_Solid_FEM()
   MatDestroy(&K);
 }
 
-void PGAssem_Solid_FEM::GetSubVecIndex_vp(
-    std::vector<PetscInt> &idx_v,
-    std::vector<PetscInt> &idx_p ) const
-{
-  const int nlocal = pnode->get_nlocalnode();
-
-  idx_v.resize(3 * nlocal);
-  idx_p.resize(nlocal);
-
-  for(int ii=0; ii<nlocal; ++ii)
-  {
-    const PetscInt gid = pnode->get_node_loc(ii);
-    idx_p[ii] = 4 * gid;
-    idx_v[3*ii  ] = 4 * gid + 1;
-    idx_v[3*ii+1] = 4 * gid + 2;
-    idx_v[3*ii+2] = 4 * gid + 3;
-  }
-}
-
 void PGAssem_Solid_FEM::EssBC_KG( const int &field )
 {
   const int local_dir = nbc->get_Num_LD(field);

--- a/examples/solids/src/PNonlinear_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solver.cpp
@@ -7,6 +7,7 @@ PNonlinear_Solver::PNonlinear_Solver(
     std::unique_ptr<Matrix_PETSc> in_bc_mat,
     std::unique_ptr<TimeMethod_GenAlpha> in_tmga,
     std::unique_ptr<ALocal_NBC> in_nbc_disp,
+    IS in_is_velo, IS in_is_pres,
     const double &input_nrtol, const double &input_natol,
     const double &input_ndtol, const int &input_max_iteration,
     const int &input_renew_freq, const int &input_renew_threshold )
@@ -18,15 +19,10 @@ PNonlinear_Solver::PNonlinear_Solver(
   bc_mat(std::move(in_bc_mat)),
   tmga(std::move(in_tmga)),
   nbc_disp(std::move(in_nbc_disp)),
-  is_velo(nullptr), is_pres(nullptr)
+  is_velo(in_is_velo), is_pres(in_is_pres)
 {
-  std::vector<PetscInt> idx_v, idx_p;
-  gassem->GetSubVecIndex_vp(idx_v, idx_p);
-
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()),
-      idx_v.data(), PETSC_COPY_VALUES, &is_velo);
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()),
-      idx_p.data(), PETSC_COPY_VALUES, &is_pres);
+  PetscObjectReference(reinterpret_cast<PetscObject>(is_velo));
+  PetscObjectReference(reinterpret_cast<PetscObject>(is_pres));
 }
 
 PNonlinear_Solver::~PNonlinear_Solver()


### PR DESCRIPTION
### Motivation

- 避免在多个位置重复为固体混合 (p, vx, vy, vz) 布局生成索引集，并将固体特有的索引生成逻辑从通用 PETSc 工具中分离出来。 
- 通过统一创建并共享 PETSc `IS`，简化初始加速度计算与非线性求解器间的所有权管理并避免重复销毁或泄漏。

### Description

- 新增 `SOLID_INIT::create_vp_index_sets(const APart_Node&, IS&, IS&)`，直接根据本地节点的全局索引生成压力与速度 `IS`（压力索引为 `4*gid`，速度为 `4*gid+1/2/3`）。
- 将 `initialize_dot_solution` 修改为接收并借用外部 `IS is_velo` 与 `IS is_pres`，删除原函数中自行调用的 `GetSubVecIndex_vp`、`ISCreateGeneral` 与局部索引数组，且不在该函数中销毁 `IS`。
- 在 `driver.cpp` 中于 `pNode` 被移动到 `PGAssem_Solid_FEM` 之前创建上述两个 `IS`，并将其传给 `initialize_dot_solution` 和随后构造的 `PNonlinear_Solver`，构造后在 driver 中销毁本地引用以避免泄漏或双重销毁。
- 修改 `PNonlinear_Solver` 构造函数以接受这两个 `IS`，并在构造函数中用 `PetscObjectReference(reinterpret_cast<PetscObject>(...))` 增加引用计数；析构函数保留调用 `ISDestroy` 释放求解器持有的引用。
- 删除 `PGAssem_Solid_FEM::GetSubVecIndex_vp` 的声明与实现，移除相关重复实现点并清理接口。

### Testing

- 运行静态一致性检查 `git diff --check`，结果通过。
- 用 `rg` 搜索确认 `GetSubVecIndex_vp` 无残留引用，结果为无残留。
- 执行 Python 脚本的源码不变式检查来验证索引布局、创建顺序、`PetscObjectReference` 与 `ISDestroy` 的使用，所有断言通过。
- 尝试配置示例构建：`cmake -S examples/solids -B /tmp/perigee-solids-build -DCMAKE_BUILD_TYPE=Debug`，配置被阻塞因为当前环境缺少仓库期望的本地 CMake 片段 `conf/system_lib_loading.cmake`（该项与本改动无关）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276585c704832ab279724caa6bf721)