### PR TITLE
Refactor PETSc subvector IS creation and propagate IS through solvers

### DIFF
--- a/examples/solids/driver.cpp
+++ b/examples/solids/driver.cpp
@@ -219,6 +219,9 @@ int main(int argc, char *argv[])
       disp, velo, pres, dot_disp, dot_velo, dot_pres,
       initial_index, initial_time, initial_step );
 
+  IS is_velo, is_pres;
+  SOLID_INIT::generate_subvector_is(pNode.get(), is_velo, is_pres);
+
   // ===== Global Assembly Routine =====
   std::unique_ptr<PGAssem_Solid_FEM> gloAssem_ptr =
     SYS_T::make_unique<PGAssem_Solid_FEM>(
@@ -232,6 +235,7 @@ int main(int argc, char *argv[])
 
   // ===== Initialize the dot_sol vectors by solving mass matrix =====
   SOLID_INIT::initialize_dot_solution( is_restart, gloAssem_ptr.get(),
+      is_velo, is_pres,
       dot_disp.get(), dot_velo.get(), dot_pres.get(),
       disp.get(), velo.get(), pres.get() );
 
@@ -254,12 +258,14 @@ int main(int argc, char *argv[])
 
   SYS_T::commPrint("===> Start Finite Element Analysis:\n");
 
-  tsolver->TM_Solid_GenAlpha( is_restart,
+  tsolver->TM_Solid_GenAlpha( is_restart, is_velo, is_pres,
       std::move(dot_disp), std::move(dot_velo), std::move(dot_pres),
       std::move(disp), std::move(velo), std::move(pres) );
 
   // Ensure PETSc objects are destroyed before PetscFinalize
   tsolver.reset();
+  ISDestroy(&is_velo);
+  ISDestroy(&is_pres);
 
   PetscFinalize();
   return EXIT_SUCCESS;

--- a/examples/solids/include/InitHelpers.hpp
+++ b/examples/solids/include/InitHelpers.hpp
@@ -11,6 +11,28 @@
 
 namespace SOLID_INIT
 {
+  inline void generate_subvector_is(
+      const APart_Node * const pNode,
+      IS &is_velo, IS &is_pres )
+  {
+    const int nlocal = pNode->get_nlocalnode();
+    std::vector<PetscInt> idx_v(3 * nlocal), idx_p(nlocal);
+
+    for(int ii=0; ii<nlocal; ++ii)
+    {
+      const PetscInt gid = pNode->get_node_loc(ii);
+      idx_p[ii] = 4 * gid;
+      idx_v[3*ii  ] = 4 * gid + 1;
+      idx_v[3*ii+1] = 4 * gid + 2;
+      idx_v[3*ii+2] = 4 * gid + 3;
+    }
+
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()),
+        idx_v.data(), PETSC_COPY_VALUES, &is_velo);
+    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()),
+        idx_p.data(), PETSC_COPY_VALUES, &is_pres);
+  }
+
   inline void initialize_solution_state( bool is_restart,
       int restart_index, double restart_time, double restart_step,
       const std::string &restart_disp_name,
@@ -71,6 +93,7 @@ namespace SOLID_INIT
 
   inline void initialize_dot_solution( bool is_restart, 
       PGAssem_Solid_FEM * const gloAssem,
+      IS is_velo, IS is_pres,
       PDNSolution * const &dot_disp,
       PDNSolution * const &dot_velo,
       PDNSolution * const &dot_pres,
@@ -101,13 +124,6 @@ namespace SOLID_INIT
     lsolver_acce->Solve( gloAssem->K, gloAssem->G, dot_vp );
     VecScale(dot_vp, -1.0);
 
-    std::vector<PetscInt> idx_v, idx_p;
-    gloAssem->GetSubVecIndex_vp(idx_v, idx_p);
-
-    IS is_velo, is_pres;
-    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()), idx_v.data(), PETSC_COPY_VALUES, &is_velo);
-    ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()), idx_p.data(), PETSC_COPY_VALUES, &is_pres);
-
     Vec sol_v, sol_p;
     VecGetSubVector(dot_vp, is_velo, &sol_v);
     VecGetSubVector(dot_vp, is_pres, &sol_p);
@@ -120,8 +136,6 @@ namespace SOLID_INIT
 
     VecRestoreSubVector(dot_vp, is_velo, &sol_v);
     VecRestoreSubVector(dot_vp, is_pres, &sol_p);
-    ISDestroy(&is_velo);
-    ISDestroy(&is_pres);
     VecDestroy(&dot_vp);
 
     dot_disp->Copy( velo );

--- a/examples/solids/include/PGAssem_Solid_FEM.hpp
+++ b/examples/solids/include/PGAssem_Solid_FEM.hpp
@@ -55,10 +55,6 @@ class PGAssem_Solid_FEM : public IPGAssem
         const PDNSolution * const &velo,
         const PDNSolution * const &pres ) override;
 
-    void GetSubVecIndex_vp(
-        std::vector<PetscInt> &idx_v,
-        std::vector<PetscInt> &idx_p ) const;
-
   private:
     const std::unique_ptr<const ALocal_IEN> locien;
     const std::unique_ptr<const ALocal_Elem> locelem;

--- a/examples/solids/include/PNonlinear_Solver.hpp
+++ b/examples/solids/include/PNonlinear_Solver.hpp
@@ -27,7 +27,7 @@ class PNonlinear_Solver
         const double &input_ndtol, const int &input_max_iteration,
         const int &input_renew_freq, const int &input_renew_threshold );
 
-    ~PNonlinear_Solver();
+    ~PNonlinear_Solver() = default;
 
     int get_non_max_its() const {return nmaxits;}
 
@@ -39,6 +39,7 @@ class PNonlinear_Solver
         const bool &new_tangent_flag,
         const double &curr_time,
         const double &dt,
+        IS is_velo, IS is_pres,
         const PDNSolution * const &pre_dot_disp,
         const PDNSolution * const &pre_dot_velo,
         const PDNSolution * const &pre_dot_pres,
@@ -62,7 +63,6 @@ class PNonlinear_Solver
     const std::unique_ptr<Matrix_PETSc> bc_mat;
     const std::unique_ptr<TimeMethod_GenAlpha> tmga;
     const std::unique_ptr<ALocal_NBC> nbc_disp;
-    IS is_velo, is_pres;
 
     void Print_convergence_info( const int &count,
         const double &rel_err, const double &abs_err ) const

--- a/examples/solids/include/PTime_Solver.hpp
+++ b/examples/solids/include/PTime_Solver.hpp
@@ -31,6 +31,7 @@ class PTime_Solver
 
     void TM_Solid_GenAlpha(
         const bool &restart_init_assembly_flag,
+        IS is_velo, IS is_pres,
         std::unique_ptr<PDNSolution> init_dot_disp,
         std::unique_ptr<PDNSolution> init_dot_velo,
         std::unique_ptr<PDNSolution> init_dot_pres,

--- a/examples/solids/src/PGAssem_Solid_FEM.cpp
+++ b/examples/solids/src/PGAssem_Solid_FEM.cpp
@@ -75,25 +75,6 @@ PGAssem_Solid_FEM::~PGAssem_Solid_FEM()
   MatDestroy(&K);
 }
 
-void PGAssem_Solid_FEM::GetSubVecIndex_vp(
-    std::vector<PetscInt> &idx_v,
-    std::vector<PetscInt> &idx_p ) const
-{
-  const int nlocal = pnode->get_nlocalnode();
-
-  idx_v.resize(3 * nlocal);
-  idx_p.resize(nlocal);
-
-  for(int ii=0; ii<nlocal; ++ii)
-  {
-    const PetscInt gid = pnode->get_node_loc(ii);
-    idx_p[ii] = 4 * gid;
-    idx_v[3*ii  ] = 4 * gid + 1;
-    idx_v[3*ii+1] = 4 * gid + 2;
-    idx_v[3*ii+2] = 4 * gid + 3;
-  }
-}
-
 void PGAssem_Solid_FEM::EssBC_KG( const int &field )
 {
   const int local_dir = nbc->get_Num_LD(field);

--- a/examples/solids/src/PNonlinear_Solver.cpp
+++ b/examples/solids/src/PNonlinear_Solver.cpp
@@ -17,23 +17,8 @@ PNonlinear_Solver::PNonlinear_Solver(
   lsolver(std::move(in_lsolver)),
   bc_mat(std::move(in_bc_mat)),
   tmga(std::move(in_tmga)),
-  nbc_disp(std::move(in_nbc_disp)),
-  is_velo(nullptr), is_pres(nullptr)
-{
-  std::vector<PetscInt> idx_v, idx_p;
-  gassem->GetSubVecIndex_vp(idx_v, idx_p);
-
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_v.size()),
-      idx_v.data(), PETSC_COPY_VALUES, &is_velo);
-  ISCreateGeneral(PETSC_COMM_WORLD, static_cast<PetscInt>(idx_p.size()),
-      idx_p.data(), PETSC_COPY_VALUES, &is_pres);
-}
-
-PNonlinear_Solver::~PNonlinear_Solver()
-{
-  ISDestroy(&is_velo);
-  ISDestroy(&is_pres);
-}
+  nbc_disp(std::move(in_nbc_disp))
+{}
 
 void PNonlinear_Solver::print_info() const
 {
@@ -131,6 +116,7 @@ void PNonlinear_Solver::GenAlpha_Seg_solve_Solid(
     const bool &new_tangent_flag,
     const double &curr_time,
     const double &dt,
+    IS is_velo, IS is_pres,
     const PDNSolution * const &pre_dot_disp,
     const PDNSolution * const &pre_dot_velo,
     const PDNSolution * const &pre_dot_pres,

--- a/examples/solids/src/PTime_Solver.cpp
+++ b/examples/solids/src/PTime_Solver.cpp
@@ -28,6 +28,7 @@ void PTime_Solver::print_info() const
 
 void PTime_Solver::TM_Solid_GenAlpha(
     const bool &restart_init_assembly_flag,
+    IS is_velo, IS is_pres,
     std::unique_ptr<PDNSolution> init_dot_disp,
     std::unique_ptr<PDNSolution> init_dot_velo,
     std::unique_ptr<PDNSolution> init_dot_pres,
@@ -96,6 +97,7 @@ void PTime_Solver::TM_Solid_GenAlpha(
 
     nsolver->GenAlpha_Seg_solve_Solid( renew_flag,
         time_info->get_time(), time_info->get_step(),
+        is_velo, is_pres,
         pre_dot_disp.get(), pre_dot_velo.get(), pre_dot_pres.get(),
         pre_disp.get(), pre_velo.get(), pre_pres.get(),
         cur_dot_disp.get(), cur_dot_velo.get(), cur_dot_pres.get(),


### PR DESCRIPTION
### Motivation
- Centralize creation of PETSc index sets for the velocity and pressure subvectors to avoid duplicated creation/destruction and to allow reuse by time and nonlinear solver routines.
- Remove ownership of the subvector `IS` objects from `PNonlinear_Solver` and avoid reconstructing indices in multiple places to simplify lifecycle management.

### Description
- Add `SOLID_INIT::generate_subvector_is` in `InitHelpers.hpp` to create `IS is_velo` and `IS is_pres` from `APart_Node` node layout.
- Create `is_velo`/`is_pres` in the main driver (`driver.cpp`), pass them into `initialize_dot_solution`, the time solver `TM_Solid_GenAlpha`, and onward into `PNonlinear_Solver::GenAlpha_Seg_solve_Solid`, and destroy them at program end.
- Update function signatures: `initialize_dot_solution`, `PTime_Solver::TM_Solid_GenAlpha`, and `PNonlinear_Solver::GenAlpha_Seg_solve_Solid` now accept `IS is_velo, IS is_pres`; remove `PGAssem_Solid_FEM::GetSubVecIndex_vp` and related internal IS creation.
- Simplify `PNonlinear_Solver` by removing `IS` members, defaulting its destructor, and eliminating local IS creation/destruction in constructors/destructors and in `initialize_dot_solution`.

### Testing
- Built the examples target with `cmake --build . --target examples` and the build completed successfully.
- Ran the solids example driver as a smoke test (`examples/solids/driver`) and observed successful execution without PETSc `IS` related errors.
- Ran the test suite with `ctest` and no regressions related to the modified components were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27696fffb8832aafb089e363b5e282)