### PR TITLE
Remove num_dir_nodes and num_per_nodes data in NodalBC classes

### DIFF
--- a/examples/fsi/include/NodalBC_3D_FSI.hpp
+++ b/examples/fsi/include/NodalBC_3D_FSI.hpp
@@ -46,13 +46,13 @@ class NodalBC_3D_FSI : public INodalBC
       return 0;
     }
 
-    virtual unsigned int get_num_dir_nodes() const {return num_dir_nodes;}
+    virtual unsigned int get_num_dir_nodes() const
+    {return static_cast<unsigned int>(dir_nodes.size());}
 
     virtual unsigned int get_num_per_nodes() const {return 0;}
 
   private:
     std::vector<unsigned int> dir_nodes;
-    unsigned int num_dir_nodes;
 
     NodalBC_3D_FSI() {};
 

--- a/examples/fsi/src/NodalBC_3D_FSI.cpp
+++ b/examples/fsi/src/NodalBC_3D_FSI.cpp
@@ -84,9 +84,6 @@ NodalBC_3D_FSI::NodalBC_3D_FSI( const std::string &fluid_file,
       break;
   }
 
-  // count the number of dirichlet nodes
-  num_dir_nodes = dir_nodes.size();
-
   // generate the ID array
   Create_ID( nFunc );
 }
@@ -118,9 +115,6 @@ NodalBC_3D_FSI::NodalBC_3D_FSI( const std::string &fluid_file,
       SYS_T::print_fatal( "NodalBC_3D_FSI Error: No such type of FSI BC.\n" );
       break;
   }
-
-  // count the number of dirichlet nodes
-  num_dir_nodes = dir_nodes.size();
 
   // generate the ID array
   Create_ID( nFunc );

--- a/include/NodalBC.hpp
+++ b/include/NodalBC.hpp
@@ -8,12 +8,8 @@
 //
 // The data contained in this class include:
 // dir_nodes : the nodal indices for the Dirichlet nodes;
-// num_dir_nodes : the number of the Dirichlet nodes, i.e., the length
-//                 of the dir_nodes array;
 // per_slave_nodes : the nodal indices for the slave nodes;
 // per_master_nodes : the nodal indices for the master nodes;
-// num_per_nodes : the number of periodic-type nodes, i.e., the length 
-//                 of the per_slave_nodes / per_master_nodes.
 //
 // ID : the vector for the ID array, which is generated based on the 
 //      nFunc, the number of total basis functions, and the dir_nodes
@@ -31,8 +27,8 @@ class NodalBC : public INodalBC
   public:
     // --------------------------------------------------------------
     // Default constructor: clear the dir_nodes, per_slave_nodes,
-    // per_master_nodes; set num_dir_nodes, num_per_nodes to be zero;
-    // set ID based on the above "no-nodal bc" setting.
+    // and per_master_nodes vectors; set ID based on the above
+    // "no-nodal bc" setting.
     // --------------------------------------------------------------
     NodalBC( const int &nFunc );
     
@@ -85,16 +81,16 @@ class NodalBC : public INodalBC
     virtual unsigned int get_per_master_nodes(const unsigned int &ii) const
     {return per_master_nodes[ii];}
 
-    virtual unsigned int get_num_dir_nodes() const {return num_dir_nodes;}
+    virtual unsigned int get_num_dir_nodes() const
+    {return static_cast<unsigned int>(dir_nodes.size());}
 
-    virtual unsigned int get_num_per_nodes() const {return num_per_nodes;}
+    virtual unsigned int get_num_per_nodes() const
+    {return static_cast<unsigned int>(per_slave_nodes.size());}
 
   private:
     std::vector<unsigned int> dir_nodes {};
-    unsigned int num_dir_nodes {};
 
     std::vector<unsigned int> per_slave_nodes {}, per_master_nodes {};
-    unsigned int num_per_nodes {};
     
     NodalBC() = delete;
 

--- a/include/NodalBC_3D_inflow.hpp
+++ b/include/NodalBC_3D_inflow.hpp
@@ -51,7 +51,8 @@ class NodalBC_3D_inflow : public INodalBC
       return 0;
     }
 
-    virtual unsigned int get_num_dir_nodes() const {return num_dir_nodes;}
+    virtual unsigned int get_num_dir_nodes() const
+    {return static_cast<unsigned int>(dir_nodes.size());}
 
     virtual unsigned int get_num_per_nodes() const {return 0;}
 
@@ -60,7 +61,7 @@ class NodalBC_3D_inflow : public INodalBC
         const unsigned int &ii ) const { return dir_nodes_on_inlet[nbc_id][ii]; }
 
     virtual unsigned int get_num_dir_nodes_on_inlet( const int &nbc_id ) const
-    { return num_dir_nodes_on_inlet[nbc_id]; }
+    { return static_cast<unsigned int>(dir_nodes_on_inlet[nbc_id].size()); }
 
     virtual double get_inf_active_area(const int &nbc_id) const {return inf_active_area[nbc_id];}
 
@@ -143,14 +144,11 @@ class NodalBC_3D_inflow : public INodalBC
     NodalBC_3D_inflow() = delete;
     
     // The dirichlet nodes on each inlet surface
-    // length num_nbc x num_dir_nodes_on_inlet[ii]
+    // length num_nbc x get_num_dir_nodes_on_inlet(ii)
     std::vector< std::vector<unsigned int> > dir_nodes_on_inlet;
-    std::vector<unsigned int> num_dir_nodes_on_inlet;
 
-    // All dirichlet nodes stored in a row and the total number of dirichlet
-    // nodes
+    // All dirichlet nodes stored in a row
     std::vector<unsigned int> dir_nodes;
-    unsigned int num_dir_nodes;
 
     // number of inlet surfaces and element type
     const int num_nbc;
@@ -185,7 +183,7 @@ class NodalBC_3D_inflow : public INodalBC
     std::vector< std::vector<double> > intNA;
 
     // number of nodes and cells on each surface. Length num_nbc.
-    // Note: num_node[ii] does not equal num_dir_nodes[ii] in this class.
+    // Note: num_node[ii] does not equal get_num_dir_nodes_on_inlet(ii).
     // nLocBas[ii] is 3, 6, 4 or 9.
     std::vector<int> num_node, num_cell, nLocBas;
 

--- a/include/NodalBC_3D_rotated.hpp
+++ b/include/NodalBC_3D_rotated.hpp
@@ -33,7 +33,8 @@ class NodalBC_3D_rotated : public INodalBC
     virtual unsigned int get_dir_nodes(const unsigned int &ii) const
     {return dir_nodes[ii];}
 
-    virtual unsigned int get_num_dir_nodes() const {return num_dir_nodes;}    
+    virtual unsigned int get_num_dir_nodes() const
+    {return static_cast<unsigned int>(dir_nodes.size());}
 
     virtual unsigned int get_per_master_nodes(const unsigned int &ii) const
     {
@@ -54,7 +55,7 @@ class NodalBC_3D_rotated : public INodalBC
     { return dir_nodes_on_rotated_surface[ii]; }
 
     virtual unsigned int get_num_dir_nodes_on_rotated_surface() const
-    { return num_dir_nodes_on_rotated_surface; }    
+    { return static_cast<unsigned int>(dir_nodes_on_rotated_surface.size()); }
 
     // Access to num_node
     virtual int get_num_node() const {return num_node;}
@@ -88,20 +89,16 @@ class NodalBC_3D_rotated : public INodalBC
     NodalBC_3D_rotated() = delete;
 
     // The dirichlet nodes on rotated surface
-    // length = num_dir_nodes_on_rotated_surface
     std::vector<unsigned int> dir_nodes_on_rotated_surface;
-    unsigned int num_dir_nodes_on_rotated_surface; 
 
     // The dirichlet nodes
-    // length = num_dir_nodes
     std::vector<unsigned int> dir_nodes;
-    unsigned int num_dir_nodes; 
 
     // number of moving surfaces and element type
     const FEType elem_type;
 
     // number of nodes and cells on rotated surface.
-    // Note: num_node equal num_dir_nodes in this class.
+    // Note: num_node equals get_num_dir_nodes() in this class.
     // nLocBas is 3, 6, 4 or 9.
     int num_node, num_cell, nLocBas;
 

--- a/src/Mesh/NodalBC.cpp
+++ b/src/Mesh/NodalBC.cpp
@@ -7,8 +7,6 @@ NodalBC::NodalBC( const int &nFunc )
   dir_nodes.clear();
   per_slave_nodes.clear();
   per_master_nodes.clear();
-  num_dir_nodes = 0;
-  num_per_nodes = 0;
 
   Create_ID( nFunc );
   
@@ -21,7 +19,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
   dir_nodes.clear();
   per_slave_nodes.clear();
   per_master_nodes.clear();
-  num_per_nodes = 0;
 
   for( int ii{0}; ii < VEC_T::get_size(vtkfileList); ++ii )
   {
@@ -40,7 +37,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
   
   VEC_T::sort_unique_resize(dir_nodes);
 
-  num_dir_nodes = dir_nodes.size();
 
   Create_ID( nFunc );
 
@@ -57,7 +53,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
   dir_nodes.clear();
   per_slave_nodes.clear();
   per_master_nodes.clear();
-  num_per_nodes = 0;
 
   for( int ii{0}; ii < VEC_T::get_size(vtkfileList); ++ii )
   {
@@ -76,7 +71,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
 
   VEC_T::sort_unique_resize(dir_nodes);
 
-  num_dir_nodes = dir_nodes.size();
 
   for( int ii{0}; ii < VEC_T::get_size(slafileList); ++ii )
   {
@@ -96,7 +90,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
     }
   }
 
-  num_per_nodes = per_slave_nodes.size();
 
   Create_ID( nFunc );
 
@@ -119,7 +112,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
   dir_nodes.clear();
   per_slave_nodes.clear();
   per_master_nodes.clear();
-  num_per_nodes = 0;
 
   for( const auto &vtkfile : vtkfileList )
   {
@@ -155,7 +147,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
 
   VEC_T::sort_unique_resize(dir_nodes);
 
-  num_dir_nodes = dir_nodes.size();
 
   Create_ID( nFunc );
 
@@ -175,7 +166,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
   dir_nodes.clear();
   per_slave_nodes.clear();
   per_master_nodes.clear();
-  num_per_nodes = 0;
 
   for( const auto &vtkfile : vtkfileList )
   {
@@ -224,7 +214,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
 
   VEC_T::sort_unique_resize(dir_nodes);
 
-  num_dir_nodes = dir_nodes.size();
 
   Create_ID( nFunc );
 
@@ -244,8 +233,6 @@ NodalBC::NodalBC( const std::vector<std::string> &vtkfileList,
   per_slave_nodes.clear();
   per_master_nodes.clear();
 
-  num_dir_nodes = 0;
-  num_per_nodes = 0;
 
   switch( type )
   {
@@ -286,7 +273,6 @@ void NodalBC::BC_type_1( const std::vector<std::string> &vtkfileList,
     }
   }
 
-  num_per_nodes = per_slave_nodes.size();
   std::cout<<"-----> Master slave relations: \n";
   for( const auto &vtkfile : vtkfileList )
     std::cout<<"     "<<vtkfile<<" follows 0th node in the file "<<std::endl;
@@ -321,8 +307,6 @@ void NodalBC::BC_type_2( const std::vector<std::string> &vtkfileList,
     per_master_nodes.push_back( static_cast<unsigned int>( gnode[ 0 ]) );
   }
 
-  num_dir_nodes = dir_nodes.size();
-  num_per_nodes = per_slave_nodes.size();
 
   std::cout<<"-----> Dirichlet nodes from "<<vtkfileList[0]<<std::endl;
   std::cout<<"       Master-slave from "<<vtkfileList[1]<<" with 0th node master."<<std::endl;
@@ -343,10 +327,8 @@ void NodalBC::BC_type_3( const std::vector<std::string> &vtkfileList,
 
   dir_nodes.resize(1);
   dir_nodes[0] = static_cast<unsigned int>( gnode[0] );
-  num_dir_nodes = 1;
   per_slave_nodes.clear();
   per_master_nodes.clear();
-  num_per_nodes = 0;
   std::cout<<"-----> Dirichlet node "<<gnode[0]<<
     " from "<<vtkfileList[0]<<std::endl;
 }

--- a/src/Mesh/NodalBC_3D_inflow.cpp
+++ b/src/Mesh/NodalBC_3D_inflow.cpp
@@ -20,12 +20,9 @@ void NodalBC_3D_inflow::init( const std::vector<std::string> &inffileList,
 { 
   // 1. Clear the container for Dirichlet nodes
   dir_nodes.clear();
-  num_dir_nodes = 0;
 
   dir_nodes_on_inlet.resize( num_nbc );
   for(int ii=0; ii<num_nbc; ++ii) dir_nodes_on_inlet[ii].clear();
-
-  num_dir_nodes_on_inlet.resize( num_nbc );
 
   // 2. Analyze the file type and read in the data
   num_node.resize( num_nbc );
@@ -86,8 +83,6 @@ void NodalBC_3D_inflow::init( const std::vector<std::string> &inffileList,
         dir_nodes_on_inlet[ii].push_back( global_node[ii][jj] );
       }
     }
-
-    num_dir_nodes_on_inlet[ii] = dir_nodes_on_inlet[ii].size();
 
     // Calculate the centroid of the surface
     centroid[ii] = Vec3::gen_zero();
@@ -303,11 +298,11 @@ void NodalBC_3D_inflow::init( const std::vector<std::string> &inffileList,
     delete [] temp_sol; temp_sol = nullptr;
   } // end ii-loop
 
-  num_dir_nodes = dir_nodes.size();
+  const auto num_dir_nodes_before_dedup = dir_nodes.size();
 
   VEC_T::sort_unique_resize(dir_nodes);
 
-  SYS_T::print_fatal_if( num_dir_nodes != dir_nodes.size(), "Error: NodalBC_3D_inflow::init function: there are repeated nodes in the inflow file list.\n" );
+  SYS_T::print_fatal_if( num_dir_nodes_before_dedup != dir_nodes.size(), "Error: NodalBC_3D_inflow::init function: there are repeated nodes in the inflow file list.\n" );
 
   // Generate ID array
   Create_ID( nFunc );

--- a/src/Mesh/NodalBC_3D_rotated.cpp
+++ b/src/Mesh/NodalBC_3D_rotated.cpp
@@ -15,7 +15,6 @@ NodalBC_3D_rotated::NodalBC_3D_rotated(
   // Clear the container for Dirichlet nodes
   dir_nodes_on_rotated_surface.clear();
   dir_nodes.clear();
-  num_dir_nodes_on_rotated_surface = 0;
 
   // Analyze the file type and read in the data
   num_node = 0;
@@ -56,15 +55,13 @@ NodalBC_3D_rotated::NodalBC_3D_rotated(
     dir_nodes.push_back( global_node[jj] );
   }
 
-  num_dir_nodes_on_rotated_surface = dir_nodes_on_rotated_surface.size();
-
-  num_dir_nodes = dir_nodes.size();
+  const auto num_dir_nodes_before_dedup = dir_nodes_on_rotated_surface.size();
  
   VEC_T::sort_unique_resize(dir_nodes_on_rotated_surface);
 
   VEC_T::sort_unique_resize(dir_nodes);
 
-  SYS_T::print_fatal_if( num_dir_nodes_on_rotated_surface != dir_nodes_on_rotated_surface.size(), "Error: NodalBC_3D_rotated::NodalBC_3D_rotated: there are repeated nodes in the rotated file list.\n" );
+  SYS_T::print_fatal_if( num_dir_nodes_before_dedup != dir_nodes_on_rotated_surface.size(), "Error: NodalBC_3D_rotated::NodalBC_3D_rotated: there are repeated nodes in the rotated file list.\n" );
 
   // Generate ID array
   Create_ID( nFunc );


### PR DESCRIPTION
### Motivation
- Eliminate redundant stored counters (`num_dir_nodes`, `num_per_nodes`, etc.) that duplicate `std::vector` sizes and can get out of sync. 
- Simplify and harden duplicate detection by comparing vector size before/after deduplication. 

### Description
- Replaced stored count members with calls to `vector::size()` in `NodalBC`, `NodalBC_3D_inflow`, `NodalBC_3D_rotated`, and `NodalBC_3D_FSI` by changing getters to return `static_cast<unsigned int>(dir_nodes.size())` (and analogous containers). 
- Removed member variables `num_dir_nodes`, `num_per_nodes`, `num_dir_nodes_on_inlet`, and related assignments and updates from constructors and `init` routines. 
- Adjusted inlet/rotated/inflow initialization logic to capture the pre-dedup count in a temporary variable and compare it with the post-`sort_unique_resize` size to detect duplicates. 
- Updated usages that relied on previously stored counts to instead query container sizes (for example `get_num_dir_nodes_on_inlet` now returns `dir_nodes_on_inlet[nbc_id].size()`). 

### Testing
- Built the project using the usual build (`cmake`/`make`) with no compilation errors. 
- Ran the test suite via `ctest` and observed all tests passing. 
- Ran example targets that exercise `NodalBC` variants to validate initialization and duplicate-detection behavior, with no runtime failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d56a21f94832a80c729237f29510a)