### PR TITLE
Remove unused prestress inputs from solid local assembly

### DIFF
--- a/examples/solids/include/PGAssem_Solid_FEM.hpp
+++ b/examples/solids/include/PGAssem_Solid_FEM.hpp
@@ -65,9 +65,7 @@ class PGAssem_Solid_FEM : public IPGAssem
     const std::unique_ptr<IPLocAssem_2x2Block> locassem;
 
     const int num_ebc;
-    const int nLocBas, snLocBas, dof_mat, nlgn, nqpv;
-
-    std::vector<double> zero_prestress;
+    const int nLocBas, snLocBas, dof_mat, nlgn;
 
     void EssBC_KG( const int &field );
     void EssBC_G( const int &field );

--- a/examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp
+++ b/examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp
@@ -62,8 +62,7 @@ class PLocAssem_2x2Block_VMS_Hyperelasticity : public IPLocAssem_2x2Block
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress );
+        const double * const &eleCtrlPts_z );
 
     virtual void Assem_Tangent_Residual(
         const double &time, const double &dt,
@@ -75,8 +74,7 @@ class PLocAssem_2x2Block_VMS_Hyperelasticity : public IPLocAssem_2x2Block
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress );
+        const double * const &eleCtrlPts_z );
  
     virtual void Assem_Mass_Residual(
         const double * const &disp,
@@ -84,8 +82,7 @@ class PLocAssem_2x2Block_VMS_Hyperelasticity : public IPLocAssem_2x2Block
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress );
+        const double * const &eleCtrlPts_z );
 
     virtual void Assem_Residual_EBC(
         const int &ebc_id,

--- a/examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp
+++ b/examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp
@@ -62,8 +62,7 @@ class PLocAssem_2x2Block_VMS_Incompressible : public IPLocAssem_2x2Block
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress );
+        const double * const &eleCtrlPts_z );
 
     virtual void Assem_Tangent_Residual(
         const double &time, const double &dt,
@@ -75,8 +74,7 @@ class PLocAssem_2x2Block_VMS_Incompressible : public IPLocAssem_2x2Block
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress );
+        const double * const &eleCtrlPts_z );
 
     virtual void Assem_Mass_Residual(
         const double * const &disp,
@@ -84,8 +82,7 @@ class PLocAssem_2x2Block_VMS_Incompressible : public IPLocAssem_2x2Block
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress );
+        const double * const &eleCtrlPts_z );
 
     virtual void Assem_Residual_EBC(
         const int &ebc_id,

--- a/examples/solids/src/PGAssem_Solid_FEM.cpp
+++ b/examples/solids/src/PGAssem_Solid_FEM.cpp
@@ -20,8 +20,7 @@ PGAssem_Solid_FEM::PGAssem_Solid_FEM(
   nLocBas( locassem->get_nLocBas_0() ),
   snLocBas( locassem->get_snLocBas_0() ),
   dof_mat( locassem->get_dof_0() + locassem->get_dof_1() ),
-  nlgn( pnode->get_nlocghonode() ),
-  nqpv( locassem->get_nqpv() )
+  nlgn( pnode->get_nlocghonode() )
 {
   SYS_T::print_fatal_if( dof_mat != nbc->get_dof_LID(),
       "Error: PGAssem_Solid_FEM, dof_mat and nbc dof mismatch.\n" );
@@ -30,8 +29,6 @@ PGAssem_Solid_FEM::PGAssem_Solid_FEM(
     SYS_T::print_fatal_if( snLocBas != ebc->get_cell_nLocBas(ebc_id),
         "Error: PGAssem_Solid_FEM, snLocBas has to be uniform.\n" );
   }
-
-  zero_prestress.assign( nqpv * 6, 0.0 );
 
   const int nlocrow = dof_mat * pnode -> get_nlocalnode();
 
@@ -242,7 +239,7 @@ void PGAssem_Solid_FEM::Assem_mass_residual(
     const std::vector<double> local_p = GetLocal( array_p, IEN, nLocBas, 1 );
 
     locassem -> Assem_Mass_Residual( &local_d[0], &local_v[0], &local_p[0],
-        ectrl_x, ectrl_y, ectrl_z, &zero_prestress[0] );
+        ectrl_x, ectrl_y, ectrl_z );
 
     for(int ii=0; ii<nLocBas; ++ii)
     {
@@ -328,7 +325,7 @@ void PGAssem_Solid_FEM::Assem_Residual(
 
     locassem -> Assem_Residual( curr_time, dt, &local_dot_d[0], &local_dot_v[0],
         &local_dot_p[0], &local_d[0], &local_v[0], &local_p[0],
-        ectrl_x, ectrl_y, ectrl_z, &zero_prestress[0] );
+        ectrl_x, ectrl_y, ectrl_z );
 
     for(int ii=0; ii<nLocBas; ++ii)
     {
@@ -400,7 +397,7 @@ void PGAssem_Solid_FEM::Assem_Tangent_Residual(
 
     locassem -> Assem_Tangent_Residual( curr_time, dt, &local_dot_d[0], &local_dot_v[0],
         &local_dot_p[0], &local_d[0], &local_v[0], &local_p[0],
-        ectrl_x, ectrl_y, ectrl_z, &zero_prestress[0] );
+        ectrl_x, ectrl_y, ectrl_z );
 
     for(int ii=0; ii<nLocBas; ++ii)
     {

--- a/examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp
+++ b/examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp
@@ -104,8 +104,7 @@ void PLocAssem_2x2Block_VMS_Hyperelasticity::Assem_Residual(
     const double * const &pres,
     const double * const &eleCtrlPts_x,
     const double * const &eleCtrlPts_y,
-    const double * const &eleCtrlPts_z,
-    const double * const &qua_prestress )
+    const double * const &eleCtrlPts_z )
 {
   elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
 
@@ -189,15 +188,6 @@ void PLocAssem_2x2Block_VMS_Hyperelasticity::Assem_Residual(
 
     Tensor2_3D P_iso = matmodel->get_PK_1st( F );
 
-    // ------------------------------------------------------------------------
-    // 1st PK stress corrected by prestress
-    const Tensor2_3D prestress( qua_prestress[qua*6+0], qua_prestress[qua*6+5], qua_prestress[qua*6+4],
-        qua_prestress[qua*6+5], qua_prestress[qua*6+1], qua_prestress[qua*6+3],
-        qua_prestress[qua*6+4], qua_prestress[qua*6+3], qua_prestress[qua*6+2] );
-
-    P_iso += prestress * Ten2::cofactor( F );
-    // ------------------------------------------------------------------------
-
     const double rho = matmodel->get_rho(p);
     const double mbeta = matmodel->get_beta(p);
     const double detF = F.det();
@@ -252,8 +242,7 @@ void PLocAssem_2x2Block_VMS_Hyperelasticity::Assem_Tangent_Residual(
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress )
+        const double * const &eleCtrlPts_z )
 {
   elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
 
@@ -349,15 +338,6 @@ void PLocAssem_2x2Block_VMS_Hyperelasticity::Assem_Tangent_Residual(
     SymmTensor2_3D S_iso;
     const Tensor4_3D AA_iso = matmodel->get_PK_FFStiffness(F, P_iso, S_iso);
     
-    // ------------------------------------------------------------------------
-    // 1st PK stress corrected by prestress
-    const Tensor2_3D prestress( qua_prestress[qua*6+0], qua_prestress[qua*6+5], qua_prestress[qua*6+4],
-        qua_prestress[qua*6+5], qua_prestress[qua*6+1], qua_prestress[qua*6+3],
-        qua_prestress[qua*6+4], qua_prestress[qua*6+3], qua_prestress[qua*6+2] );
-
-    P_iso += prestress * Ten2::cofactor( F );
-    // ------------------------------------------------------------------------
-
     const double rho = matmodel->get_rho(p);
     const double drho = matmodel->get_drho_dp(p);
 
@@ -558,8 +538,7 @@ void PLocAssem_2x2Block_VMS_Hyperelasticity::Assem_Mass_Residual(
     const double * const &pres,
     const double * const &eleCtrlPts_x,
     const double * const &eleCtrlPts_y,
-    const double * const &eleCtrlPts_z,
-    const double * const &qua_prestress )
+    const double * const &eleCtrlPts_z )
 {
   elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
 
@@ -631,15 +610,6 @@ void PLocAssem_2x2Block_VMS_Hyperelasticity::Assem_Mass_Residual(
 
     Tensor2_3D P_iso = matmodel->get_PK_1st( F );
     
-    // ------------------------------------------------------------------------
-    // 1st PK stress corrected by prestress
-    const Tensor2_3D prestress( qua_prestress[qua*6+0], qua_prestress[qua*6+5], qua_prestress[qua*6+4],
-        qua_prestress[qua*6+5], qua_prestress[qua*6+1], qua_prestress[qua*6+3],
-        qua_prestress[qua*6+4], qua_prestress[qua*6+3], qua_prestress[qua*6+2] );
-
-    P_iso += prestress * Ten2::cofactor( F );
-    // ------------------------------------------------------------------------
-
     double mbeta = matmodel->get_beta(p);
 
     // use 1.0 in case of fully incompressible. 

--- a/examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp
+++ b/examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp
@@ -106,8 +106,7 @@ void PLocAssem_2x2Block_VMS_Incompressible::Assem_Residual(
     const double * const &pres,
     const double * const &eleCtrlPts_x,
     const double * const &eleCtrlPts_y,
-    const double * const &eleCtrlPts_z,
-    const double * const &qua_prestress )
+    const double * const &eleCtrlPts_z )
 {
   elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
 
@@ -191,15 +190,6 @@ void PLocAssem_2x2Block_VMS_Incompressible::Assem_Residual(
 
     Tensor2_3D P_iso = matmodel->get_PK_1st( F );
 
-    // ------------------------------------------------------------------------
-    // 1st PK stress corrected by prestress
-    const Tensor2_3D prestress( qua_prestress[qua*6+0], qua_prestress[qua*6+5], qua_prestress[qua*6+4],
-        qua_prestress[qua*6+5], qua_prestress[qua*6+1], qua_prestress[qua*6+3],
-        qua_prestress[qua*6+4], qua_prestress[qua*6+3], qua_prestress[qua*6+2] );
-
-    P_iso += prestress * Ten2::cofactor( F );
-    // ------------------------------------------------------------------------
-
     const double rho = matmodel->get_rho(p);
 
     const double detF = F.det();
@@ -254,8 +244,7 @@ void PLocAssem_2x2Block_VMS_Incompressible::Assem_Tangent_Residual(
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress )
+        const double * const &eleCtrlPts_z )
 {
   elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
 
@@ -350,15 +339,6 @@ void PLocAssem_2x2Block_VMS_Incompressible::Assem_Tangent_Residual(
     SymmTensor2_3D S_iso;
     const Tensor4_3D AA_iso = matmodel->get_PK_FFStiffness(F, P_iso, S_iso);
 
-    // ------------------------------------------------------------------------
-    // 1st PK stress corrected by prestress
-    const Tensor2_3D prestress( qua_prestress[qua*6+0], qua_prestress[qua*6+5], qua_prestress[qua*6+4],
-        qua_prestress[qua*6+5], qua_prestress[qua*6+1], qua_prestress[qua*6+3],
-        qua_prestress[qua*6+4], qua_prestress[qua*6+3], qua_prestress[qua*6+2] );
-
-    P_iso += prestress * Ten2::cofactor( F );
-    // ------------------------------------------------------------------------
-    
     const double rho = matmodel->get_rho(p);
     const double detF = F.det();
 
@@ -532,8 +512,7 @@ void PLocAssem_2x2Block_VMS_Incompressible::Assem_Mass_Residual(
         const double * const &pres,
         const double * const &eleCtrlPts_x,
         const double * const &eleCtrlPts_y,
-        const double * const &eleCtrlPts_z,
-        const double * const &qua_prestress )
+        const double * const &eleCtrlPts_z )
 {
   elementv->buildBasis( quadv.get(), eleCtrlPts_x, eleCtrlPts_y, eleCtrlPts_z );
 
@@ -605,15 +584,6 @@ void PLocAssem_2x2Block_VMS_Incompressible::Assem_Mass_Residual(
     const double invFDV_t = invF.MatTContraction(DVelo);
 
     Tensor2_3D P_iso = matmodel->get_PK_1st( F );
-
-    // ------------------------------------------------------------------------
-    // 1st PK stress corrected by prestress
-    const Tensor2_3D prestress( qua_prestress[qua*6+0], qua_prestress[qua*6+5], qua_prestress[qua*6+4],
-        qua_prestress[qua*6+5], qua_prestress[qua*6+1], qua_prestress[qua*6+3],
-        qua_prestress[qua*6+4], qua_prestress[qua*6+3], qua_prestress[qua*6+2] );
-
-    P_iso += prestress * Ten2::cofactor( F );
-    // ------------------------------------------------------------------------
 
     double mbeta = matmodel->get_beta(p);
 


### PR DESCRIPTION
### Motivation
- The `qua_prestress` parameter and associated `zero_prestress` buffer were always unused (threaded through as an all-zero array) and clutter the VMS local-assembly APIs and callers.
- Removing the unused prestress plumbing simplifies interfaces and avoids allocating unnecessary storage.

### Description
- Removed the `qua_prestress` parameter from `Assem_Residual`, `Assem_Tangent_Residual`, and `Assem_Mass_Residual` declarations in `examples/solids/include/PLocAssem_2x2Block_VMS_Hyperelasticity.hpp` and `examples/solids/include/PLocAssem_2x2Block_VMS_Incompressible.hpp` by deleting the trailing prestress argument.
- Deleted the prestress-correction code blocks (construction of `prestress` and `P_iso += prestress * Ten2::cofactor(F)`) from the residual, tangent/residual, and mass/residual implementations in `examples/solids/src/PLocAssem_2x2Block_VMS_Hyperelasticity.cpp` and `examples/solids/src/PLocAssem_2x2Block_VMS_Incompressible.cpp`.
- Removed the `zero_prestress` member and allocation/initialization in the global assembler by updating `examples/solids/include/PGAssem_Solid_FEM.hpp` and `examples/solids/src/PGAssem_Solid_FEM.cpp`, and updated all call sites to stop passing the now-removed prestress buffer.
- Committed the changes under the message `Remove unused solid prestress assembly input` and updated CMake lists remain unchanged except source edits.

### Testing
- Ran `git diff --check` to ensure no whitespace or conflict markers remained and the working tree was clean, which succeeded.
- Verified no occurrences of `qua_prestress` or `zero_prestress` remain under `examples/solids` using `rg`, which succeeded.
- Performed a Python-based consistency check that confirmed the prestress parameter and zero-buffer plumbing were removed from all targeted files, which succeeded.
- Attempted `cmake -S examples/solids -B /tmp/perigee-solids-build` to configure the examples, which reported a configuration error because `conf/system_lib_loading.cmake` is not present in this checkout, so full build verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276d51039c832a9c799cf5dc567e80)