### PR TITLE
Avoid temporary copies in ALocal_IEN connectivity access

### DIFF
--- a/include/ALocal_IEN.hpp
+++ b/include/ALocal_IEN.hpp
@@ -61,9 +61,9 @@ class ALocal_IEN
     
     virtual std::vector<int> get_LIEN( int ee ) const
     {
-      std::vector<int> elem_ien(nLocBas, 0);
-      for(int ii=0; ii<nLocBas; ++ii) elem_ien[ii] = LIEN[ee * nLocBas + ii];
-    
+      std::vector<int> elem_ien(nLocBas);
+      std::copy_n(LIEN.cbegin() + ee * nLocBas, nLocBas, elem_ien.begin());
+
       return elem_ien;
     }
 
@@ -73,7 +73,7 @@ class ALocal_IEN
     // ------------------------------------------------------------------------
     virtual void get_LIEN(int ee, int * const &elem_ien) const
     {
-      for(int ii=0; ii<nLocBas; ++ii) elem_ien[ii] = LIEN[ee * nLocBas + ii];
+      std::copy_n(LIEN.cbegin() + ee * nLocBas, nLocBas, elem_ien);
     }
 
     // ------------------------------------------------------------------------
@@ -85,9 +85,9 @@ class ALocal_IEN
     // ------------------------------------------------------------------------
     virtual bool isNode_in_Elem(int elem, int node) const
     {
-      const std::vector<int> eIEN = get_LIEN( elem );
-      std::vector<int>::const_iterator it = std::find(eIEN.begin(), eIEN.end(), node);
-      return (it != eIEN.end());
+      const auto elem_begin = LIEN.cbegin() + elem * nLocBas;
+      const auto elem_end = elem_begin + nLocBas;
+      return std::find(elem_begin, elem_end, node) != elem_end;
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Avoid unnecessary temporary allocations and element-wise copying when accessing an element's connectivity and when testing node membership, improving performance and memory churn.
- Use standard algorithms to make intent clearer and rely on optimized library implementations.

### Description
- Replace the manual loop in `get_LIEN(int ee) const` with `std::copy_n` into a sized `std::vector<int>` to avoid zero-initialization and element-wise assignment.
- Replace the manual loop in `get_LIEN(int ee, int * const &elem_ien) const` with `std::copy_n` writing directly into the provided raw array.
- Rewrite `isNode_in_Elem(int elem, int node) const` to call `std::find` on the `LIEN` subrange (`LIEN.cbegin() + elem * nLocBas` to that plus `nLocBas`) to avoid constructing a temporary vector.

### Testing
- Performed a syntax-only compile check with `printf '#include "ALocal_IEN.hpp"\n' | c++ -std=c++11 -Iinclude -x c++ -fsyntax-only -`, which succeeded.
- Ran whitespace/style checks with `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cc20e8da0832aa14f6fee5137b7df)